### PR TITLE
docs: forbid hard-wrapping in tracker-posted content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,24 +91,38 @@ Code-specific skills:
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 
-### Tracker Placeholder Syntax
+### Tracker Content Formatting
 
-Tracker APIs and sanitizers silently strip angle-bracket tokens as HTML,
-so `<placeholder>` syntax corrupts issue/PR bodies on programmatic reads
-and edits.
+Tracker bodies (issue bodies, PR descriptions, comments) do NOT render
+like committed `.md` files: APIs/sanitizers silently strip angle-bracket
+tokens as HTML, and single newlines render as hard line breaks rather
+than collapsing as in standard Markdown. Both silently corrupt
+tracker-posted content. The rules below cover tracker-posted content
+only — files committed to the repo (like this one) keep angle brackets
+and normal hard-wrapping.
 
-- In ALL content posted to the tracker (issue bodies, PR descriptions,
-  comments), write placeholders with guillemets: `«` and `»` — e.g.
-  `decisions/«id».json`, `«timestamp»-«slug»`. Never `<placeholder>`.
-  (Angle brackets remain fine in files committed to the repo, like this
-  one — the rule covers tracker-posted content only.)
-- If an EXISTING ticket is found using `<...>` placeholders, ask the
-  user whether it should be fixed (converted to `«…»`) — don't rewrite
-  it unprompted.
-- If such placeholders occur in content you are about to post anyway as
-  a normal message (no explicit edit of an existing ticket needed —
-  e.g. a new ticket, comment, or quoted text), fix them to `«…»`
-  proactively and tell the user you did.
+Placeholder syntax:
+
+- In ALL tracker-posted content, write placeholders with guillemets:
+  `«` and `»` — e.g. `decisions/«id».json`, `«timestamp»-«slug»`.
+  Never `<placeholder>` — it is stripped on programmatic reads and
+  edits.
+
+Line wrapping:
+
+- Never hard-wrap tracker-posted markdown. Write one paragraph or list
+  item per line and let the renderer wrap; a fixed-column wrap breaks
+  the rendered text at random places, because each single newline
+  becomes a hard break.
+
+Repairing violations (applies to both rules):
+
+- If an EXISTING ticket violates them, ask the user whether it should
+  be fixed — don't rewrite it unprompted.
+- If a violation occurs in content you are about to post anyway as a
+  normal message (no explicit edit of an existing ticket needed — e.g.
+  a new ticket, comment, or quoted text), fix it proactively and tell
+  the user you did.
 
 ### Agentic Engineering Workflow
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -99,24 +99,38 @@ Code-specific skills:
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 
-### Tracker Placeholder Syntax
+### Tracker Content Formatting
 
-Tracker APIs and sanitizers silently strip angle-bracket tokens as HTML,
-so `<placeholder>` syntax corrupts issue/PR bodies on programmatic reads
-and edits.
+Tracker bodies (issue bodies, PR descriptions, comments) do NOT render
+like committed `.md` files: APIs/sanitizers silently strip angle-bracket
+tokens as HTML, and single newlines render as hard line breaks rather
+than collapsing as in standard Markdown. Both silently corrupt
+tracker-posted content. The rules below cover tracker-posted content
+only — files committed to the repo (like this one) keep angle brackets
+and normal hard-wrapping.
 
-- In ALL content posted to the tracker (issue bodies, PR descriptions,
-  comments), write placeholders with guillemets: `«` and `»` — e.g.
-  `decisions/«id».json`, `«timestamp»-«slug»`. Never `<placeholder>`.
-  (Angle brackets remain fine in files committed to the repo, like this
-  one — the rule covers tracker-posted content only.)
-- If an EXISTING ticket is found using `<...>` placeholders, ask the
-  user whether it should be fixed (converted to `«…»`) — don't rewrite
-  it unprompted.
-- If such placeholders occur in content you are about to post anyway as
-  a normal message (no explicit edit of an existing ticket needed —
-  e.g. a new ticket, comment, or quoted text), fix them to `«…»`
-  proactively and tell the user you did.
+Placeholder syntax:
+
+- In ALL tracker-posted content, write placeholders with guillemets:
+  `«` and `»` — e.g. `decisions/«id».json`, `«timestamp»-«slug»`.
+  Never `<placeholder>` — it is stripped on programmatic reads and
+  edits.
+
+Line wrapping:
+
+- Never hard-wrap tracker-posted markdown. Write one paragraph or list
+  item per line and let the renderer wrap; a fixed-column wrap breaks
+  the rendered text at random places, because each single newline
+  becomes a hard break.
+
+Repairing violations (applies to both rules):
+
+- If an EXISTING ticket violates them, ask the user whether it should
+  be fixed — don't rewrite it unprompted.
+- If a violation occurs in content you are about to post anyway as a
+  normal message (no explicit edit of an existing ticket needed — e.g.
+  a new ticket, comment, or quoted text), fix it proactively and tell
+  the user you did.
 
 ### Agentic Engineering Workflow
 


### PR DESCRIPTION
Closes #42

Generalizes the `AGENTS.md` "Tracker Placeholder Syntax" section (from #40/#41) into **Tracker Content Formatting**: tracker bodies render single newlines as hard breaks (unlike committed `.md` files), so fixed-column hard-wrapping breaks the rendered text at random places. The section now carries both rules — guillemet placeholders and no hard-wrapping (one paragraph/list item per line) — with shared repair guidance: ask before fixing an existing ticket in violation, fix proactively (and say so) when the content is being posted anyway.

Applied template-first per `docs/conventions.md`:
- `docs(template)` commit — edits `template/AGENTS.md.jinja` only (propagates to stamped projects via `copier update`)
- `chore: reapply template to self` commit — root `AGENTS.md` adopted verbatim from the rendered template (render diffed against root first; only this section differed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR

---
_Generated by [Claude Code](https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR)_