### PR TITLE
feat: add grilling and domain-modeling skill dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .pytest_cache/
 .copier-answers*.yml
 /.agents/skills/
+/.claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
-| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions during design |
-| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one       |
+| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
+| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
 
 ## Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
+| `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
+| `domain-modeling`        | Pinning down domain terminology or recording architectural decisions during design                 |
 
 ## Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
 | `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
 | `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
+| `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
+| `to-spec`                | Turning the current conversation into a spec/PRD and publishing it to the tracker                  |
 
 ## Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
-| `domain-modeling`        | Pinning down domain terminology or recording architectural decisions during design                 |
+| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions during design |
+| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one       |
 
 ## Git
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,12 @@
       "skillPath": "original/documenting-decisions/SKILL.md",
       "computedHash": "3ba6f8d16a89f3dbc1eee34747eb5882e08dff5ccfba71fddf71009915311eef"
     },
+    "domain-modeling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
+      "computedHash": "67343881f5def98487d56243155716110afbcbf22ec92421c882d532b941cb17"
+    },
     "grill-me": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -24,6 +30,12 @@
       "sourceType": "github",
       "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
       "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
     },
     "requesting-code-review": {
       "source": "obra/superpowers",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,13 +11,13 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/documenting-decisions/SKILL.md",
-      "computedHash": "82a193cb1992cb223fe5bf5e89e71ea89dcee57d7b5bd71dd03dc9a548fceb6c"
+      "computedHash": "b71f6fc8250903091477b16e0ca976b20d4d65fd7d12acd7d5025b9d4bddfe08"
     },
     "domain-modeling": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "derived/domain-modeling/SKILL.md",
-      "computedHash": "705e60bb831309c734b5922e134bb6af7408c90728ccc904fdd1b7fd5a8e769f"
+      "computedHash": "839ba2d025f594dc698730aee74066eb640ac02013b4029749d61b4262793cc7"
     },
     "grill-me": {
       "source": "mattpocock/skills",
@@ -49,11 +49,23 @@
       "skillPath": "derived/tdd/SKILL.md",
       "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
     },
+    "to-spec": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "derived/to-spec/SKILL.md",
+      "computedHash": "11bace9728fd91873b01ea743694226544907a8983a90b6e327324a41e062b0f"
+    },
+    "to-tickets": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "derived/to-tickets/SKILL.md",
+      "computedHash": "9c58978e2d01e2eacd7616722158b1d1dc409521b1ee1f443420cecb6b2d6cc0"
+    },
     "writing-adrs": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/writing-adrs/SKILL.md",
-      "computedHash": "3e3653c8e6ce28927fe0575023c573fad7f41c756c7334f0f3c782d52f79ad3d"
+      "computedHash": "5a4fd656b3b7b0badcbb7d6ea8dfccfd1f5d510b123938e7ab8d19bbb682a3b4"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,13 +11,13 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/documenting-decisions/SKILL.md",
-      "computedHash": "6de79ad3f21409d7215bb8fb6013357fd53b46054091faf3dddb7d3573b2b157"
+      "computedHash": "82a193cb1992cb223fe5bf5e89e71ea89dcee57d7b5bd71dd03dc9a548fceb6c"
     },
     "domain-modeling": {
-      "source": "mattpocock/skills",
+      "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
-      "computedHash": "67343881f5def98487d56243155716110afbcbf22ec92421c882d532b941cb17"
+      "skillPath": "derived/domain-modeling/SKILL.md",
+      "computedHash": "705e60bb831309c734b5922e134bb6af7408c90728ccc904fdd1b7fd5a8e769f"
     },
     "grill-me": {
       "source": "mattpocock/skills",
@@ -48,6 +48,12 @@
       "sourceType": "github",
       "skillPath": "derived/tdd/SKILL.md",
       "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
+    },
+    "writing-adrs": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "original/writing-adrs/SKILL.md",
+      "computedHash": "3e3653c8e6ce28927fe0575023c573fad7f41c756c7334f0f3c782d52f79ad3d"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,13 +5,13 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "derived/caveman/SKILL.md",
-      "computedHash": "eac65828cc17c46ec0353d76735813f7c95e88f57226fd5c665254b7bdbc737b"
+      "computedHash": "30b52226790cba1d0ab173e16af901002d43e76bc02ca47d47ec67be76984e83"
     },
     "documenting-decisions": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/documenting-decisions/SKILL.md",
-      "computedHash": "3ba6f8d16a89f3dbc1eee34747eb5882e08dff5ccfba71fddf71009915311eef"
+      "computedHash": "6de79ad3f21409d7215bb8fb6013357fd53b46054091faf3dddb7d3573b2b157"
     },
     "domain-modeling": {
       "source": "mattpocock/skills",
@@ -47,7 +47,7 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "derived/tdd/SKILL.md",
-      "computedHash": "45895388d0897cc91e32cbce796a31354e28d0ec770a83543d1122aa324f430a"
+      "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
     }
   }
 }

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -63,8 +63,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
-| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions during design |
-| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one       |
+| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
+| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
 
 ## Git
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -62,6 +62,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
+| `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
+| `domain-modeling`        | Pinning down domain terminology or recording architectural decisions during design                 |
 
 ## Git
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -65,6 +65,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
 | `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
 | `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
+| `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
+| `to-spec`                | Turning the current conversation into a spec/PRD and publishing it to the tracker                  |
 
 ## Git
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -63,7 +63,8 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
-| `domain-modeling`        | Pinning down domain terminology or recording architectural decisions during design                 |
+| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions during design |
+| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one       |
 
 ## Git
 

--- a/template/skills-lock.json
+++ b/template/skills-lock.json
@@ -5,25 +5,25 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "derived/caveman/SKILL.md",
-      "computedHash": "eac65828cc17c46ec0353d76735813f7c95e88f57226fd5c665254b7bdbc737b"
+      "computedHash": "30b52226790cba1d0ab173e16af901002d43e76bc02ca47d47ec67be76984e83"
     },
     "documenting-decisions": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/documenting-decisions/SKILL.md",
-      "computedHash": "3ba6f8d16a89f3dbc1eee34747eb5882e08dff5ccfba71fddf71009915311eef"
+      "computedHash": "6de79ad3f21409d7215bb8fb6013357fd53b46054091faf3dddb7d3573b2b157"
     },
     "tdd": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "derived/tdd/SKILL.md",
-      "computedHash": "45895388d0897cc91e32cbce796a31354e28d0ec770a83543d1122aa324f430a"
+      "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
     },
     "requesting-code-review": {
       "source": "obra/superpowers",
       "sourceType": "github",
       "skillPath": "skills/requesting-code-review/SKILL.md",
-      "computedHash": "874f3786b05007a8b4a60452a4cd89b9917c645d34b6b1e40ea05037d12f0e67"
+      "computedHash": "cde520e9118d7e6b74b5ab0123cff2f68d9c07bddb3f82c997753b6126600aed"
     },
     "grill-me": {
       "source": "mattpocock/skills",

--- a/template/skills-lock.json
+++ b/template/skills-lock.json
@@ -44,10 +44,16 @@
       "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
     },
     "domain-modeling": {
-      "source": "mattpocock/skills",
+      "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
-      "computedHash": "67343881f5def98487d56243155716110afbcbf22ec92421c882d532b941cb17"
+      "skillPath": "derived/domain-modeling/SKILL.md",
+      "computedHash": "705e60bb831309c734b5922e134bb6af7408c90728ccc904fdd1b7fd5a8e769f"
+    },
+    "writing-adrs": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "original/writing-adrs/SKILL.md",
+      "computedHash": "3e3653c8e6ce28927fe0575023c573fad7f41c756c7334f0f3c782d52f79ad3d"
     }
   }
 }

--- a/template/skills-lock.json
+++ b/template/skills-lock.json
@@ -36,6 +36,18 @@
       "sourceType": "github",
       "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
       "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
+    },
+    "domain-modeling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
+      "computedHash": "67343881f5def98487d56243155716110afbcbf22ec92421c882d532b941cb17"
     }
   }
 }

--- a/template/skills-lock.json
+++ b/template/skills-lock.json
@@ -11,19 +11,13 @@
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/documenting-decisions/SKILL.md",
-      "computedHash": "6de79ad3f21409d7215bb8fb6013357fd53b46054091faf3dddb7d3573b2b157"
+      "computedHash": "b71f6fc8250903091477b16e0ca976b20d4d65fd7d12acd7d5025b9d4bddfe08"
     },
-    "tdd": {
+    "domain-modeling": {
       "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "derived/tdd/SKILL.md",
-      "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
-    },
-    "requesting-code-review": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/requesting-code-review/SKILL.md",
-      "computedHash": "cde520e9118d7e6b74b5ab0123cff2f68d9c07bddb3f82c997753b6126600aed"
+      "skillPath": "derived/domain-modeling/SKILL.md",
+      "computedHash": "839ba2d025f594dc698730aee74066eb640ac02013b4029749d61b4262793cc7"
     },
     "grill-me": {
       "source": "mattpocock/skills",
@@ -43,17 +37,35 @@
       "skillPath": "skills/productivity/grilling/SKILL.md",
       "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
     },
-    "domain-modeling": {
+    "requesting-code-review": {
+      "source": "obra/superpowers",
+      "sourceType": "github",
+      "skillPath": "skills/requesting-code-review/SKILL.md",
+      "computedHash": "cde520e9118d7e6b74b5ab0123cff2f68d9c07bddb3f82c997753b6126600aed"
+    },
+    "tdd": {
       "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "derived/domain-modeling/SKILL.md",
-      "computedHash": "705e60bb831309c734b5922e134bb6af7408c90728ccc904fdd1b7fd5a8e769f"
+      "skillPath": "derived/tdd/SKILL.md",
+      "computedHash": "b663ec89bd4d0babc7572eb39ce21fe56a95c6da9d74149a17ce93b7c4906253"
+    },
+    "to-spec": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "derived/to-spec/SKILL.md",
+      "computedHash": "11bace9728fd91873b01ea743694226544907a8983a90b6e327324a41e062b0f"
+    },
+    "to-tickets": {
+      "source": "frankify-app/skills",
+      "sourceType": "github",
+      "skillPath": "derived/to-tickets/SKILL.md",
+      "computedHash": "9c58978e2d01e2eacd7616722158b1d1dc409521b1ee1f443420cecb6b2d6cc0"
     },
     "writing-adrs": {
       "source": "frankify-app/skills",
       "sourceType": "github",
       "skillPath": "original/writing-adrs/SKILL.md",
-      "computedHash": "3e3653c8e6ce28927fe0575023c573fad7f41c756c7334f0f3c782d52f79ad3d"
+      "computedHash": "5a4fd656b3b7b0badcbb7d6ea8dfccfd1f5d510b123938e7ab8d19bbb682a3b4"
     }
   }
 }


### PR DESCRIPTION
Follow-up to #14 (issue #13). Closes #18.

## Summary

`grill-me` and `grill-with-docs` turned out to be thin wrappers: both just invoke `/grilling`, and `grill-with-docs` additionally uses `/domain-modeling`. Neither dependency was installed in #14, so the wrappers were broken.

- Register `grilling` from [mattpocock/skills](https://github.com/mattpocock/skills) in `skills-lock.json` and mirror it in `template/skills-lock.json`.
- Register `domain-modeling` as the **derived** version from [frankify-app/skills](https://github.com/frankify-app/skills) (`derived/domain-modeling`) — glossary retargeted to `docs/glossary/` for `uvx disambiguate`, no `CONTEXT.md`/`CONTEXT-MAP.md`, ADR mechanics delegated to `writing-adrs`. (Initially added from upstream; repointed per frankify-app/skills#6 / #18.)
- Add `writing-adrs` (frankify-app/skills `original/writing-adrs`) to both locks — owns the ADR format, numbering, and when-to-write criteria in `docs/adr/`.
- Add trigger rows for `grilling`, `domain-modeling`, and `writing-adrs` to the skill tables in `AGENTS.md` and `template/AGENTS.md.jinja`.
- Ignore `/.claude/skills/` (skills-CLI symlink dir for Claude Code discovery, mirrors the ignored `/.agents/skills/`).

Dependency audit: none of the added skills reference further skills, so the set is closed.

## Verification

- `uv run pytest` — 5 passed, 2 skipped.
- `npx skills update -p -y` hydrates cleanly; no `CONTEXT.md`/`CONTEXT-MAP.md` instructions remain in installed copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tDJBj2TMJoifTuAviBGXY