### PR TITLE
fix: align AGENTS.md skill-table pipes; add prek lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,25 @@ jobs:
       - run: uv run pytest
         shell: bash
 
+  lint:
+    # Enforce the configured prek hooks repo-side: hooks only run at commit
+    # time on contributor machines, so a missing local setup can land lint
+    # violations (see issue #15). This job blocks PRs regardless.
+    runs-on: ubuntu-latest
+    name: "Lint (prek run --all-files)"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - run: |
+          uv tool install prek
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        shell: bash
+      - run: prek run --all-files --show-diff-on-failure
+        shell: bash
+
   conflict-detection:
     # Enforcement arm of the file-ownership policy: copier update merges and
     # writes .rej files but still exits 0. Generate a fixture, run the update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
 | `requesting-code-review` | After completing implementation                                                                    |
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
-| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                    |
-| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                  |
+| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
+| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 
 ## Git
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -60,8 +60,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
 | `requesting-code-review` | After completing implementation                                                                    |
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
-| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                    |
-| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                  |
+| `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
+| `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 
 ## Git
 


### PR DESCRIPTION
Closes #15

## What

- Align trailing pipes on `grill-me` / `grill-with-docs` rows (added in #14) in `template/AGENTS.md.jinja` — rows were one char wider than header, so every generated project failed MD060 on first commit touching AGENTS.md. Same fix applied to this repo's own `AGENTS.md`.
- Add `lint` job to CI: `prek run --all-files` blocks PRs on configured hook failures regardless of contributor-side hook setup.

## Verified

- `markdownlint-cli2` over all repo globs: 0 errors.
- Fresh `copier copy` render → `markdownlint-cli2 AGENTS.md`: 0 errors.
- `prek run --all-files` (shellcheck skipped — binary download blocked in sandbox): all hooks pass, including actionlint on the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeXqHiTmWQz37FN3nF1fyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeXqHiTmWQz37FN3nF1fyf)_