### PR TITLE
feat(template): ship scheduled copier-update workflow to consuming repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,11 @@ jobs:
           git -C "$fixture_dir" commit -qm "chore: generated fixture"
 
           # Re-render the agentic layer against the same template state.
+          # Pin --vcs-ref: without it copier resolves the latest release tag,
+          # which on a PR branch ahead of that tag counts as a downgrade from
+          # the ci-conflict-check ref used above, and copier refuses to run.
           uv run copier update --trust --defaults "${data[@]}" \
+            --vcs-ref ci-conflict-check \
             --answers-file .copier-answers.agentic.yml "$fixture_dir"
 
           rejects="$(find "$fixture_dir" -name '*.rej' -print)"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Generated projects receive:
 - **Architecture stub** — `docs/architecture.md` linking to the project glossary term.
 - **Cross-cutting lint hooks** (optional) — when `agentic_precommit` is `prek`, a `.pre-commit-config.yaml` covering commit messages, JSON, Markdown, and spelling only. No unit tests in prek — tests belong in CI. Language-specific linting stays with whatever template owns the source code.
 - **Shared config** — `.editorconfig`, `.codespellrc`, `commitlint.config.mjs`, and `scripts/doctor.sh` (host-tool checks).
+- **Scheduled template updates** (GitHub forge only) — `.github/workflows/template-update.yml` runs `copier update` weekly and opens a PR when a newer template release exists. See [Automated template updates](#automated-template-updates).
 
 All Copier questions use the `agentic_` prefix so this template can layer without colliding with other templates. Answers are stored in `.copier-answers.agentic.yml` (not Copier's default).
 
@@ -97,6 +98,28 @@ This template only writes files it is configured to own. It does not silently ta
 | Source code, package manifests, language lint hooks | base / layered template |
 
 **Conflict detection** is not enforced inside `copier.yml`. Copier's default update behaviour may produce `.rej` files and still exit zero. CI on this repository runs `copier update` against fixture projects and fails if any `.rej` files exist or the tree is unexpectedly dirty — surfacing collisions (for example both templates touching `.pre-commit-config.yaml`) instead of letting silent rejects rot.
+
+## Automated template updates
+
+On the GitHub forge, generated projects receive `.github/workflows/template-update.yml`. The workflow is self-propagating: update a consuming repo once and it keeps receiving updater changes with every subsequent template release.
+
+What it does:
+
+- **Trigger** — weekly cron plus manual `workflow_dispatch`.
+- **Update** — runs `copier update --defaults --trust --skip-tasks` against the latest template release tag (tasks are skipped because post-render tasks need host tools absent on CI runners).
+- **No changes** — exits clean, no PR.
+- **Changes** — pushes a `chore/template-update-<version>` branch and opens a PR whose body shows the version delta and the release changelog excerpt. If an update PR is already open, the run skips instead of stacking duplicates.
+- **Conflicts** — copier's inline conflict markers are committed as-is; the PR still opens and red lint/CI flags the markers for human/agent resolution on the branch. Updates never silently stall.
+
+### Required setup in consuming repos
+
+The workflow authenticates with a GitHub App installation token (same pattern as a semantic-release bot) instead of the default `GITHUB_TOKEN` — PRs opened with `GITHUB_TOKEN` trigger no CI, which would defeat the conflict-surfacing strategy. Each consuming repo needs:
+
+1. A GitHub App (e.g. your release bot) installed on the repository with **contents: read/write** and **pull requests: read/write** permissions.
+2. A repository (or org) **variable** `RELEASE_BOT_CLIENT_ID` set to the app's client ID.
+3. A repository (or org) **secret** `RELEASE_BOT_PRIVATE_KEY` containing an app private key.
+
+Until these are configured, scheduled runs fail at the token-minting step and do nothing else.
 
 ## Configuration
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
@@ -1,0 +1,127 @@
+name: Template Update
+
+on:
+  schedule:
+    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+# The workflow only acts through the release-bot app token minted below —
+# the default GITHUB_TOKEN would open PRs that trigger no CI, silently
+# skipping the checks that flag copier conflict markers for resolution.
+permissions: {}
+
+concurrency:
+  group: template-update
+
+jobs:
+  update:
+    name: "copier update (agentic template)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Skip if an update PR is already open
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          open_prs="$(gh pr list --state open --json headRefName \
+            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
+          if [ "$open_prs" -gt 0 ]; then
+            echo "An update PR is already open ($open_prs) — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.dedupe.outputs.skip == 'false'
+        with:
+          # Push the update branch as the app so the resulting PR runs CI.
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.dedupe.outputs.skip == 'false'
+
+      - name: Run copier update against the latest template tag
+        if: steps.dedupe.outputs.skip == 'false'
+        id: update
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          old_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          # --skip-tasks: post-tasks (doctor.sh, skills install, prek) need
+          # host tools absent on runners; the consuming repo already ran them.
+          # copier-template-extensions is required to load the template's
+          # Jinja extensions.
+          uvx --with copier-template-extensions copier update \
+            --answers-file "$answers_file" \
+            --defaults --trust --skip-tasks
+
+          new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+          {
+            echo "old_ref=$old_ref"
+            echo "new_ref=$new_ref"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Already up to date ($old_ref) — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open update PR
+        if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_REF: ${{ steps.update.outputs.old_ref }}
+          NEW_REF: ${{ steps.update.outputs.new_ref }}
+        run: |
+          set -euo pipefail
+          branch="chore/template-update-$NEW_REF"
+
+          git config user.name "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # Conflicts are committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution on
+          # the branch, so updates never silently stall.
+          git add -A
+          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
+          git push -u origin "$branch"
+
+          # Changelog excerpt from the template's GitHub Release for the new
+          # tag. Best-effort: a missing release only degrades the PR body.
+          src_path="$(awk '$1 == "_src_path:" {print $2}' .copier-answers.agentic.yml)"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+          changelog="$(gh release view "$NEW_REF" --repo "$template_repo" \
+            --json body --jq .body \
+            || echo "_No release notes found for $NEW_REF in $template_repo._")"
+
+          {
+            echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
+            echo
+            echo "If CI is red, the update hit merge conflicts — resolve copier's inline conflict markers on this branch."
+            echo
+            echo "## Template changelog ($NEW_REF)"
+            echo
+            echo "$changelog"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "chore: update agentic template to $NEW_REF" \
+            --body-file /tmp/pr-body.md \
+            --head "$branch"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -35,8 +35,12 @@ COMMON_FILES = frozenset(
     }
 )
 
-EXPECTED_WITH_PREK = COMMON_FILES | {".pre-commit-config.yaml"}
-EXPECTED_WITHOUT_PREK = COMMON_FILES
+# Shipped only on the GitHub forge (the updater authenticates via a GitHub
+# App and drives `gh`; Forgejo repos get no .github directory).
+GITHUB_ONLY_FILES = frozenset({".github/workflows/template-update.yml"})
+
+EXPECTED_WITH_PREK = COMMON_FILES | GITHUB_ONLY_FILES | {".pre-commit-config.yaml"}
+EXPECTED_WITHOUT_PREK = COMMON_FILES | GITHUB_ONLY_FILES
 
 
 def _relative_file_tree(root: Path) -> frozenset[str]:
@@ -127,7 +131,10 @@ def test_e2e_copy_variants_render_clean_tree(
     """Variant answers still render the same owned file set with substituted values."""
     dst_path = render_project(**overrides)
 
-    expected = {path.replace("snake-farm", slug) for path in EXPECTED_WITH_PREK}
+    base = EXPECTED_WITH_PREK
+    if overrides.get("agentic_forge") == "forgejo":
+        base = base - GITHUB_ONLY_FILES
+    expected = {path.replace("snake-farm", slug) for path in base}
     _assert_tree(dst_path, frozenset(expected))
 
     assert repo_url in (dst_path / "AGENTS.md").read_text()

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -153,3 +153,42 @@ def test_claude_settings_put_shims_on_agent_path(
     hook = dst_path / "scripts" / "enable-agent-shims.sh"
     _check_file_contents(hook, ["scripts/agent-shims", "CLAUDE_ENV_FILE"])
     assert hook.stat().st_mode & 0o111, "PATH hook must be executable"
+
+
+def test_github_forge_ships_template_update_workflow(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """GitHub forge: scheduled copier-update workflow rendered verbatim."""
+    dst_path = _render(tmp_path, base_answers, "updater-github")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "template-update.yml",
+        [
+            "workflow_dispatch",
+            "copier update",
+            "--defaults --trust --skip-tasks",
+            "copier-template-extensions",
+            "actions/create-github-app-token",
+            "RELEASE_BOT_CLIENT_ID",
+            "RELEASE_BOT_PRIVATE_KEY",
+            "chore/template-update-",
+            # GitHub expressions must survive rendering (file is not Jinja).
+            "${{ steps.app-token.outputs.token }}",
+        ],
+    )
+
+
+def test_forgejo_forge_ships_no_github_workflow(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Forgejo forge: no .github directory — the updater is GitHub-only."""
+    answers = {
+        **base_answers,
+        "agentic_forge": "forgejo",
+        "agentic_forgejo_host": "git.example.com",
+    }
+    dst_path = _render(tmp_path, answers, "updater-forgejo")
+
+    assert not (dst_path / ".github").exists()


### PR DESCRIPTION
Closes #24.

## What

Template now ships the updater. GitHub-forge projects get `.github/workflows/template-update.yml` — self-propagating, repos receive it by updating once.

Workflow does:

- Weekly cron + `workflow_dispatch`.
- `copier update --defaults --trust --skip-tasks` via `uvx --with copier-template-extensions` against latest template tag (tags exist since #23; tasks skipped — post-tasks need host tools absent on runners).
- No changes: exits clean, no PR.
- Changes: branch `chore/template-update-<version>`, commit, PR with version delta + release changelog excerpt. Skips when an update PR is already open.
- Conflicts: copier inline markers committed as-is; PR opens anyway, red CI flags markers for resolution on branch. Updates never stall silently.
- Auth: installation token from release-bot GitHub App (`RELEASE_BOT_CLIENT_ID` var + `RELEASE_BOT_PRIVATE_KEY` secret) — default `GITHUB_TOKEN` PRs trigger no CI, which would defeat the conflict strategy.

## How

- Workflow is a plain `.yml` (not `.jinja`) so GitHub `${{ }}` expressions survive rendering verbatim; needs no templating since answers-file name is fixed and template repo URL is read from `_src_path` at runtime.
- `.github` directory name is conditional on `agentic_forge == 'github'` — Forgejo renders get no `.github` at all (updater drives `gh` + GitHub App auth).
- README: new "Automated template updates" section documents behavior and required app setup in consuming repos.

DECISION: gate updater to GitHub forge only — spec'd auth is a GitHub App; Forgejo needs its own workflow format and token model, out of scope.
DECISION: changelog excerpt is best-effort (`gh release view || fallback note`) — missing release notes only degrade the PR body, never block the update PR.

## Tests

- `test_github_forge_ships_template_update_workflow` — workflow rendered with intact `${{ }}` expressions, app-token auth, dedupe branch prefix.
- `test_forgejo_forge_ships_no_github_workflow` — no `.github/` for Forgejo.
- e2e exact-tree sets extended with `GITHUB_ONLY_FILES`, subtracted for the Forgejo variant.
- actionlint passes on rendered workflow; prek lint green. Two pre-existing e2e failures (`doctor.sh` host tools absent in sandbox) fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChkuFnw1wX6SooZvMhGoLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChkuFnw1wX6SooZvMhGoLs)_