### PR TITLE
docs: mandate guillemet placeholder syntax in tracker content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,25 @@ Code-specific skills:
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 
+### Tracker Placeholder Syntax
+
+Tracker APIs and sanitizers silently strip angle-bracket tokens as HTML,
+so `<placeholder>` syntax corrupts issue/PR bodies on programmatic reads
+and edits.
+
+- In ALL content posted to the tracker (issue bodies, PR descriptions,
+  comments), write placeholders with guillemets: `«` and `»` — e.g.
+  `decisions/«id».json`, `«timestamp»-«slug»`. Never `<placeholder>`.
+  (Angle brackets remain fine in files committed to the repo, like this
+  one — the rule covers tracker-posted content only.)
+- If an EXISTING ticket is found using `<...>` placeholders, ask the
+  user whether it should be fixed (converted to `«…»`) — don't rewrite
+  it unprompted.
+- If such placeholders occur in content you are about to post anyway as
+  a normal message (no explicit edit of an existing ticket needed —
+  e.g. a new ticket, comment, or quoted text), fix them to `«…»`
+  proactively and tell the user you did.
+
 ### Agentic Engineering Workflow
 
 Use `ghx` for all repository interaction. `gh` and `tea` are disabled — calling them tells you to use `ghx` instead (enforced via shims in `scripts/agent-shims/`, on PATH in agent sessions only; tracker access through MCP tools is not gated by the shims).

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -99,6 +99,25 @@ Code-specific skills:
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 
+### Tracker Placeholder Syntax
+
+Tracker APIs and sanitizers silently strip angle-bracket tokens as HTML,
+so `<placeholder>` syntax corrupts issue/PR bodies on programmatic reads
+and edits.
+
+- In ALL content posted to the tracker (issue bodies, PR descriptions,
+  comments), write placeholders with guillemets: `«` and `»` — e.g.
+  `decisions/«id».json`, `«timestamp»-«slug»`. Never `<placeholder>`.
+  (Angle brackets remain fine in files committed to the repo, like this
+  one — the rule covers tracker-posted content only.)
+- If an EXISTING ticket is found using `<...>` placeholders, ask the
+  user whether it should be fixed (converted to `«…»`) — don't rewrite
+  it unprompted.
+- If such placeholders occur in content you are about to post anyway as
+  a normal message (no explicit edit of an existing ticket needed —
+  e.g. a new ticket, comment, or quoted text), fix them to `«…»`
+  proactively and tell the user you did.
+
 ### Agentic Engineering Workflow
 
 {% set _other_clis = ['ghx', 'gh', 'tea'] | reject('equalto', agentic_tracker_cli) | list -%}


### PR DESCRIPTION
Closes #40

Adds a **Tracker Placeholder Syntax** section to `AGENTS.md`: placeholders in all tracker-posted content (issue bodies, PR descriptions, comments) use guillemets `«` and `»` — never angle brackets, which tracker APIs/sanitizers silently strip as HTML, corrupting bodies on programmatic reads and edits. The section also sets the repair behavior: ask the user before fixing an existing ticket that uses angle-bracket placeholders; fix proactively (and say so) when the content is being posted anyway as a normal message.

Applied template-first per `docs/conventions.md`:
- `docs(template)` commit — edits `template/AGENTS.md.jinja` only (propagates to stamped projects via `copier update`)
- `chore: reapply template to self` commit — root `AGENTS.md` adopted verbatim from the rendered template (render diffed against root first; only the new section differed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR

---
_Generated by [Claude Code](https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR)_