### PR TITLE
feat(template): bridge .agents/skills into .claude/skills via symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Copier](https://copier.readthedocs.io/) template that overlays agentic-engine
 Generated projects receive:
 
 - **Agent docs** — `AGENTS.md` and `CLAUDE.md`, templated with project name, description, slug, and (optionally) forge/repo URL. `AGENTS.md` keeps a universal core (glossary, skills, git/tracker workflow, style); its coding sections render only when `agentic_project_kind` is `code`. It links to `docs/conventions.md`, a repo-owned file seeded once and never overwritten on `copier update` — rich local rules go there without conflicts.
-- **Skills** — pinned in `skills-lock.json`; a post-render step runs `npx skills@latest experimental_install` to populate `.agents/skills/`. Code-only skills (`tdd`, `requesting-code-review`, `to-tickets`) are included only when `agentic_project_kind` is `code`.
+- **Skills** — pinned in `skills-lock.json`; a post-render step runs `npx skills@latest experimental_install` to populate `.agents/skills/`. Code-only skills (`tdd`, `requesting-code-review`, `to-tickets`) are included only when `agentic_project_kind` is `code`. `.claude/skills` is shipped as a symlink to `.agents/skills` so Claude Code registers the installed skills as platform skills / slash commands (`experimental_install` doesn't propagate into per-agent directories on lockfile restore). Windows note: git symlinks need `core.symlinks=true` plus developer mode.
 - **Glossary** — `docs/glossary/` with a seed entry for the project itself. Terms are resolved with `uvx disambiguate==<agentic_disambiguate_version>` (pinned — disambiguate is pre-alpha with breaking changes between releases).
 - **Architecture stub** — `docs/architecture.md` linking to the project glossary term (`agentic_project_kind` is `code` only).
 - **Cross-cutting lint hooks** (optional) — when `agentic_precommit` is `prek`, a `.pre-commit-config.yaml` covering commit messages, JSON, Markdown, glossary lint (pinned `disambiguate --lint` as a local hook — no repo-local `core.hooksPath` setup needed; lint roots are configurable via the `agentic_disambiguate_roots` answer so repos never patch the rendered hook), and — for English content only — spelling. No unit tests in prek — tests belong in CI. Language-specific linting stays with whatever template owns the source code.
@@ -91,7 +91,7 @@ This template only writes files it is configured to own. It does not silently ta
 | --- | --- |
 | `AGENTS.md`, `CLAUDE.md` | agentic-template |
 | `docs/conventions.md` | **project** — seeded once by agentic-template, never overwritten (`_skip_if_exists`) |
-| `skills-lock.json`, `.agents/skills/` | agentic-template |
+| `skills-lock.json`, `.agents/skills/`, `.claude/skills` (symlink) | agentic-template |
 | `docs/glossary/`, `docs/architecture.md` | agentic-template |
 | `.editorconfig`, `.codespellrc`, `commitlint.config.mjs` | agentic-template |
 | `scripts/doctor.sh` | agentic-template |

--- a/copier.yml
+++ b/copier.yml
@@ -104,6 +104,9 @@ agentic_repo_owner:
 # Copier metadata
 _min_copier_version: "9.11.0"
 _subdirectory: template
+# Keep the .claude/skills → ../.agents/skills bridge a symlink in generated
+# repos instead of copying (a copy would be empty — skills install post-render).
+_preserve_symlinks: true
 _answers_file: .copier-answers.agentic.yml
 # Seeded once, never overwritten on `copier update` — rich repo-local rules
 # live there so AGENTS.md updates never conflict with hand-written content.

--- a/template/.claude/skills
+++ b/template/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/template/.markdownlint-cli2.yaml
+++ b/template/.markdownlint-cli2.yaml
@@ -16,3 +16,6 @@ ignores:
   - .copier-answers.agentic.yml
   - .all-contributorsrc
   - .agents/skills/**
+  # Bridged agent skill dirs (symlinks into .agents/skills) — keep excludes in
+  # sync so skill files aren't linted through the symlink.
+  - .claude/skills/**

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -1,5 +1,5 @@
 # See https://pre-commit.com for more information
-exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills"
+exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills|\\.claude/skills"
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit, commit-msg]
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -156,6 +156,28 @@ def test_claude_settings_put_shims_on_agent_path(
     assert hook.stat().st_mode & 0o111, "PATH hook must be executable"
 
 
+def test_claude_skills_symlink_bridges_agents_skills(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Claude Code loads skills from .claude/skills — shipped as a symlink so
+    .agents/skills stays the single canonical location."""
+    dst_path = _render(tmp_path, base_answers, "skills-bridge")
+
+    link = dst_path / ".claude" / "skills"
+    assert link.is_symlink(), ".claude/skills must be a symlink, not a copy"
+    assert link.readlink() == Path("../.agents/skills")
+
+    # Lint configs must exclude the bridged dir, else skill files get linted
+    # through the symlink.
+    _check_file_contents(
+        dst_path / ".markdownlint-cli2.yaml", [".claude/skills/**"]
+    )
+    _check_file_contents(
+        dst_path / ".pre-commit-config.yaml", ["\\.claude/skills"]
+    )
+
+
 def test_project_kind_code_renders_code_artifacts(
     tmp_path: Path,
     base_answers: dict[str, str],

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -170,12 +170,8 @@ def test_claude_skills_symlink_bridges_agents_skills(
 
     # Lint configs must exclude the bridged dir, else skill files get linted
     # through the symlink.
-    _check_file_contents(
-        dst_path / ".markdownlint-cli2.yaml", [".claude/skills/**"]
-    )
-    _check_file_contents(
-        dst_path / ".pre-commit-config.yaml", ["\\.claude/skills"]
-    )
+    _check_file_contents(dst_path / ".markdownlint-cli2.yaml", [".claude/skills/**"])
+    _check_file_contents(dst_path / ".pre-commit-config.yaml", ["\\.claude/skills"])
 
 
 def test_project_kind_code_renders_code_artifacts(


### PR DESCRIPTION
Closes #30

## What

Skills installed by `npx skills@latest experimental_install` land only in `.agents/skills/`, so Claude Code never registers them as platform skills / slash commands in generated repos (the AGENTS.md fallback works, but costs a detour, and `/grill-me`-style invocations fail outright).

This ships the bridge in the template itself, keeping `.agents/skills/` the single canonical location:

- **`template/.claude/skills` → `../.agents/skills` symlink**, checked in (declarative, visible in the template diff, no `_tasks` ordering concerns).
- **`_preserve_symlinks: true`** in `copier.yml` so the symlink is rendered as a symlink instead of being followed (it dangles at render time — skills install post-render).
- **Lint excludes extended** to the bridged dir: `.claude/skills/**` added to the template's `.markdownlint-cli2.yaml` ignores and `\.claude/skills` to the prek `exclude` regex, so skill files aren't linted through the symlink (previously hit as MD041 errors).
- **Test** asserting the rendered project gets a real symlink pointing at `../.agents/skills` and that both lint configs exclude it.
- **README**: documents the bridge, the ownership of `.claude/skills`, and the Windows `core.symlinks` caveat.

Other agents' directories (Cursor, Codex, …) are deliberately left alone for now — only `.claude/` already exists in `template/`; revisit when upstream `skills` fixes `experimental_install` propagation.

## Testing

`uv run pytest tests/` — 19 passed, 2 skipped, including the new `test_claude_skills_symlink_bridges_agents_skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJDJYLARMvsgz6Hp9D29J2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJDJYLARMvsgz6Hp9D29J2)_