### PR TITLE
feat: add grill-me and grill-with-docs skills from mattpocock/skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
 | `requesting-code-review` | After completing implementation                                                                    |
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
+| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                    |
+| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                  |
 
 ## Git
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,18 @@
       "skillPath": "original/documenting-decisions/SKILL.md",
       "computedHash": "3ba6f8d16a89f3dbc1eee34747eb5882e08dff5ccfba71fddf71009915311eef"
     },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "f321507f77702a54af1db66549ec1685fc625390d06c57d7949cdcda8eb1b5c7"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
+    },
     "requesting-code-review": {
       "source": "obra/superpowers",
       "sourceType": "github",

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -60,6 +60,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
 | `requesting-code-review` | After completing implementation                                                                    |
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
+| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                    |
+| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                  |
 
 ## Git
 

--- a/template/skills-lock.json
+++ b/template/skills-lock.json
@@ -24,6 +24,18 @@
       "sourceType": "github",
       "skillPath": "skills/requesting-code-review/SKILL.md",
       "computedHash": "874f3786b05007a8b4a60452a4cd89b9917c645d34b6b1e40ea05037d12f0e67"
+    },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "f321507f77702a54af1db66549ec1685fc625390d06c57d7949cdcda8eb1b5c7"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
     }
   }
 }


### PR DESCRIPTION
Closes #13

## Summary

- Register `grill-me` and `grill-with-docs` from [mattpocock/skills](https://github.com/mattpocock/skills) in `skills-lock.json` (installed via `npx skills add`, so `skillPath` and `computedHash` are CLI-generated).
- Mirror both entries in `template/skills-lock.json` so newly generated projects hydrate them via `npx skills experimental_install`.
- Add trigger rows for both skills to the skill table in `AGENTS.md` and `template/AGENTS.md.jinja`.

## Deviations from the issue

- The issue calls the second skill `grill-me-with-docs`, but upstream it is named **`grill-with-docs`** (`skills/engineering/grill-with-docs/SKILL.md`); the lock entries use the real name.

## Verification

- `uv run pytest` — 5 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tDJBj2TMJoifTuAviBGXY

---
_Generated by [Claude Code](https://claude.ai/code/session_012tDJBj2TMJoifTuAviBGXY)_