### PR TITLE
feat(release): tag template releases (semantic-release style)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+# One release run at a time, queued (not cancelled) so every push to main
+# is evaluated — cancelling could skip a releasable commit.
+concurrency:
+  group: release
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    # Cut a tag + GitHub Release from conventional commits on main
+    # (see issue #23). This releases the template repo itself so copier
+    # resolves stable version tags instead of HEAD; the rendered template
+    # payload is untouched and stays language-agnostic. semantic-release
+    # runs via npx using Node preinstalled on the runner — no release
+    # tooling is added to the repo's Python project or the template.
+    runs-on: ubuntu-latest
+    name: "Release (semantic-release)"
+    permissions:
+      # Tags and GitHub Releases only; issue/PR comments and labels are
+      # disabled in .releaserc.json, so no issues/pull-requests scopes.
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # semantic-release needs full history and tags to find the
+          # previous release and analyze the commits since.
+          fetch-depth: 0
+      - run: npx --yes semantic-release@24
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "failTitle": false,
+        "labels": false,
+        "releasedLabels": false
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Closes #23

## What

- New `.github/workflows/release.yml`: on every push to `main`, runs `npx semantic-release@24`. It parses conventional commits since the last tag, and when releasable, cuts a `v<semver>` tag plus a GitHub Release with a generated changelog.
- New `.releaserc.json`: branches = `main`, plugins = commit-analyzer + release-notes-generator + github. Issue/PR success/fail comments and labels disabled (frugal; also lets the job run with `contents: write` only).

## Why

Template had no tags, so `copier update` fell back to HEAD — non-reproducible downstream updates, opaque `_commit` hashes. With tags, copier resolves the latest release by default and update PRs read as `v0.3.0 -> v0.4.0`.

## Decisions

- DECISION:TOOLING semantic-release runs via `npx` in CI only, using the runner's preinstalled Node. Nothing is added to the repo's Python project or the rendered template payload, so the template stays language-agnostic (the release stack applies to the template repo itself, not rendered output).
- DECISION:SCOPE No `CHANGELOG.md` commit-back: release notes live on the GitHub Release. Avoids release-commit loops on `main` and keeps the workflow to `contents: write`.
- Release runs are serialized via a queued (not cancelled) concurrency group so every `main` push is evaluated.

## Obstacles

None; no deviation from the issue spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTLdWNVbcBSprLm5ePGp7b)_