### PR TITLE
feat: repoint grilling skill to frankify-app/skills derivation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Repo: <https://github.com/frankify-app/agentic-engineering-template>
 Ubiquitous language is defined in docs/glossary/. Use
 
 ```bash
-uvx disambiguate <term>
+uvx disambiguate==0.2.0 <term>
 ```
 
 to get a topologically ordered glossary disambiguating all relevant terms
@@ -18,13 +18,13 @@ to understand the given term.
 Before working on a ticket, run:
 
 ```bash
-uvx disambiguate --from <ticket-file>
+uvx disambiguate==0.2.0 --from <ticket-file>
 ```
 
 or for GitHub issues:
 
 ```bash
-ghx issue view <number> --json body -q .body | uvx disambiguate --from -
+ghx issue view <number> --json body -q .body | uvx disambiguate==0.2.0 --from -
 ```
 
 to resolve all referenced terms at once.
@@ -54,23 +54,34 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 
 **Loading:** Use platform skill tool if available, else read `.agents/skills/<name>/SKILL.md` directly.
 
+Each table is sorted alphabetically by skill — keep it sorted when adding entries.
+
 | Skill                    | Trigger                                                                                            |
 | ------------------------ | -------------------------------------------------------------------------------------------------- |
-| `tdd`                    | Test-driven-development for any implementation                                                     |
-| `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
-| `requesting-code-review` | After completing implementation                                                                    |
 | `caveman`                | Compact wording when writing prose (issues description, PR description, comments on repo or code)  |
+| `documenting-decisions`  | Any implementation task — place `DECISION:` markers                                                |
+| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
 | `grill-me`               | User asks to be grilled/interviewed about a plan or design before implementation                   |
 | `grill-with-docs`        | Grilling session that also records ADRs and glossary entries as decisions are made                 |
 | `grilling`               | Core interview loop used by `grill-me`/`grill-with-docs`; also on any 'grill' trigger phrase       |
-| `domain-modeling`        | Pinning down domain terminology (glossary in `docs/glossary/`) or recording decisions in design    |
-| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
-| `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
 | `to-spec`                | Turning the current conversation into a spec/PRD and publishing it to the tracker                  |
+| `writing-adrs`           | Recording an architectural decision as an ADR in `docs/adr/`, or when another skill flags one      |
+
+Code-specific skills:
+
+| Skill                    | Trigger                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| `requesting-code-review` | After completing implementation                                                                    |
+| `tdd`                    | Test-driven-development for any implementation                                                     |
+| `to-tickets`             | Splitting approved work into tracer-bullet issues with blocking edges (reproducible-spec rules)    |
 
 ### Repo-Local Skill Overrides
 
-- `grilling`: present each question via the platform's multiple-choice dialog (e.g. `AskUserQuestion` in Claude Code) when the platform supports one; fall back to plain-text questions otherwise.
+- `grilling`: present questions via the platform's native question dialog (e.g. `AskUserQuestion` in Claude Code) when the platform provides one; fall back to plain text otherwise. (The multiple-choice question format itself is part of the skill — this override only covers presentation.)
+
+### Skill Environment Variables
+
+- `DECISION_MEMORY_REPO` — URL of the decision-memory repo the `grilling` skill records decisions to. Recording requires this env var in the agent's execution environment; the skill reads exactly this name (shared contract with the skill — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
 
 ## Git
 
@@ -82,15 +93,15 @@ Live in `.agents/skills/`. Synced using `npx skills update -p -y` — don't edit
 
 ### Agentic Engineering Workflow
 
-Use `ghx` for all repository interaction. `gh` and `tea` are disabled — calling them tells you to use `ghx` instead.
-
-`ghx` exposes a curated subset of `gh`'s verbs (plus a few additions, e.g. `--code-comment`) and presents the **same `gh`-style interface against both GitHub and Forgejo**, so you never need to know which host the repo is on. It is **not** a full `gh` replacement: it has only the verbs listed below. If a command isn't in this list, `ghx` doesn't have it — don't fall back to `gh`/`tea`.
+Use `ghx` for all repository interaction. `gh` and `tea` are disabled — calling them tells you to use `ghx` instead (enforced via shims in `scripts/agent-shims/`, on PATH in agent sessions only; tracker access through MCP tools is not gated by the shims).
 
 #### Available `ghx` verbs
 
 - **issues:** `issue create`, `issue view` (`--comments`), `issue list`, `issue comment`, `issue edit`
 - **pull requests:** `pr create`, `pr view` (`--comments`), `pr list`, `pr comment`, `pr edit`, `pr review` (`--body`, repeatable `--code-comment path:line:text`), `pr checks`, `pr status`
 - **CI:** `run list`, `run view`
+
+`ghx` exposes a curated subset of `gh`'s verbs (plus a few additions, e.g. `--code-comment`) and presents the **same `gh`-style interface against both GitHub and Forgejo**, so you never need to know which host the repo is on. It is **not** a full `gh` replacement: it has only the verbs listed above. If a command isn't in that list, `ghx` doesn't have it — don't fall back to `gh`/`tea`.
 
 Use `run list` / `run view` for workflow-run detail; use `pr checks` / `pr status` for a PR's check rollup.
 
@@ -148,3 +159,7 @@ Add packages using the package manager only, never edit requirements/dependencie
 - Document all params, return shapes, and every possible error response
 - Test cases must cover edge cases for inputs and every @returns line in the contract
 - Non-trivial decisions or behavior should be documented via inline comments
+
+## Project Conventions
+
+Repo-specific rules live in [docs/conventions.md](docs/conventions.md). Copier seeds that file once and never overwrites it — put rich local conventions there, not in this template-owned file.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,5 @@
+# Agentic Engineering Template — Project Conventions
+
+Repo-specific rules referenced from [AGENTS.md](../AGENTS.md). This file is
+seeded once by the agentic template and never overwritten by `copier update` —
+edit it freely.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -3,3 +3,39 @@
 Repo-specific rules referenced from [AGENTS.md](../AGENTS.md). This file is
 seeded once by the agentic template and never overwritten by `copier update` —
 edit it freely.
+
+## Template-First Changes (Self-Application)
+
+This repo is the template AND uses itself as a template: root artifacts that
+have a counterpart under `template/` (`AGENTS.md`, `skills-lock.json`,
+`scripts/doctor.sh`, `scripts/agent-shims/`, …) are template *output*, never
+hand-edited. Editing both places duplicates work; editing only the root drifts
+from the template.
+
+For any change touching a templated file, always follow this route:
+
+1. Edit only the source under `template/` (plus `copier.yml`, `extensions/`,
+   tests).
+2. Commit the template-only change(s).
+3. Self-apply: render the template from the current branch and adopt the
+   rendered output for the affected root files verbatim:
+
+   ```bash
+   uv run copier copy --trust --defaults --skip-tasks --vcs-ref HEAD \
+     --data agentic_project_name="Agentic Engineering Template" \
+     --data agentic_project_description="Copier template for agentic engineering scaffolding" \
+     --data agentic_project_slug=agentic-engineering-template \
+     --data agentic_repo_owner=frankify-app \
+     . <tmp-render-dir>
+   ```
+
+4. Copy the affected files from the render into the repo root and commit them
+   as a separate `chore: reapply template to self` commit.
+
+This doubles as a proving ground: the self-applied root files are the rendered
+template output, reviewed in the same PR as the template change.
+
+Exception: root files that intentionally diverge from the template for
+template-development needs (currently `.pre-commit-config.yaml`, which carries
+jinja lint hooks) are NOT overwritten by self-application — keep maintaining
+them by hand and list them here when adding new ones.

--- a/scripts/agent-shims/gh
+++ b/scripts/agent-shims/gh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Agent-PATH shim: this CLI is not the chosen tracker CLI for this repo.
+# On PATH only inside agent sessions (see .claude/settings.json); the
+# user's shell is untouched.
+echo "gh: disabled — use ghx (see AGENTS.md)" >&2
+exit 1

--- a/scripts/agent-shims/tea
+++ b/scripts/agent-shims/tea
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Agent-PATH shim: this CLI is not the chosen tracker CLI for this repo.
+# On PATH only inside agent sessions (see .claude/settings.json); the
+# user's shell is untouched.
+echo "tea: disabled — use ghx (see AGENTS.md)" >&2
+exit 1

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -127,10 +127,31 @@ done
 
 warn_tool ghx "not installed (deferred; agents use ghx for repo interaction)"
 
+
+# Decision-memory contract (grilling skill): warn when the env var is unset;
+# when set, a cheap ls-remote surfaces bad URLs / missing credentials now
+# instead of mid-session. No clone here — session-start shallow-clone is the
+# skill's job, per-session and ephemeral by design.
+decision_memory_failed=false
 echo
-echo "Summary: $pass ok, $fail required missing"
+if [[ -z "${DECISION_MEMORY_REPO:-}" ]]; then
+    echo "⚠ DECISION_MEMORY_REPO — unset; grilling skill skips decision recording. Set it in your shell profile (local), the environment config (remote sessions), or a CI secret."
+elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_REPO" >/dev/null 2>&1; then
+    echo "✓ DECISION_MEMORY_REPO (reachable)"
+    pass=$((pass + 1))
+else
+    echo "✗ DECISION_MEMORY_REPO — set but not reachable (bad URL or missing credentials): git ls-remote failed"
+    fail=$((fail + 1))
+    decision_memory_failed=true
+fi
+
+echo
+echo "Summary: $pass ok, $fail failed"
 
 if [[ ${#missing[@]} -eq 0 ]]; then
+    if [[ "$decision_memory_failed" == true ]]; then
+        exit 1
+    fi
     exit 0
 fi
 

--- a/scripts/enable-agent-shims.sh
+++ b/scripts/enable-agent-shims.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook: prepend the agent shims to PATH for this
+# agent session only. `env` in .claude/settings.json cannot express a PATH
+# prepend (values are literal, no $PATH expansion), so we write an export
+# to CLAUDE_ENV_FILE, which every Bash tool call in the session sources.
+# The user's own shell and dotfiles are never touched.
+set -euo pipefail
+
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+    shim_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}/scripts/agent-shims"
+    echo "export PATH=\"${shim_dir}:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+fi

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -32,10 +32,10 @@
       "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
     },
     "grilling": {
-      "source": "mattpocock/skills",
+      "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "skills/productivity/grilling/SKILL.md",
-      "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
+      "skillPath": "derived/grilling/SKILL.md",
+      "computedHash": "82c8da67d4ec62ded3a4b3823b0e4678d93a0acfc22ac41180cb1b4a5f336872"
     },
     "requesting-code-review": {
       "source": "obra/superpowers",

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -85,7 +85,11 @@ Code-specific skills:
 
 ### Repo-Local Skill Overrides
 
-- `grilling`: present each question via the platform's multiple-choice dialog (e.g. `AskUserQuestion` in Claude Code) when the platform supports one; fall back to plain-text questions otherwise.
+- `grilling`: present questions via the platform's native question dialog (e.g. `AskUserQuestion` in Claude Code) when the platform provides one; fall back to plain text otherwise. (The multiple-choice question format itself is part of the skill — this override only covers presentation.)
+
+### Skill Environment Variables
+
+- `DECISION_MEMORY_REPO` — URL of the decision-memory repo the `grilling` skill records decisions to. Recording requires this env var in the agent's execution environment; the skill reads exactly this name (shared contract with the skill — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
 
 ## Git
 

--- a/template/scripts/doctor.sh.jinja
+++ b/template/scripts/doctor.sh.jinja
@@ -136,10 +136,30 @@ warn_tool {{ agentic_tracker_cli }} "not installed (deferred; agents use {{ agen
 {% endif -%}
 {% raw %}
 
+# Decision-memory contract (grilling skill): warn when the env var is unset;
+# when set, a cheap ls-remote surfaces bad URLs / missing credentials now
+# instead of mid-session. No clone here — session-start shallow-clone is the
+# skill's job, per-session and ephemeral by design.
+decision_memory_failed=false
 echo
-echo "Summary: $pass ok, $fail required missing"
+if [[ -z "${DECISION_MEMORY_REPO:-}" ]]; then
+    echo "⚠ DECISION_MEMORY_REPO — unset; grilling skill skips decision recording. Set it in your shell profile (local), the environment config (remote sessions), or a CI secret."
+elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_REPO" >/dev/null 2>&1; then
+    echo "✓ DECISION_MEMORY_REPO (reachable)"
+    pass=$((pass + 1))
+else
+    echo "✗ DECISION_MEMORY_REPO — set but not reachable (bad URL or missing credentials): git ls-remote failed"
+    fail=$((fail + 1))
+    decision_memory_failed=true
+fi
+
+echo
+echo "Summary: $pass ok, $fail failed"
 
 if [[ ${#missing[@]} -eq 0 ]]; then
+    if [[ "$decision_memory_failed" == true ]]; then
+        exit 1
+    fi
     exit 0
 fi
 

--- a/template/skills-lock.json.jinja
+++ b/template/skills-lock.json.jinja
@@ -32,10 +32,10 @@
       "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
     },
     "grilling": {
-      "source": "mattpocock/skills",
+      "source": "frankify-app/skills",
       "sourceType": "github",
-      "skillPath": "skills/productivity/grilling/SKILL.md",
-      "computedHash": "1de9e777a60b184b29412fadacb7bbde8c14bb7037e5c4d9d086c941281d1742"
+      "skillPath": "derived/grilling/SKILL.md",
+      "computedHash": "82c8da67d4ec62ded3a4b3823b0e4678d93a0acfc22ac41180cb1b4a5f336872"
     },
 {%- if agentic_project_kind == 'code' %}
     "requesting-code-review": {

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -411,3 +411,55 @@ def test_forgejo_forge_ships_no_github_workflow(
     dst_path = _render(tmp_path, answers, "updater-forgejo")
 
     assert not (dst_path / ".github").exists()
+
+
+def test_grilling_pinned_to_frankify_derivation(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """`grilling` pins the frankify-app/skills derivation, not upstream."""
+    dst_path = _render(tmp_path, base_answers, "grilling-pin")
+
+    lock = json.loads((dst_path / "skills-lock.json").read_text())
+    grilling = lock["skills"]["grilling"]
+    assert grilling["source"] == "frankify-app/skills"
+    assert grilling["skillPath"] == "derived/grilling/SKILL.md"
+
+
+def test_decision_memory_repo_env_var_contract(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """DECISION_MEMORY_REPO is an env-var-only contract: no copier question,
+    no value in any committed artifact (.copier-answers* included); AGENTS.md
+    documents the contract and doctor.sh checks the env var."""
+    # Even if a consumer passes a URL as copier data, it must render nowhere.
+    stray_url = "https://github.com/acme/decision-memory"
+    answers = {**base_answers, "agentic_decision_memory_repo": stray_url}
+    dst_path = _render(tmp_path, answers, "decision-memory")
+
+    for path in dst_path.rglob("*"):
+        if path.is_file():
+            assert stray_url not in path.read_text(), (
+                f"DECISION_MEMORY_REPO value leaked into {path}"
+            )
+
+    # Not an init-time answer: no question, so nothing recorded on update.
+    _check_file_contents(
+        dst_path / ".copier-answers.agentic.yml",
+        unexpect_strs=["decision_memory"],
+    )
+    _check_file_contents(
+        dst_path / "AGENTS.md",
+        ["DECISION_MEMORY_REPO", "skips recording"],
+    )
+    _check_file_contents(
+        dst_path / "scripts" / "doctor.sh",
+        ["DECISION_MEMORY_REPO", 'git ls-remote "$DECISION_MEMORY_REPO"'],
+    )
+
+
+def test_copier_has_no_decision_memory_question() -> None:
+    """The template must never ask for the decision-memory URL at init time."""
+    copier_yml = (PROJECT_ROOT / "copier.yml").read_text()
+    assert "decision_memory" not in copier_yml


### PR DESCRIPTION
Closes #34

## Changes

Four commits: red-step tests → template-only changes → self-application. All root artifacts come from the template run, not hand edits.

- **Manifest repoint** (`template/skills-lock.json.jinja`): `grilling` now pins `frankify-app/skills` at `derived/grilling/SKILL.md` (merged via frankify-app/skills#12). `computedHash` recomputed via `npx skills` tooling against `main` (installed the skill in a scratch project and took the lock hash it produced — not hand-edited). No upstream sync — pin tracks the derivation repo only.
- **`DECISION_MEMORY_REPO` env-var contract (no copier question)**: the template asks for nothing at init time; the URL lives only in the agent's execution environment. A test renders with a stray URL passed as copier data and asserts it appears in no output file (`.copier-answers*` included), plus a guard test that `copier.yml` never grows a decision-memory question.
- **`template/AGENTS.md.jinja`**: new "Skill Environment Variables" section documents the fixed env var name (shared contract with the skill), skip-recording-and-say-so behavior when unset, and per-environment pointers (shell profile locally, environment config for remote sessions, CI secret). The `grilling` override now only carries the platform-dialog presentation hint (`AskUserQuestion`); MC-format wording dropped since the derived skill bakes it in.
- **`template/scripts/doctor.sh.jinja`**: warns (does not fail) when `DECISION_MEMORY_REPO` is unset, with the same pointers; when set, runs `GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_REPO"` so a bad URL or missing credentials surface at doctor time (✗ + exit 1) instead of mid-session. No clone at init — session-start shallow clone stays the skill's job. All three paths exercised live.
- **Self-application** (final commit): this repo uses itself as its template, so root `AGENTS.md`, `skills-lock.json`, and `scripts/doctor.sh` are taken verbatim from `copier copy --vcs-ref HEAD` with this repo's own answers.

## Obstacles / deviations

- The self-render surfaced drift from earlier template-only commits never reapplied to root: pinned `disambiguate` commands, split/sorted skills tables, agent-shim enforcement wording, and the Project Conventions section. The final commit syncs that along, including `scripts/agent-shims/`, `scripts/enable-agent-shims.sh`, and the `docs/conventions.md` seed the regenerated AGENTS.md references. `.pre-commit-config.yaml` was left untouched — root intentionally customizes it for template (jinja) linting.
- The ticket was revised mid-implementation (secret copier question → env-var-only contract) and frankify-app/skills#12 merged with content changes over the head first hashed; both iterations were folded away during history consolidation.

## DECISION markers

- `DECISION:SCOPE` — self-application limited to template-owned files touched or referenced by this ticket's output; full root sync of intentionally-customized files (e.g. `.pre-commit-config.yaml`) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhjoZfTwYJus2McmQxgwTU