### PR TITLE
feat: ship lint CI workflow (prek + conflict-marker check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Generated projects receive:
 - **Cross-cutting lint hooks** (optional) — when `agentic_precommit` is `prek`, a `.pre-commit-config.yaml` covering commit messages, JSON, Markdown, glossary lint (pinned `disambiguate --lint` as a local hook — no repo-local `core.hooksPath` setup needed; lint roots are configurable via the `agentic_disambiguate_roots` answer so repos never patch the rendered hook), and — for English content only — spelling. No unit tests in prek — tests belong in CI. Language-specific linting stays with whatever template owns the source code.
 - **Shared config** — `.editorconfig`, `.codespellrc` (English content only), `commitlint.config.mjs`, and `scripts/doctor.sh` (host-tool checks).
 - **Scheduled template updates** (GitHub forge only) — `.github/workflows/template-update.yml` runs `copier update` weekly and opens a PR when a newer template release exists. See [Automated template updates](#automated-template-updates).
+- **Lint CI** (GitHub forge only) — `.github/workflows/lint.yml` fails on committed copier conflict markers (always rendered, even with `agentic_precommit` set to `none` — it guards the updater contract) and, when `agentic_precommit` is `prek`, runs all prek hooks over all files. CI evaluates the tree at PR HEAD while prek runs per commit locally, so the workflow complements the local hooks rather than replacing them — intermediate commits (e.g. TDD red-step commits) stay lintable locally without blocking the PR.
 
 All Copier questions use the `agentic_` prefix so this template can layer without colliding with other templates. Answers are stored in `.copier-answers.agentic.yml` (not Copier's default).
 
@@ -95,6 +96,7 @@ This template only writes files it is configured to own. It does not silently ta
 | `docs/glossary/`, `docs/architecture.md` | agentic-template |
 | `.editorconfig`, `.codespellrc`, `commitlint.config.mjs` | agentic-template |
 | `scripts/doctor.sh` | agentic-template |
+| `.github/workflows/template-update.yml`, `.github/workflows/lint.yml` | agentic-template (GitHub forge only) |
 | `.pre-commit-config.yaml` | agentic-template **only** when `agentic_precommit` is `prek`; otherwise not written |
 | Source code, package manifests, language lint hooks | base / layered template |
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -1,0 +1,48 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-{% raw %}${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
+jobs:
+  # Rendered even when agentic_precommit is 'none': the marker check guards
+  # the template-updater contract (committed copier conflict markers must
+  # turn CI red), not the hook configuration.
+  conflict-markers:
+    name: "conflict markers (template updates)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # template-update PRs commit copier's inline conflict markers on
+      # purpose so red CI flags them for human/agent resolution.
+      - name: Check for conflict markers
+        run: |
+          set -euo pipefail
+          if git grep -nE '^(<{7}|={7}$|>{7})' -- ':!.agents/skills'; then
+            echo "::error::Conflict markers found — resolve copier's inline markers on this branch (see the template-update PR body)."
+            exit 1
+          fi
+{%- if agentic_precommit == 'prek' %}
+
+  prek:
+    name: "prek (all hooks, all files)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      # prek bootstraps hook runtimes (node for markdownlint/commitlint,
+      # go for actionlint) itself; uvx provides prek.
+      - name: Run prek hooks
+        run: uvx prek run --all-files --show-diff-on-failure
+{%- endif %}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -38,7 +38,12 @@ COMMON_FILES = frozenset(
 
 # Shipped only on the GitHub forge (the updater authenticates via a GitHub
 # App and drives `gh`; Forgejo repos get no .github directory).
-GITHUB_ONLY_FILES = frozenset({".github/workflows/template-update.yml"})
+GITHUB_ONLY_FILES = frozenset(
+    {
+        ".github/workflows/template-update.yml",
+        ".github/workflows/lint.yml",
+    }
+)
 
 EXPECTED_WITH_PREK = COMMON_FILES | GITHUB_ONLY_FILES | {".pre-commit-config.yaml"}
 EXPECTED_WITHOUT_PREK = COMMON_FILES | GITHUB_ONLY_FILES

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -463,3 +463,42 @@ def test_copier_has_no_decision_memory_question() -> None:
     """The template must never ask for the decision-memory URL at init time."""
     copier_yml = (PROJECT_ROOT / "copier.yml").read_text()
     assert "decision_memory" not in copier_yml
+
+
+def test_github_forge_ships_lint_workflow_with_prek_job(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """GitHub forge + prek: lint workflow with marker check and prek jobs."""
+    dst_path = _render(tmp_path, base_answers, "lint-github-prek")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "lint.yml",
+        [
+            "pull_request",
+            "cancel-in-progress: true",
+            "git grep -nE",
+            "::error::",
+            ":!.agents/skills",
+            "uvx prek run --all-files --show-diff-on-failure",
+            "astral-sh/setup-uv",
+            # GitHub expressions must survive Jinja rendering.
+            "${{ github.ref }}",
+        ],
+    )
+
+
+def test_lint_workflow_without_prek_keeps_marker_check(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """agentic_precommit=none: marker check stays (guards the updater
+    contract), the prek job is omitted."""
+    answers = {**base_answers, "agentic_precommit": "none"}
+    dst_path = _render(tmp_path, answers, "lint-github-none")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "lint.yml",
+        ["git grep -nE", "::error::"],
+        unexpect_strs=["prek"],
+    )


### PR DESCRIPTION
Closes #33.

Template ships CI now, not just local hooks. Update PRs with committed conflict markers turn red instead of sitting green.

## What

- New template-owned `.github/workflows/lint.yml` (GitHub forge only), rendered from `lint.yml.jinja`:
  - **conflict-markers job** — `git grep -nE '^(<{7}|={7}$|>{7})'` over tree, excludes `.agents/skills/`, fails with `::error::` pointing at update-PR body. Renders even with `agentic_precommit == 'none'` — guards the updater contract, not hook config.
  - **prek job** — `uvx prek run --all-files --show-diff-on-failure`, gated on `agentic_precommit == 'prek'`. Checkout + setup-uv only; prek bootstraps hook runtimes itself.
  - Triggers: `pull_request` + push to `main`. Per-ref concurrency, cancel-in-progress. Actions SHA-pinned with version comments (same pins as `template-update.yml`).
- README: feature bullet (incl. CI-at-PR-HEAD vs prek-per-commit note — complements, not replaces), ownership-table row for both workflows.
- Tests: rendered workflow with prek job (GitHub expressions survive Jinja via `{% raw %}`), and `agentic_precommit=none` keeps marker check but drops prek job.

## Verified

- `pytest tests/test_generate_project.py` — 17 passed
- Rendered `lint.yml` passes yamllint (shipped config, `--strict`) and actionlint v1.7.7
- Marker grep sanity-checked in a throwaway repo: exit 1 clean, exit 0 with markers, `.agents/skills/` markers ignored

## Notes

- Consuming repos with a hand-rolled workflow at same path get copier conflict on first update — expected, self-resolving via this workflow's marker check. Called out in commit body for changelog.
- Forgejo stays out of scope per issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sgskf8rCtRHZ2Ly4V7d5rk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sgskf8rCtRHZ2Ly4V7d5rk)_