### PR TITLE
docs: mandate environment-declared tooling in managed environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 **First:** Read `AGENTS.md`. Follow all instructions and skills there.
 
+## Environment Tooling
+
+In managed environments (e.g. Claude Code on the Web), ALWAYS use the
+tooling the environment itself declares (e.g. GitHub MCP tools for
+GitHub operations). Never fall back to `gh`, `ghx`, `curl`, or similar
+CLIs there — the environment actively sabotages them. The environment's
+tool declarations override any command examples elsewhere in this repo,
+including `AGENTS.md`.
+
 ## Pull Requests
 
 Share PR URL in response to user.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -7,10 +7,12 @@ edit it freely.
 ## Template-First Changes (Self-Application)
 
 This repo is the template AND uses itself as a template: root artifacts that
-have a counterpart under `template/` (`AGENTS.md`, `skills-lock.json`,
-`scripts/doctor.sh`, `scripts/agent-shims/`, …) are template *output*, never
-hand-edited. Editing both places duplicates work; editing only the root drifts
-from the template.
+have a counterpart under `template/` (`AGENTS.md`, `CLAUDE.md`,
+`skills-lock.json`, `scripts/doctor.sh`, `scripts/agent-shims/`, …) are
+template *output*, never hand-edited. Editing both places duplicates work;
+editing only the root drifts from the template. When unsure whether a root
+file is templated, check for its counterpart under `template/` (e.g.
+`template/CLAUDE.md.jinja`) before editing.
 
 For any change touching a templated file, always follow this route:
 

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -2,6 +2,15 @@
 
 **First:** Read `AGENTS.md`. Follow all instructions and skills there.
 
+## Environment Tooling
+
+In managed environments (e.g. Claude Code on the Web), ALWAYS use the
+tooling the environment itself declares (e.g. GitHub MCP tools for
+GitHub operations). Never fall back to `gh`, `ghx`, `curl`, or similar
+CLIs there — the environment actively sabotages them. The environment's
+tool declarations override any command examples elsewhere in this repo,
+including `AGENTS.md`.
+
 ## Pull Requests
 
 Share PR URL in response to user.


### PR DESCRIPTION
Closes #39

Adds an **Environment Tooling** section to `CLAUDE.md` stating that in managed environments (e.g. Claude Code on the Web), agents must always use the tooling the environment itself declares (e.g. GitHub MCP tools for GitHub operations) and never fall back to `gh`, `ghx`, `curl`, or similar CLIs, which are actively sabotaged there. The environment's tool declarations explicitly override command examples elsewhere in the repo, including `AGENTS.md`.

Applied template-first per `docs/conventions.md`:
- `docs(template)` commit — edits `template/CLAUDE.md.jinja` only (propagates to stamped projects via `copier update`)
- `chore: reapply template to self` commit — root `CLAUDE.md` adopted verbatim from the rendered template
- `docs` commit — names `CLAUDE.md` explicitly in the template-first convention's example list and adds a check-`template/`-first hint, so the hand-edit prohibition is harder to miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR