### PR TITLE
feat: choosable tracker CLI with agent-PATH shims for the rest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
 | `to-spec`                | Turning the current conversation into a spec/PRD and publishing it to the tracker                  |
 
+### Repo-Local Skill Overrides
+
+- `grilling`: present each question via the platform's multiple-choice dialog (e.g. `AskUserQuestion` in Claude Code) when the platform supports one; fall back to plain-text questions otherwise.
+
 ## Git
 
 - Branch: `<agent>/<issue-number>-<desc>` (e.g. `hermes/42-fix-auth`, `claude/42-fix-auth`)

--- a/copier.yml
+++ b/copier.yml
@@ -22,6 +22,15 @@ agentic_precommit:
     - none
   default: prek
 
+agentic_tracker_cli:
+  type: str
+  help: "Tracker CLI agents must use for repository interaction (issues/PRs/CI)."
+  choices:
+    - ghx
+    - gh
+    - tea
+  default: ghx
+
 agentic_forge:
   type: str
   help: "Forge hosting the repository."

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/enable-agent-shims.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -24,7 +24,7 @@ uvx disambiguate --from <ticket-file>
 or for GitHub issues:
 
 ```bash
-ghx issue view <number> --json body -q .body | uvx disambiguate --from -
+{{ agentic_tracker_cli }} issue view <number> --json body -q .body | uvx disambiguate --from -
 ```
 
 to resolve all referenced terms at once.
@@ -68,6 +68,10 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 | `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
 | `to-spec`                | Turning the current conversation into a spec/PRD and publishing it to the tracker                  |
 
+### Repo-Local Skill Overrides
+
+- `grilling`: present each question via the platform's multiple-choice dialog (e.g. `AskUserQuestion` in Claude Code) when the platform supports one; fall back to plain-text questions otherwise.
+
 ## Git
 
 - Branch: `<agent>/<issue-number>-<desc>` (e.g. `hermes/42-fix-auth`, `claude/42-fix-auth`)
@@ -78,16 +82,19 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 
 ### Agentic Engineering Workflow
 
-Use `ghx` for all repository interaction. `gh` and `tea` are disabled — calling them tells you to use `ghx` instead.
+{% set _other_clis = ['ghx', 'gh', 'tea'] | reject('equalto', agentic_tracker_cli) | list -%}
+Use `{{ agentic_tracker_cli }}` for all repository interaction. `{{ _other_clis[0] }}` and `{{ _other_clis[1] }}` are disabled — calling them tells you to use `{{ agentic_tracker_cli }}` instead (enforced via shims in `scripts/agent-shims/`, on PATH in agent sessions only; tracker access through MCP tools is not gated by the shims).
 
-`ghx` exposes a curated subset of `gh`'s verbs (plus a few additions, e.g. `--code-comment`) and presents the **same `gh`-style interface against both GitHub and Forgejo**, so you never need to know which host the repo is on. It is **not** a full `gh` replacement: it has only the verbs listed below. If a command isn't in this list, `ghx` doesn't have it — don't fall back to `gh`/`tea`.
-
-#### Available `ghx` verbs
+#### Available `{{ agentic_tracker_cli }}` verbs
 
 - **issues:** `issue create`, `issue view` (`--comments`), `issue list`, `issue comment`, `issue edit`
 - **pull requests:** `pr create`, `pr view` (`--comments`), `pr list`, `pr comment`, `pr edit`, `pr review` (`--body`, repeatable `--code-comment path:line:text`), `pr checks`, `pr status`
 - **CI:** `run list`, `run view`
 
+{% if agentic_tracker_cli == 'ghx' -%}
+`ghx` exposes a curated subset of `gh`'s verbs (plus a few additions, e.g. `--code-comment`) and presents the **same `gh`-style interface against both GitHub and Forgejo**, so you never need to know which host the repo is on. It is **not** a full `gh` replacement: it has only the verbs listed above. If a command isn't in that list, `ghx` doesn't have it — don't fall back to `gh`/`tea`.
+
+{% endif -%}
 Use `run list` / `run view` for workflow-run detail; use `pr checks` / `pr status` for a PR's check rollup.
 
 The modes below are the kinds of work the user will ask for. **Each runs in its own session — possibly a different model or agent** (Review especially). Follow the named skills at each step.
@@ -95,12 +102,12 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
 #### Plan
 
 - Explore the codebase. Flag `DECISION:SCOPE` when resolving ambiguities. Use the `documenting-decisions` skill (refs: `pre-approval-gate.md`, `scope-interpretation.md`).
-- Write an issue → `ghx issue create`
-- Set issue metadata → `ghx issue edit` (labels/assignees/milestone)
+- Write an issue → `{{ agentic_tracker_cli }} issue create`
+- Set issue metadata → `{{ agentic_tracker_cli }} issue edit` (labels/assignees/milestone)
 
 #### Implement
 
-- Read the given issue and comments → `ghx issue view --comments`
+- Read the given issue and comments → `{{ agentic_tracker_cli }} issue view --comments`
 - Do Test-Driven Development per the `tdd` skill.
 - Implement the minimal code to pass tests, then the remaining code per the ticket spec. Place `DECISION:` markers per the `documenting-decisions` skill (refs: `decision-markers.md`, `marker-examples.md`).
 - Commit discipline:
@@ -110,30 +117,30 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
 {%- endif %}
   - TDD red-step commits are expected and required (a commit whose new tests fail but whose lint/format passes). **CI evaluates at PR HEAD, not per-commit**, so a red-step commit does not constitute a CI failure — do not treat it as one.
   - Don't fix lint manually — run the formatter. Only touch code directly if the tools can't resolve it.
-- Push → `git push` *(plain git; git is not routed through `ghx`)*
-- Create the PR if not already present, and link it to the issue both ways → `ghx pr create` (start with `Closes #<number>` in description), then `ghx issue edit` if a back-reference is needed. **If a PR already exists for this branch, do not create or re-link it** — skip to CI.
+- Push → `git push` *(plain git; git is not routed through `{{ agentic_tracker_cli }}`)*
+- Create the PR if not already present, and link it to the issue both ways → `{{ agentic_tracker_cli }} pr create` (start with `Closes #<number>` in description), then `{{ agentic_tracker_cli }} issue edit` if a back-reference is needed. **If a PR already exists for this branch, do not create or re-link it** — skip to CI.
   PR body must include:
   - `Closes #<number>`.
   - Any obstacles that diverged from the initial plan, and — in the rare event spec deviation was unavoidable — what deviated and why.
   - All `DECISION:` markers present in the diff, rendered per the `documenting-decisions` skill format.
-- Check CI → `ghx run list` / `ghx run view` (or `ghx pr checks` once the PR exists).
+- Check CI → `{{ agentic_tracker_cli }} run list` / `{{ agentic_tracker_cli }} run view` (or `{{ agentic_tracker_cli }} pr checks` once the PR exists).
 - If CI fails, fix it by re-entering this **Implement** workflow.
 
 #### Review
 
-- Read the given issue and comments → `ghx issue view --comments`
+- Read the given issue and comments → `{{ agentic_tracker_cli }} issue view --comments`
 - Review the PR and give Critical / Important feedback per the `requesting-code-review` skill.
-- Submit it as a single review → `ghx pr review`:
+- Submit it as a single review → `{{ agentic_tracker_cli }} pr review`:
   - PR-level summary feedback → `--body "..."`
   - Feedback tied to specific lines → repeatable `--code-comment path:line:text`
-  - Put both in the same `ghx pr review` call; don't split a review across `pr review` and `pr comment`.
+  - Put both in the same `{{ agentic_tracker_cli }} pr review` call; don't split a review across `pr review` and `pr comment`.
 
 #### Apply Review Comments
 
-- Read the given issue and comments → `ghx issue view --comments`
-- Read PR comments and code comments → `ghx pr view --comments`
-- If the review uncovers inconsistencies in the issue, **comment** on it freely → `ghx issue comment`
-- Only **edit** issue content when the user explicitly requests it → `ghx issue edit`. Editing is gated on explicit request because it can overwrite human-authored intent; commenting is always safe, editing is not.
+- Read the given issue and comments → `{{ agentic_tracker_cli }} issue view --comments`
+- Read PR comments and code comments → `{{ agentic_tracker_cli }} pr view --comments`
+- If the review uncovers inconsistencies in the issue, **comment** on it freely → `{{ agentic_tracker_cli }} issue comment`
+- Only **edit** issue content when the user explicitly requests it → `{{ agentic_tracker_cli }} issue edit`. Editing is gated on explicit request because it can overwrite human-authored intent; commenting is always safe, editing is not.
 - Then re-enter the **Implement** workflow.
 
 ## Dependencies

--- a/template/scripts/agent-shims/{% if agentic_tracker_cli != 'gh' %}gh{% endif %}.jinja
+++ b/template/scripts/agent-shims/{% if agentic_tracker_cli != 'gh' %}gh{% endif %}.jinja
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Agent-PATH shim: this CLI is not the chosen tracker CLI for this repo.
+# On PATH only inside agent sessions (see .claude/settings.json); the
+# user's shell is untouched.
+echo "gh: disabled — use {{ agentic_tracker_cli }} (see AGENTS.md)" >&2
+exit 1

--- a/template/scripts/agent-shims/{% if agentic_tracker_cli != 'ghx' %}ghx{% endif %}.jinja
+++ b/template/scripts/agent-shims/{% if agentic_tracker_cli != 'ghx' %}ghx{% endif %}.jinja
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Agent-PATH shim: this CLI is not the chosen tracker CLI for this repo.
+# On PATH only inside agent sessions (see .claude/settings.json); the
+# user's shell is untouched.
+echo "ghx: disabled — use {{ agentic_tracker_cli }} (see AGENTS.md)" >&2
+exit 1

--- a/template/scripts/agent-shims/{% if agentic_tracker_cli != 'tea' %}tea{% endif %}.jinja
+++ b/template/scripts/agent-shims/{% if agentic_tracker_cli != 'tea' %}tea{% endif %}.jinja
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Agent-PATH shim: this CLI is not the chosen tracker CLI for this repo.
+# On PATH only inside agent sessions (see .claude/settings.json); the
+# user's shell is untouched.
+echo "tea: disabled — use {{ agentic_tracker_cli }} (see AGENTS.md)" >&2
+exit 1

--- a/template/scripts/doctor.sh.jinja
+++ b/template/scripts/doctor.sh.jinja
@@ -128,7 +128,13 @@ for tool in "${REQUIRED_TOOLS[@]}"; do
     fi
 done
 
-warn_tool ghx "not installed (deferred; agents use ghx for repo interaction)"
+{% endraw -%}
+{# gh is already a required host tool above; warning on it again would be
+   redundant, so the tracker-CLI warning renders only for ghx/tea. -#}
+{% if agentic_tracker_cli != 'gh' -%}
+warn_tool {{ agentic_tracker_cli }} "not installed (deferred; agents use {{ agentic_tracker_cli }} for repo interaction)"
+{% endif -%}
+{% raw %}
 
 echo
 echo "Summary: $pass ok, $fail required missing"

--- a/template/scripts/enable-agent-shims.sh
+++ b/template/scripts/enable-agent-shims.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook: prepend the agent shims to PATH for this
+# agent session only. `env` in .claude/settings.json cannot express a PATH
+# prepend (values are literal, no $PATH expansion), so we write an export
+# to CLAUDE_ENV_FILE, which every Bash tool call in the session sources.
+# The user's own shell and dotfiles are never touched.
+set -euo pipefail
+
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+    shim_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}/scripts/agent-shims"
+    echo "export PATH=\"${shim_dir}:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+fi

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,6 +15,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 # Exact file set the template must produce (no orphans, no omissions).
 COMMON_FILES = frozenset(
     {
+        ".claude/settings.json",
         ".codespellrc",
         ".copier-answers.agentic.yml",
         ".editorconfig",
@@ -26,7 +27,10 @@ COMMON_FILES = frozenset(
         "docs/architecture.md",
         "docs/glossary/.markdownlint-cli2.yaml",
         "docs/glossary/snake-farm.md",
+        "scripts/agent-shims/gh",
+        "scripts/agent-shims/tea",
         "scripts/doctor.sh",
+        "scripts/enable-agent-shims.sh",
         "skills-lock.json",
     }
 )

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -46,3 +46,110 @@ def test_slug_auto_derived(
         dst_path / "AGENTS.md",
         ["https://github.com/actions-user/my-cool-app"],
     )
+
+
+# Prose that only applies to ghx (the GitHub/Forgejo parity paragraph).
+GHX_PARITY_PROSE = "same `gh`-style interface against both GitHub and Forgejo"
+
+
+def _render(tmp_path: Path, answers: dict[str, str], dst_name: str) -> Path:
+    dst_path = tmp_path / dst_name
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=answers,
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+    )
+    return dst_path
+
+
+def test_tracker_cli_default_renders_ghx_docs_and_gh_tea_shims(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Default answer (ghx): ghx-flavored docs, shims for gh and tea only."""
+    dst_path = _render(tmp_path, base_answers, "tracker-default")
+
+    _check_file_contents(
+        dst_path / "AGENTS.md",
+        [
+            "Use `ghx` for all repository interaction",
+            "`gh` and `tea` are disabled",
+            GHX_PARITY_PROSE,
+            "`ghx issue create`",
+        ],
+    )
+
+    shim_dir = dst_path / "scripts" / "agent-shims"
+    assert not (shim_dir / "ghx").exists(), "chosen CLI must not be shimmed"
+    for shim_name in ("gh", "tea"):
+        shim = shim_dir / shim_name
+        _check_file_contents(
+            shim,
+            [f"{shim_name}: disabled — use ghx (see AGENTS.md)", "exit 1"],
+        )
+        assert shim.stat().st_mode & 0o111, f"shim {shim_name} must be executable"
+
+    _check_file_contents(
+        dst_path / "scripts" / "doctor.sh",
+        ['warn_tool ghx "not installed'],
+    )
+    _check_file_contents(
+        dst_path / ".copier-answers.agentic.yml",
+        ["agentic_tracker_cli: ghx"],
+    )
+
+
+def test_tracker_cli_gh_renders_gh_docs_and_ghx_tea_shims(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Choosing gh: gh-flavored docs without ghx prose, shims for ghx and tea."""
+    answers = {**base_answers, "agentic_tracker_cli": "gh"}
+    dst_path = _render(tmp_path, answers, "tracker-gh")
+
+    _check_file_contents(
+        dst_path / "AGENTS.md",
+        [
+            "Use `gh` for all repository interaction",
+            "`ghx` and `tea` are disabled",
+            "`gh issue create`",
+        ],
+        unexpect_strs=[GHX_PARITY_PROSE],
+    )
+
+    shim_dir = dst_path / "scripts" / "agent-shims"
+    assert not (shim_dir / "gh").exists(), "chosen CLI must not be shimmed"
+    for shim_name in ("ghx", "tea"):
+        _check_file_contents(
+            shim_dir / shim_name,
+            [f"{shim_name}: disabled — use gh (see AGENTS.md)", "exit 1"],
+        )
+
+    # gh is already a required host tool, so doctor.sh must not warn on it.
+    _check_file_contents(
+        dst_path / "scripts" / "doctor.sh",
+        unexpect_strs=["warn_tool gh ", "warn_tool ghx", "warn_tool tea"],
+    )
+    _check_file_contents(
+        dst_path / ".copier-answers.agentic.yml",
+        ["agentic_tracker_cli: gh"],
+    )
+
+
+def test_claude_settings_put_shims_on_agent_path(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Repo-committed Claude Code config wires the shim dir onto agent PATH."""
+    dst_path = _render(tmp_path, base_answers, "tracker-settings")
+
+    _check_file_contents(
+        dst_path / ".claude" / "settings.json",
+        ["SessionStart", "scripts/enable-agent-shims.sh"],
+    )
+    hook = dst_path / "scripts" / "enable-agent-shims.sh"
+    _check_file_contents(hook, ["scripts/agent-shims", "CLAUDE_ENV_FILE"])
+    assert hook.stat().st_mode & 0o111, "PATH hook must be executable"


### PR DESCRIPTION
Closes #20

## What

- **`agentic_tracker_cli` enum** in `copier.yml` (`ghx`/`gh`/`tea`, default `ghx`), persisted in the answers file.
- **Templated AGENTS.md workflow**: all tracker commands use the chosen CLI; the ghx-specific GitHub/Forgejo parity paragraph renders only when `ghx` is chosen. The intro names the two non-chosen CLIs as disabled and notes that MCP-based tracker access is not gated (out of scope per issue).
- **`scripts/agent-shims/`**: one executable shim per non-chosen CLI, printing `<cli>: disabled — use <chosen> (see AGENTS.md)` to stderr and exiting 1. Rendered via conditional filenames, so the chosen CLI is never shimmed.
- **Agent-only PATH injection**: repo-committed `.claude/settings.json` registers a SessionStart hook (`scripts/enable-agent-shims.sh`) that writes a PATH prepend to `CLAUDE_ENV_FILE`. User shell/dotfiles untouched.
- **doctor.sh** warns when the *chosen* CLI is missing instead of hardcoding `ghx`; no duplicate warning when `gh` is chosen since `gh` is already a required host tool.
- **Grilling override line** added to the Skills section in both the repo's AGENTS.md and the template: use the platform's multiple-choice dialog (AskUserQuestion) when supported, plain text otherwise.

## Decisions / deviations

- `DECISION:` Verified per issue point 4 that `env` in `.claude/settings.json` cannot express a PATH prepend (values are literal, no `$PATH`/`$CLAUDE_PROJECT_DIR` expansion), so the specified fallback — a SessionStart hook exporting PATH — is used, via the documented `CLAUDE_ENV_FILE` mechanism.
- `DECISION:` The ghx parity paragraph moved below the verb list ("listed above" instead of "listed below") so both template source and rendered output pass markdownlint (MD022) without disable comments.
- Template repo itself is not gated (explicitly out of scope per issue point 5).

## Tests

- Default answers render ghx-flavored docs + executable `gh`/`tea` shims; `ghx` shim absent; doctor warns on ghx.
- `agentic_tracker_cli=gh` renders gh-flavored docs without ghx prose + `ghx`/`tea` shims; no doctor warn duplication.
- `.claude/settings.json` + hook script wiring and executability.
- e2e expected-tree updated with the new files.

`pytest`: 8 passed, 2 skipped (host-tool smoke tests). All prek hooks pass except shellcheck, whose binary download is 403-blocked by the sandbox proxy; shell scripts validated with `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167qibF95CjozDj81imvM8E

---
_Generated by [Claude Code](https://claude.ai/code/session_0167qibF95CjozDj81imvM8E)_