### PR TITLE
feat: decision recorder (record.py) + guard subtemplate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Code-specific skills:
 
 ### Skill Environment Variables
 
-- `DECISION_MEMORY_REPO` — URL of the decision-memory repo the `grilling` skill records decisions to. Recording requires this env var in the agent's execution environment; the skill reads exactly this name (shared contract with the skill — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
+- `DECISION_MEMORY_URL` — FULL git URL of the decision-memory repo that `tools/record.py` (and the `grilling` skill through it) records decisions to. A full URL rather than an owner/repo slug, so the hosting stays swappable. Recording requires this env var in the agent's execution environment; the tool and the skill read exactly this name (shared contract — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
 
 ## Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ Placeholder syntax:
   `«` and `»` — e.g. `decisions/«id».json`, `«timestamp»-«slug»`.
   Never `<placeholder>` — it is stripped on programmatic reads and
   edits.
+- Guillemets are for tracker-posted content ONLY. In code (source
+  files, comments, error messages, help text) use plain
+  `<angle-bracket>` placeholders — committed files never pass through
+  a tracker sanitizer, and guillemets are alien there.
 
 Line wrapping:
 

--- a/copier.yml
+++ b/copier.yml
@@ -1,18 +1,35 @@
 # questions
+agentic_subtemplate:
+  type: str
+  help: >-
+    Which subtemplate to render: `template` is the full project scaffold;
+    `guard` stamps a decision-memory STORE — the CI guard (validator +
+    guard runner + workflow), the vendored store docs (conventions,
+    extraction prompt, README/AGENTS/CLAUDE), and a seeded preference
+    set. With `guard`, all project-scaffold questions are skipped,
+    keeping the store's answers file minimal.
+  choices:
+    - template
+    - guard
+  default: template
+
 agentic_project_name:
   type: str
   help: "Human-readable project name (agent docs, glossary)."
   placeholder: "My Project"
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_project_description:
   type: str
   help: "Short project description (glossary seed entry)."
   placeholder: "A helpful project."
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_project_slug:
   type: str
   help: "Project slug in kebab-case (repo URL, glossary path). Auto-derived from name; override if needed."
   default: "{{ agentic_project_name | lower | replace(' ', '-') | replace('_', '-') }}"
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_project_kind:
   type: str
@@ -21,16 +38,19 @@ agentic_project_kind:
     - code
     - docs
   default: code
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_language:
   type: str
   help: "Primary content language as an ISO 639-1 code (e.g. en, de). Language-sensitive tooling (codespell) is only rendered for English content."
   default: en
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_disambiguate_version:
   type: str
   help: "Pinned disambiguate version (pre-alpha — breaking changes between releases; hook and docs commands use this pin)."
   default: "0.2.0"
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_disambiguate_roots:
   type: str
@@ -40,6 +60,7 @@ agentic_disambiguate_roots:
     Empty keeps disambiguate's default roots. Kept as answer data so repos
     never patch the template-owned .pre-commit-config.yaml.
   default: ""
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_precommit:
   type: str
@@ -48,6 +69,7 @@ agentic_precommit:
     - prek
     - none
   default: prek
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_tracker_cli:
   type: str
@@ -57,6 +79,7 @@ agentic_tracker_cli:
     - gh
     - tea
   default: ghx
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_forge:
   type: str
@@ -71,7 +94,7 @@ agentic_forge:
     {%- else -%}
     github
     {%- endif %}
-  when: "{{ not detect_forge() }}"
+  when: "{{ agentic_subtemplate == 'template' and not detect_forge() }}"
 
 agentic_forgejo_host:
   type: str
@@ -99,11 +122,12 @@ agentic_repo_owner:
     {%- else -%}
     {{ UNSET }}
     {%- endif %}
-  validator: "{% if not agentic_repo_owner %}Could not detect repo owner — run `gh auth login` or `git config github.user <login>`, or enter manually{% endif %}"
+  validator: "{% if agentic_subtemplate == 'template' and not agentic_repo_owner %}Could not detect repo owner — run `gh auth login` or `git config github.user <login>`, or enter manually{% endif %}"
+  when: "{{ agentic_subtemplate == 'template' }}"
 
 # Copier metadata
 _min_copier_version: "9.11.0"
-_subdirectory: template
+_subdirectory: "{{ agentic_subtemplate }}"
 # Keep the .claude/skills → ../.agents/skills bridge a symlink in generated
 # repos instead of copying (a copy would be empty — skills install post-render).
 _preserve_symlinks: true
@@ -111,17 +135,23 @@ _answers_file: .copier-answers.agentic.yml
 # Seeded once, never overwritten on `copier update` — rich repo-local rules
 # live there so AGENTS.md updates never conflict with hand-written content.
 _skip_if_exists:
-  - docs/conventions.md
+  - "{% if agentic_subtemplate == 'template' %}docs/conventions.md{% endif %}"
+  # The store's preference set is seeded once and owned by the store;
+  # everything else in the guard subtemplate is vendored (overwritten
+  # on copier update).
+  - "{% if agentic_subtemplate == 'guard' %}preferences.md{% endif %}"
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - extensions/agentic.py:AgenticExtension
 
+# Tasks are scaffold-only: the guard subtemplate stamps data-repo files
+# and must not install skills, run doctor, or register hooks there.
 _tasks:
-  - npx skills@latest experimental_install
-  - bash scripts/doctor.sh
+  - "{% if agentic_subtemplate == 'template' %}npx skills@latest experimental_install{% else %}true{% endif %}"
+  - "{% if agentic_subtemplate == 'template' %}bash scripts/doctor.sh{% else %}true{% endif %}"
   # Register prek git hooks so commits actually run them. A config file alone
   # does nothing — `prek install` must write .git/hooks. Guard on a git work
   # tree (copier may render into a plain dir) and on prek being selected.
   - >-
-    {% if agentic_precommit == 'prek' %}git rev-parse --is-inside-work-tree
+    {% if agentic_subtemplate == 'template' and agentic_precommit == 'prek' %}git rev-parse --is-inside-work-tree
     >/dev/null 2>&1 && prek install || true{% else %}true{% endif %}

--- a/guard/.github/guards/decision_validator.py
+++ b/guard/.github/guards/decision_validator.py
@@ -69,7 +69,7 @@ def estimate_tokens(text: str) -> int:
 
 
 def validate_id(record_id: object) -> list[str]:
-    """Check the ID grammar: «YYYYMMDDTHHMMSSZ»-«kebab-slug», slug <= 40."""
+    """Check the ID grammar: <YYYYMMDDTHHMMSSZ>-<kebab-slug>, slug <= 40."""
     if not isinstance(record_id, str):
         return ["id: must be a string"]
     match = ID_RE.match(record_id)

--- a/guard/.github/guards/decision_validator.py
+++ b/guard/.github/guards/decision_validator.py
@@ -181,21 +181,25 @@ def _validate_ruling(
     if outcome not in OUTCOMES:
         errors.append(f"outcome: {outcome!r} not in {sorted(OUTCOMES)}")
     elif (
-        outcome in ("hit", "miss")
+        outcome != "near-tie"
         and prediction_option is not None
         and chosen_slot is not None
     ):
         # Scored outcomes must match the slots. Near-ties are exempt by
-        # design (never scored as misses); 'refined' means the chosen
-        # answer CONTAINS the prediction plus an extension, so the slot
-        # differs without the prediction being wrong.
+        # design (never scored as misses); 'refined' requires a slot
+        # MISMATCH like miss — the chosen answer CONTAINS the
+        # prediction plus an extension, distinguished from miss only by
+        # that containment judgment (same slot would be a plain hit).
         hit = chosen_slot == prediction_option.get("slot")
         if outcome == "hit" and not hit:
             errors.append(
                 "outcome: 'hit' but chosen_slot differs from the prediction slot"
             )
-        if outcome == "miss" and hit:
-            errors.append("outcome: 'miss' but chosen_slot equals the prediction slot")
+        if outcome in ("miss", "refined") and hit:
+            errors.append(
+                f"outcome: {outcome!r} but chosen_slot equals the "
+                "prediction slot (that is a hit)"
+            )
 
     # operative_reason is required when a listed non-prediction option won.
     options = record.get("options")

--- a/guard/.github/guards/decision_validator.py
+++ b/guard/.github/guards/decision_validator.py
@@ -51,6 +51,11 @@ REJECTION_STATUSES = frozenset({"operative", "presumed-false"})
 # reason is only valid when explicitly declared "none" — never a lazy
 # default.
 PRESUMED_REASON_SOURCES = frozenset({"if_clause", "inferred", "none"})
+# Operative reasons are decider-confirmed only — deliberately NO
+# 'inferred' tier (an inferred why-chosen belongs in the chosen
+# option's own reasoning and in the rejections). 'none' declares a
+# silent pick: the decider chose without stating a reason.
+OPERATIVE_REASON_SOURCES = frozenset({"stated", "none"})
 
 MAX_SLUG_LENGTH = 40
 ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
@@ -201,7 +206,27 @@ def _validate_ruling(
                 "prediction slot (that is a hit)"
             )
 
-    # operative_reason is required when a listed non-prediction option won.
+    # operative_reason is required when a listed non-prediction option
+    # won — unless the pick was declared silent.
+    operative_source = record.get("operative_reason_source")
+    if operative_source is not None:
+        if operative_source not in OPERATIVE_REASON_SOURCES:
+            errors.append(
+                f"operative_reason_source: {operative_source!r} not in "
+                f"{sorted(OPERATIVE_REASON_SOURCES)} (operative reasons are "
+                "decider-confirmed only — no inferred tier)"
+            )
+        elif operative_source == "none":
+            if record.get("operative_reason") is not None:
+                errors.append(
+                    "operative_reason: must be null when "
+                    "operative_reason_source is 'none' (silent pick)"
+                )
+        elif not record.get("operative_reason"):
+            errors.append(
+                "operative_reason: must be a non-empty string when "
+                "operative_reason_source is 'stated'"
+            )
     options = record.get("options")
     if isinstance(options, list) and chosen_slot is not None:
         chosen_option = next(
@@ -216,10 +241,12 @@ def _validate_ruling(
             chosen_option is not None
             and chosen_option.get("role") not in PREDICTION_ROLES
             and not record.get("operative_reason")
+            and operative_source != "none"
         ):
             errors.append(
                 "operative_reason: required when a listed non-prediction "
-                "option is chosen"
+                "option is chosen (declare operative_reason_source 'none' "
+                "for a silent pick)"
             )
 
     rejections = record.get("rejections")

--- a/guard/.github/guards/decision_validator.py
+++ b/guard/.github/guards/decision_validator.py
@@ -1,0 +1,337 @@
+"""Single-source validator for decision-memory records.
+
+This file is the one validation authority for the decision-memory
+contract. It lives in the agentic-engineering-template repo (guard
+subtemplate) and is copier-vendored into the decision-memory repo,
+where BOTH consumers import it:
+
+- the CI guard (guards.py, next to this file), and
+- the writer tool (tools/record.py in template-instantiated repos),
+  which imports it from the data-repo clone at runtime.
+
+Stdlib only, no dependencies — the vendored copy must keep working
+even if the template repo disappears (fails soft: guard keeps
+working, only updates stop).
+
+All validators return a list of human-readable error strings (empty =
+valid) and TOLERATE unknown fields: new optional fields need no
+migration.
+"""
+
+from __future__ import annotations
+
+import re
+
+SCHEMA_VERSION = 1
+RECORD_TYPE = "decision"
+
+REQUIRED_FIELDS = (
+    "v",
+    "type",
+    "id",
+    "date",
+    "project",
+    "question",
+    "options",
+    "prediction_stream",
+    "artifact_ref",
+    "chosen_slot",
+    "chosen",
+    "rejections",
+    "outcome",
+)
+
+PREDICTION_ROLES = frozenset({"prediction", "prediction+recommendation"})
+OPTION_ROLES = PREDICTION_ROLES | frozenset({"recommendation", "wildcard"})
+PREDICTION_STREAMS = frozenset({"preference-driven", "cold"})
+OUTCOMES = frozenset({"hit", "miss", "near-tie"})
+REJECTION_STATUSES = frozenset({"operative", "presumed-false"})
+
+MAX_SLUG_LENGTH = 40
+ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Single source for the preferences counter-line grammar
+# ("[confirmed: N, last: YYYY-MM-DD]"): the guard's counter-math check
+# and the writer's pref-confirm bumps both consume this regex.
+COUNTER_RE = re.compile(r"\[confirmed: (\d+), last: (\d{4}-\d{2}-\d{2})\]")
+
+# ~1-2k-token hard budget on preferences.md (ticket §5); estimated at
+# the common ~4 chars/token heuristic — deliberately coarse, the budget
+# is a forcing function, not an accounting system.
+PREFERENCES_TOKEN_BUDGET = 2000
+CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Coarse token estimate for the preferences budget check."""
+    return len(text) // CHARS_PER_TOKEN
+
+
+def validate_id(record_id: object) -> list[str]:
+    """Check the ID grammar: «YYYYMMDDTHHMMSSZ»-«kebab-slug», slug <= 40."""
+    if not isinstance(record_id, str):
+        return ["id: must be a string"]
+    match = ID_RE.match(record_id)
+    if not match:
+        return [
+            f"id: {record_id!r} does not match "
+            "<UTC-timestamp>Z-<kebab-slug> (lowercase kebab-case slug)"
+        ]
+    slug = match.group(2)
+    if len(slug) > MAX_SLUG_LENGTH:
+        return [f"id: slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})"]
+    return []
+
+
+def validate_envelope(record: dict) -> list[str]:
+    """Check the universal envelope: v, type, id."""
+    errors: list[str] = []
+    v = record.get("v")
+    if not isinstance(v, int) or isinstance(v, bool) or v < 1:
+        errors.append("v: must be a positive integer schema version")
+    record_type = record.get("type")
+    if record_type != RECORD_TYPE:
+        errors.append(
+            f"type: must be {RECORD_TYPE!r} in this repo, got {record_type!r}"
+        )
+    errors.extend(validate_id(record.get("id")))
+    return errors
+
+
+def _validate_options(record: dict, errors: list[str]) -> dict | None:
+    """Validate the options block; return the prediction option if unique."""
+    options = record.get("options")
+    if not isinstance(options, list) or not options:
+        errors.append("options: must be a non-empty list")
+        return None
+    prediction_options = []
+    seen_slots: set[int] = set()
+    for i, option in enumerate(options):
+        if not isinstance(option, dict):
+            errors.append(f"options[{i}]: must be an object")
+            continue
+        slot = option.get("slot")
+        if not isinstance(slot, int) or isinstance(slot, bool):
+            errors.append(f"options[{i}].slot: must be an integer")
+        elif slot in seen_slots:
+            errors.append(f"options[{i}].slot: duplicate slot {slot}")
+        else:
+            seen_slots.add(slot)
+        label = option.get("label")
+        if not isinstance(label, str) or not label:
+            errors.append(f"options[{i}].label: must be a non-empty string")
+        role = option.get("role")
+        if role is not None and role not in OPTION_ROLES:
+            errors.append(f"options[{i}].role: {role!r} not in {sorted(OPTION_ROLES)}")
+        if role in PREDICTION_ROLES:
+            prediction_options.append(option)
+    if len(prediction_options) != 1:
+        errors.append(
+            "options: exactly one option must carry a prediction role "
+            f"({len(prediction_options)} found)"
+        )
+        return None
+    return prediction_options[0]
+
+
+def _validate_streams(
+    record: dict, prediction_option: dict | None, errors: list[str]
+) -> None:
+    stream = record.get("prediction_stream")
+    if stream not in PREDICTION_STREAMS:
+        errors.append(
+            f"prediction_stream: {stream!r} not in {sorted(PREDICTION_STREAMS)}"
+        )
+        return
+    if prediction_option is None:
+        return
+    rules_cited = prediction_option.get("rules_cited", [])
+    if not isinstance(rules_cited, list):
+        errors.append("options[].rules_cited: must be a list")
+        return
+    if stream == "preference-driven" and not rules_cited:
+        errors.append(
+            "rules_cited: must be non-empty when prediction_stream is preference-driven"
+        )
+    if stream == "cold" and rules_cited:
+        errors.append(
+            "rules_cited: must be empty when prediction_stream is cold "
+            "(cold means no preference rule predicted this)"
+        )
+
+
+def _validate_ruling(
+    record: dict, prediction_option: dict | None, errors: list[str]
+) -> None:
+    chosen_slot = record.get("chosen_slot")
+    if not isinstance(chosen_slot, int) or isinstance(chosen_slot, bool):
+        errors.append("chosen_slot: must be an integer")
+        chosen_slot = None
+    chosen = record.get("chosen")
+    if not isinstance(chosen, str) or not chosen:
+        errors.append("chosen: must be a non-empty string")
+
+    outcome = record.get("outcome")
+    if outcome not in OUTCOMES:
+        errors.append(f"outcome: {outcome!r} not in {sorted(OUTCOMES)}")
+    elif (
+        outcome != "near-tie"
+        and prediction_option is not None
+        and chosen_slot is not None
+    ):
+        # Scored outcomes must match the slots; near-ties are exempt by
+        # design (never scored as misses).
+        hit = chosen_slot == prediction_option.get("slot")
+        if outcome == "hit" and not hit:
+            errors.append(
+                "outcome: 'hit' but chosen_slot differs from the prediction slot"
+            )
+        if outcome == "miss" and hit:
+            errors.append("outcome: 'miss' but chosen_slot equals the prediction slot")
+
+    # operative_reason is required when a listed non-prediction option won.
+    options = record.get("options")
+    if isinstance(options, list) and chosen_slot is not None:
+        chosen_option = next(
+            (
+                o
+                for o in options
+                if isinstance(o, dict) and o.get("slot") == chosen_slot
+            ),
+            None,
+        )
+        if (
+            chosen_option is not None
+            and chosen_option.get("role") not in PREDICTION_ROLES
+            and not record.get("operative_reason")
+        ):
+            errors.append(
+                "operative_reason: required when a listed non-prediction "
+                "option is chosen"
+            )
+
+    rejections = record.get("rejections")
+    if not isinstance(rejections, list):
+        errors.append("rejections: must be a list")
+    else:
+        for i, rejection in enumerate(rejections):
+            if not isinstance(rejection, dict):
+                errors.append(f"rejections[{i}]: must be an object")
+                continue
+            for key in ("option", "reason"):
+                if not isinstance(rejection.get(key), str) or not rejection[key]:
+                    errors.append(f"rejections[{i}].{key}: must be a non-empty string")
+            status = rejection.get("status")
+            if status not in REJECTION_STATUSES:
+                errors.append(
+                    f"rejections[{i}].status: {status!r} not in "
+                    f"{sorted(REJECTION_STATUSES)}"
+                )
+
+
+def _validate_optional_fields(record: dict, errors: list[str]) -> None:
+    date = record.get("date")
+    if date is not None and (not isinstance(date, str) or not DATE_RE.match(date)):
+        errors.append(f"date: {date!r} is not YYYY-MM-DD")
+
+    project = record.get("project")
+    if project is not None and (not isinstance(project, str) or not project):
+        errors.append("project: must be a non-empty string")
+
+    artifact_ref = record.get("artifact_ref")
+    if artifact_ref is not None and not isinstance(artifact_ref, dict):
+        errors.append("artifact_ref: must be an object or null")
+
+    correction = record.get("correction")
+    if correction is not None and not isinstance(correction, bool):
+        errors.append("correction: must be a boolean")
+
+    closure_of = record.get("closure_of")
+    if closure_of is not None and (
+        not isinstance(closure_of, int)
+        or isinstance(closure_of, bool)
+        or closure_of < 1
+    ):
+        errors.append(f"closure_of: {closure_of!r} must be a positive PR number")
+
+    related = record.get("related")
+    if related is not None:
+        if not isinstance(related, list):
+            errors.append("related: must be a list of record IDs")
+        else:
+            for ref in related:
+                for err in validate_id(ref):
+                    errors.append(f"related: {err}")
+
+    for link_field in ("supersedes", "drill_down_of"):
+        ref = record.get(link_field)
+        if ref is not None:
+            for err in validate_id(ref):
+                errors.append(f"{link_field}: {err}")
+
+
+def validate_record(record: object, filename_stem: str | None = None) -> list[str]:
+    """Validate a single decision record against the full contract.
+
+    Returns a list of error strings; empty means valid. Unknown fields
+    are tolerated. When ``filename_stem`` is given, the record's ``id``
+    must equal it (ID = filename stem, always).
+    """
+    if not isinstance(record, dict):
+        return ["record: must be a JSON object"]
+    errors = validate_envelope(record)
+    for field in REQUIRED_FIELDS:
+        if field not in record:
+            errors.append(f"{field}: required field missing")
+    if filename_stem is not None and record.get("id") != filename_stem:
+        errors.append(
+            f"id: {record.get('id')!r} does not equal the filename stem "
+            f"{filename_stem!r}"
+        )
+    prediction_option = _validate_options(record, errors)
+    _validate_streams(record, prediction_option, errors)
+    _validate_ruling(record, prediction_option, errors)
+    _validate_optional_fields(record, errors)
+    return errors
+
+
+def validate_corpus(records: dict) -> list[str]:
+    """Cross-record checks: no dangling related/supersedes/drill_down_of.
+
+    ``records`` maps record ID -> record dict (normally the whole
+    ``decisions/`` directory).
+    """
+    errors: list[str] = []
+    for record_id, record in sorted(records.items()):
+        if not isinstance(record, dict):
+            continue
+        refs = []
+        related = record.get("related")
+        if isinstance(related, list):
+            refs.extend(("related", ref) for ref in related)
+        for link_field in ("supersedes", "drill_down_of"):
+            ref = record.get(link_field)
+            if ref is not None:
+                refs.append((link_field, ref))
+        for field, ref in refs:
+            if ref not in records:
+                errors.append(
+                    f"{record_id}: {field} points to {ref!r}, "
+                    "which does not exist in decisions/"
+                )
+    return errors
+
+
+def check_preferences_budget(
+    text: str, budget_tokens: int = PREFERENCES_TOKEN_BUDGET
+) -> list[str]:
+    """Enforce the hard token budget on preferences.md."""
+    tokens = estimate_tokens(text)
+    if tokens > budget_tokens:
+        return [
+            f"preferences.md: ~{tokens} tokens exceeds the {budget_tokens} "
+            "budget — promote requires demote (merge or demote another "
+            "rule to make room)"
+        ]
+    return []

--- a/guard/.github/guards/decision_validator.py
+++ b/guard/.github/guards/decision_validator.py
@@ -44,8 +44,13 @@ REQUIRED_FIELDS = (
 PREDICTION_ROLES = frozenset({"prediction", "prediction+recommendation"})
 OPTION_ROLES = PREDICTION_ROLES | frozenset({"recommendation", "wildcard"})
 PREDICTION_STREAMS = frozenset({"preference-driven", "cold"})
-OUTCOMES = frozenset({"hit", "miss", "near-tie"})
+OUTCOMES = frozenset({"hit", "miss", "near-tie", "refined"})
 REJECTION_STATUSES = frozenset({"operative", "presumed-false"})
+# Reason provenance for presumed-false rejections: the model records
+# the most-likely reason and DECLARES where it came from; a null
+# reason is only valid when explicitly declared "none" — never a lazy
+# default.
+PRESUMED_REASON_SOURCES = frozenset({"if_clause", "inferred", "none"})
 
 MAX_SLUG_LENGTH = 40
 ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
@@ -176,12 +181,14 @@ def _validate_ruling(
     if outcome not in OUTCOMES:
         errors.append(f"outcome: {outcome!r} not in {sorted(OUTCOMES)}")
     elif (
-        outcome != "near-tie"
+        outcome in ("hit", "miss")
         and prediction_option is not None
         and chosen_slot is not None
     ):
-        # Scored outcomes must match the slots; near-ties are exempt by
-        # design (never scored as misses).
+        # Scored outcomes must match the slots. Near-ties are exempt by
+        # design (never scored as misses); 'refined' means the chosen
+        # answer CONTAINS the prediction plus an extension, so the slot
+        # differs without the prediction being wrong.
         hit = chosen_slot == prediction_option.get("slot")
         if outcome == "hit" and not hit:
             errors.append(
@@ -219,15 +226,48 @@ def _validate_ruling(
             if not isinstance(rejection, dict):
                 errors.append(f"rejections[{i}]: must be an object")
                 continue
-            for key in ("option", "reason"):
-                if not isinstance(rejection.get(key), str) or not rejection[key]:
-                    errors.append(f"rejections[{i}].{key}: must be a non-empty string")
+            if not isinstance(rejection.get("option"), str) or not rejection["option"]:
+                errors.append(f"rejections[{i}].option: must be a non-empty string")
             status = rejection.get("status")
             if status not in REJECTION_STATUSES:
                 errors.append(
                     f"rejections[{i}].status: {status!r} not in "
                     f"{sorted(REJECTION_STATUSES)}"
                 )
+                continue
+            reason = rejection.get("reason")
+            source = rejection.get("reason_source")
+            if status == "operative":
+                # Operative reasons are decider-stated by definition.
+                if source not in (None, "stated"):
+                    errors.append(
+                        f"rejections[{i}].reason_source: {source!r} — "
+                        "operative rejections are stated by definition"
+                    )
+                if not isinstance(reason, str) or not reason:
+                    errors.append(
+                        f"rejections[{i}].reason: operative rejections "
+                        "require the stated reason, verbatim"
+                    )
+            else:  # presumed-false
+                if source not in PRESUMED_REASON_SOURCES:
+                    errors.append(
+                        f"rejections[{i}].reason_source: {source!r} not in "
+                        f"{sorted(PRESUMED_REASON_SOURCES)} (required for "
+                        "presumed-false rejections)"
+                    )
+                elif source == "none":
+                    if reason is not None:
+                        errors.append(
+                            f"rejections[{i}].reason: must be null when "
+                            "reason_source is 'none'"
+                        )
+                elif not isinstance(reason, str) or not reason:
+                    errors.append(
+                        f"rejections[{i}].reason: must be a non-empty "
+                        f"string when reason_source is {source!r} (declare "
+                        "reason_source 'none' if nothing is inferable)"
+                    )
 
 
 def _validate_optional_fields(record: dict, errors: list[str]) -> None:

--- a/guard/.github/guards/guards.py
+++ b/guard/.github/guards/guards.py
@@ -1,0 +1,207 @@
+"""CI guard for the decision-memory repo.
+
+Copier-vendored from the agentic-engineering-template guard subtemplate
+(single shared source with the writer tool's validation — both import
+decision_validator.py, which lives next to this file). Stdlib only:
+the guard must keep working even if the template repo disappears.
+
+Checks, per PR (run with --base <base-sha> from a full checkout):
+
+1. Append-only: no modify/delete/rename under decisions/**; line
+   removals in preferences.md only from pref-confirm/pref-promote
+   commits, with pref-confirm counter math validated mechanically.
+2. Full-corpus schema check: EVERY decisions/*.json validates (not
+   just added files), so guard updates re-validate the entire corpus.
+3. Dangling-reference check across the corpus.
+4. Token budget on preferences.md.
+5. Commit lint: every PR commit subject uses one of the repo's own
+   types (decision/pref-proposal/pref-promote/pref-confirm/chore).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import decision_validator  # noqa: E402  (path bootstrap above)
+
+# Match-side of the repo's own commit types. Grammar authority:
+# docs/conventions.md (§ Commit types, vendored with this file); the
+# writer composes these subjects in record.py.
+COMMIT_SUBJECT_RES = (
+    re.compile(r"^decision\([a-z0-9][a-z0-9-]*\): .+ — .+$"),
+    re.compile(r"^pref-proposal: .+$"),
+    re.compile(r"^pref-promote: .+$"),
+    re.compile(r"^pref-confirm: .+ \(n=\d+\)$"),
+    re.compile(r"^chore(\([\w-]+\))?: .+$"),
+)
+
+COUNTER_RE = decision_validator.COUNTER_RE
+
+PREF_EDIT_TYPES = ("pref-confirm:", "pref-promote:")
+
+
+def check_commit_subject(subject: str) -> str | None:
+    """Return an error string if the subject matches none of the repo's
+    commit types, else None."""
+    if any(pattern.match(subject) for pattern in COMMIT_SUBJECT_RES):
+        return None
+    return (
+        f"commit subject {subject!r} matches none of the repo's types: "
+        "decision(<project>): <slug> — <chosen> | pref-proposal: | "
+        "pref-promote: | pref-confirm: ... (n=N) | chore:"
+    )
+
+
+def parse_unified_diff(diff_text: str) -> tuple[list[str], list[str]]:
+    """Split a unified diff into (removed_lines, added_lines), without
+    the +/- prefixes and without file headers."""
+    removed: list[str] = []
+    added: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("-"):
+            removed.append(line[1:])
+        elif line.startswith("+"):
+            added.append(line[1:])
+    return removed, added
+
+
+def validate_pref_confirm_change(removed: list[str], added: list[str]) -> list[str]:
+    """Validate the counter math of a pref-confirm commit's
+    preferences.md diff: only paired counter-line updates, rule text
+    unchanged, counter incremented by exactly 1."""
+    errors: list[str] = []
+    if len(removed) != len(added):
+        errors.append(
+            "pref-confirm: must only update counter lines "
+            f"({len(removed)} removed vs {len(added)} added)"
+        )
+        return errors
+    for old, new in zip(removed, added):
+        old_match = COUNTER_RE.search(old)
+        new_match = COUNTER_RE.search(new)
+        if not old_match or not new_match:
+            errors.append(
+                "pref-confirm: changed a line without a "
+                f"[confirmed: N, last: DATE] counter: {old!r} -> {new!r}"
+            )
+            continue
+        if COUNTER_RE.sub("", old) != COUNTER_RE.sub("", new):
+            errors.append(f"pref-confirm: rule text changed: {old!r} -> {new!r}")
+        if int(new_match.group(1)) != int(old_match.group(1)) + 1:
+            errors.append(
+                "pref-confirm: counter must increment by exactly 1: "
+                f"{old_match.group(1)} -> {new_match.group(1)}"
+            )
+    return errors
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+    return result.stdout
+
+
+def check_append_only(base: str) -> list[str]:
+    """No modify/delete/rename ever touches existing decision records."""
+    errors: list[str] = []
+    diff = _git("diff", "--name-status", "--find-renames", f"{base}...HEAD")
+    for line in diff.splitlines():
+        parts = line.split("\t")
+        status = parts[0]
+        paths = parts[1:]
+        if any(p.startswith("decisions/") for p in paths) and not (status == "A"):
+            errors.append(
+                f"append-only: decisions/ change {status} {' '.join(paths)} "
+                "— existing records are never modified, deleted, or renamed"
+            )
+    return errors
+
+
+def check_commits(base: str) -> list[str]:
+    """Commit lint + preferences.md edit discipline, per commit."""
+    errors: list[str] = []
+    shas = _git("rev-list", "--no-merges", "--reverse", f"{base}..HEAD").split()
+    for sha in shas:
+        subject = _git("log", "-1", "--format=%s", sha).strip()
+        subject_error = check_commit_subject(subject)
+        if subject_error:
+            errors.append(f"{sha[:9]}: {subject_error}")
+
+        pref_diff = _git(
+            "show", "--format=", "--unified=0", sha, "--", "preferences.md"
+        )
+        removed, added = parse_unified_diff(pref_diff)
+        if not removed:
+            continue
+        if not subject.startswith(PREF_EDIT_TYPES):
+            errors.append(
+                f"{sha[:9]}: removes lines from preferences.md but is not "
+                "a pref-confirm/pref-promote commit"
+            )
+        elif subject.startswith("pref-confirm:"):
+            errors.extend(
+                f"{sha[:9]}: {e}" for e in validate_pref_confirm_change(removed, added)
+            )
+    return errors
+
+
+def check_corpus() -> list[str]:
+    """Validate the ENTIRE decisions/ corpus + refs + token budget."""
+    errors: list[str] = []
+    records: dict[str, dict] = {}
+    decisions_dir = "decisions"
+    if os.path.isdir(decisions_dir):
+        for name in sorted(os.listdir(decisions_dir)):
+            if name.startswith("."):
+                continue
+            path = os.path.join(decisions_dir, name)
+            if not name.endswith(".json"):
+                errors.append(f"{path}: non-JSON file in decisions/")
+                continue
+            stem = name[: -len(".json")]
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    record = json.load(handle)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"{path}: unreadable or invalid JSON: {exc}")
+                continue
+            errors.extend(
+                f"{path}: {e}"
+                for e in decision_validator.validate_record(record, filename_stem=stem)
+            )
+            if isinstance(record, dict) and isinstance(record.get("id"), str):
+                records[record["id"]] = record
+        errors.extend(decision_validator.validate_corpus(records))
+    if os.path.isfile("preferences.md"):
+        with open("preferences.md", encoding="utf-8") as handle:
+            errors.extend(decision_validator.check_preferences_budget(handle.read()))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        required=True,
+        help="base SHA of the PR (github.event.pull_request.base.sha)",
+    )
+    args = parser.parse_args(argv)
+
+    errors = check_append_only(args.base) + check_commits(args.base) + check_corpus()
+    for error in errors:
+        print(f"GUARD FAIL: {error}")
+    if not errors:
+        print("All guards passed.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/guard/.github/workflows/guards.yml
+++ b/guard/.github/workflows/guards.yml
@@ -1,0 +1,23 @@
+name: Guards
+
+# Copier-vendored from the agentic-engineering-template guard
+# subtemplate. Protects the decision-memory history: append-only
+# records, schema + consistency, preferences.md discipline. Stdlib
+# Python only — no dependencies to install.
+
+on:
+  pull_request:
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # Full history: the guard diffs against the PR base and
+          # inspects every PR commit individually.
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+      - run: python .github/guards/guards.py --base "${{ github.event.pull_request.base.sha }}"

--- a/guard/.gitignore
+++ b/guard/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/guard/AGENTS.md
+++ b/guard/AGENTS.md
@@ -1,0 +1,55 @@
+# Decision-Memory Store — Agent Guidelines
+
+> Copier-vendored from the agentic-engineering-template store
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+Private decision store for one principal (a person or a team):
+records, preferences, and the CI guards protecting them. Data-only — no writer tooling lives here
+(the recorder lives in the agentic-engineering-template repo; its
+`--help` is the authoritative behavior doc, design history in that
+repo's issue #37).
+
+## Golden rules
+
+Compressed summary — [docs/conventions.md](docs/conventions.md) is the
+authoritative contract.
+
+- `decisions/` is append-only: NEVER modify, delete, or rename an
+  existing record. CI rejects it; do not try.
+- Inject `preferences.md` ONLY into agent context — never
+  `decisions/` wholesale.
+- Write records through the recorder (`tools/record.py` in
+  template-instantiated repos). Hand-written records are allowed;
+  they get no help and face the same guards.
+- `preferences.md` may only change via counter-line bumps
+  (`pref-confirm`) or human promotion (`pref-promote`). Promotion is
+  human-only, always.
+- Never write this repo's URL into any public artifact. Consumers
+  reference it via the `DECISION_MEMORY_URL` env var only.
+
+## Git
+
+- Never push to `main`; PRs only.
+- Session branches: `session/<YYYYMMDDTHHMMSSZ>` (created by the
+  recorder's `open`).
+- One PR per session; one commit per record.
+- Commit types are this repo's own and are CI-linted — see
+  [docs/conventions.md](docs/conventions.md) (`decision(...)`,
+  `pref-proposal`, `pref-promote`, `pref-confirm`, `chore`).
+- In managed environments (e.g. Claude Code on the Web), ALWAYS use
+  the tooling the environment itself declares for forge operations
+  (PR creation etc.) — `gh`/`curl` are typically sabotaged there. The
+  recorder's `submit` hands the PR off to you in that case.
+
+## Pointers
+
+- [docs/conventions.md](docs/conventions.md) — the authoritative
+  writing contract: record schema, field conventions, commit types,
+  PR flow.
+- [docs/extraction-prompt.md](docs/extraction-prompt.md) — paste into
+  any chat to extract draft records from a past conversation.
+- `.github/guards/`, the docs, and this file are vendored from the
+  template repo's store subtemplate; update via `copier update`,
+  reviewed here as a normal PR diff. Only `preferences.md` (and the
+  records) are owned by this store.

--- a/guard/CLAUDE.md
+++ b/guard/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Specific Project Instructions
+
+**First:** Read `AGENTS.md`. Follow all instructions there.
+
+## Pull Requests
+
+Share PR URL in response to user.

--- a/guard/README.md
+++ b/guard/README.md
@@ -1,0 +1,85 @@
+# Decision-Memory Store
+
+> Copier-vendored from the agentic-engineering-template store
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+Private decision store: memory of decisions and preference signals
+written by agentic grilling sessions across projects, scoped to one
+principal — a person or a team (one store per principal, so personal
+and team preferences never mix). **Knowledge base, not code:** the only executable content is the CI guard
+protecting the data's integrity.
+
+## Layout
+
+```text
+«store-repo»/
+├── README.md               # this overview, human-facing
+├── CLAUDE.md               # thin Claude Code shim → AGENTS.md
+├── AGENTS.md               # agent entry point: golden rules, git rules
+├── docs/
+│   ├── conventions.md      # authoritative writing conventions — the
+│   │                       # contract any writer must satisfy
+│   └── extraction-prompt.md  # copy-paste prompt: extract draft
+│                           # records from past conversations
+├── preferences.md          # active preference set — the ONLY file
+│                           # injected into agent context
+├── proposals/              # agent-proposed preference rules awaiting
+│                           # human promotion (merge != promotion)
+├── decisions/              # full history, append-only, flat —
+│                           # one immutable JSON file per decision
+└── .github/
+    ├── workflows/guards.yml  # CI guards
+    └── guards/             # copier-vendored guard scripts
+```
+
+(`proposals/` and `decisions/` materialize with their first files.)
+
+## How it works
+
+(Summary — the authoritative contract is
+[docs/conventions.md](docs/conventions.md).)
+
+- **Records:** one immutable JSON file per decision in `decisions/`,
+  append-only. Integrity is CI-enforced rather than permission-based:
+  guards reject any PR that modifies, deletes, or renames existing
+  records.
+- **Preferences:** `preferences.md` is the active preference set — the
+  only file injected into agent sessions, kept under a hard ~2k-token
+  budget. Confirmation counters on each rule are the one sanctioned
+  edit.
+- **Proposals:** agents write candidate rules to `proposals/` (one
+  rule per file); only a human `pref-promote` commit moves content
+  into `preferences.md`.
+- **Write flow:** one PR per session, one commit per record. Merging a
+  PR accepts the records. Closing a PR without merging is itself
+  signal: the next session records why (`closure_of`).
+- **Consumers** reference this repo only through the
+  `DECISION_MEMORY_URL` environment variable (full git URL, never
+  committed anywhere public) and inject `preferences.md` only — never
+  `decisions/` wholesale.
+
+## Writing to this repo
+
+The contract lives in [docs/conventions.md](docs/conventions.md). The
+writer tool (`record.py`) lives with its consumers in the
+agentic-engineering-template repo; its `--help` (the module
+docstring) is the authoritative behavior doc, and design history
+lives in that repo's issue #37. This repo stays ignorant of which
+tools write to it. Hand-written records are allowed — they get no
+help and face the same guards.
+
+To extract decisions from a past conversation (no repo access needed
+there), use
+[docs/extraction-prompt.md](docs/extraction-prompt.md).
+
+## Guards
+
+`.github/guards/` — like this file and everything under `docs/` — is
+copier-vendored from the template repo's store subtemplate; the guard
+uses the same validator the writer tool imports, so writer and CI
+validation cannot drift. Update via `copier update` (the diff is
+reviewed here like any PR — the human gate on guard changes).
+Every guard update re-validates the entire existing corpus. The
+vendored copy keeps this repo self-contained: if the template repo
+disappears, the guard keeps working; only updates stop.

--- a/guard/README.md
+++ b/guard/README.md
@@ -13,7 +13,7 @@ protecting the data's integrity.
 ## Layout
 
 ```text
-«store-repo»/
+<store-repo>/
 ├── README.md               # this overview, human-facing
 ├── CLAUDE.md               # thin Claude Code shim → AGENTS.md
 ├── AGENTS.md               # agent entry point: golden rules, git rules

--- a/guard/docs/conventions.md
+++ b/guard/docs/conventions.md
@@ -69,7 +69,8 @@ Example (a real record):
      "status": "operative", "reason_class": "TBD"},
     {"option": "full-access direct push",
      "reason": "agent could silently rewrite preference history",
-     "status": "presumed-false", "reason_class": "TBD"}
+     "status": "presumed-false", "reason_source": "inferred",
+     "reason_class": "TBD"}
   ],
   "outcome": "miss",
   "drill_down_of": null,
@@ -117,7 +118,10 @@ everywhere — new optional fields need no migration.
   provenance defects).
 - `artifact_ref`: REQUIRED when an artifact exists — repo-relative
   path + commit SHA (content-addressed, survives rewrites) + anchor
-  when possible. Null only if genuinely no artifact.
+  when possible. Null only if genuinely no artifact. Chat-extracted
+  drafts carry null refs by design (never guess SHAs); enrich them in
+  the drafts file at ingestion time, once the commits exist — drafts
+  are plain JSON, no tooling needed.
 - `session`: opaque grouping key, NOT a locator — minted best-effort
   by the writer tool, `null` when unavailable. Never load-bearing.
 
@@ -129,14 +133,29 @@ everywhere — new optional fields need no migration.
   chosen), `correction` ("N, but actually because…" — highest-signal
   event, first-class flag), `rejections`, `outcome`.
 - `rejections[].status`: `operative` (confirmed by the choice,
-  recorded verbatim, no inference) | `presumed-false` (if-clauses of
-  other non-chosen options). Never conflate — only operative reasons
-  feed rule extraction.
+  recorded verbatim, no inference) | `presumed-false` (the likely
+  reason the option lost, recorded as inference). Never conflate —
+  only operative reasons feed rule extraction. Deciders can upgrade a
+  presumed-false reason to operative by stating their own (e.g.
+  "Option N, because XYZ" in the free-text slot).
+- `rejections[].reason_source`: REQUIRED on presumed-false rejections
+  — `if_clause` (the option's own if-clause did not hold), `inferred`
+  (most-likely reason from context, marked as the model's inference),
+  or `none` (nothing stated or inferable — ONLY then is
+  `reason: null` valid; declared, never a lazy default or a filler
+  string). Prefer `if_clause`/`inferred` over `none`. Operative
+  rejections are stated by definition (`reason_source` omitted or
+  `stated`).
 - `reason_class`: free text / `"TBD"` for now; a taxonomy emerges
   after ~20 real entries, not before.
-- `outcome`: `hit` | `miss` | `near-tie` — scored against the
-  prediction slot per stream. Near-ties are never scored as misses
-  and never carry fabricated rejection reasons.
+- `outcome`: `hit` | `miss` | `near-tie` | `refined` — scored
+  against the prediction slot per stream. Near-ties are never scored
+  as misses and never carry fabricated rejection reasons. `refined`
+  = the chosen answer CONTAINS the prediction plus an extension
+  (right but incomplete — the most common free-text answer style);
+  bucketed separately in hit rates, never counted as a miss, and
+  never auto-bumping preference counters (only clean hits confirm
+  rules).
 - `drill_down_of`: ID of the parent record when this record is a
   drill-down follow-up question (drill-downs are themselves
   prediction-scored MC events with their own records); else null.

--- a/guard/docs/conventions.md
+++ b/guard/docs/conventions.md
@@ -1,0 +1,228 @@
+# Decision-Memory Store — Writing Conventions
+
+> Copier-vendored from the agentic-engineering-template store
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+The authoritative contract any writer — tool or hand — must satisfy.
+The CI guards (`.github/guards/`) enforce it mechanically; this file
+is the human-readable authority, `decision_validator.py` the
+machine-readable one. Both live in the template repo's store
+subtemplate and change together there, in the same PR.
+
+## Storage layout
+
+- `decisions/«id».json` — one immutable JSON **file** per decision,
+  flat directory. Append-only: existing files are NEVER modified,
+  deleted, or renamed.
+- ID = filename stem = `«timestamp»-«slug»`, e.g.
+  `20260715T143205Z-agent-access`. The slug is a writer-chosen
+  kebab-case title, ≤40 chars; the timestamp is minted (UTC) by the
+  writer tool. No project prefix — `project` is a record field only;
+  artifact URLs never appear in IDs or filenames.
+
+## Record schema
+
+Records are **replay-ready**: input-side fields are written BEFORE
+the ruling, output-side after, so a replay harness can mask outcomes
+and score predictions. Field order groups the two sides.
+
+Example (a real record):
+
+```json
+{
+  "v": 1,
+  "type": "decision",
+  "id": "20260715T143205Z-agent-access",
+  "date": "2026-07-15",
+  "project": "factory",
+
+  "question": "How do agent environments access the preference repo?",
+  "context": "session-local facts informing the options, written before the ruling",
+  "options": [
+    {"slot": 1, "label": "read-only deploy key, human-approved writes",
+     "role": "prediction+recommendation",
+     "rules_cited": [],
+     "reasoning": "integrity via least privilege"},
+    {"slot": 2, "label": "full-access PAT everywhere",
+     "if_clause": "if write friction matters more than blast radius"},
+    {"slot": 3, "label": "local clone, manual sync",
+     "if_clause": "if offline work dominates"}
+  ],
+  "prediction_stream": "cold",
+  "preference_set": {"commit": "«sha»"},
+  "artifact_ref": {
+    "repo": "skills",
+    "path": "skills/grilling/SKILL.md",
+    "commit": "«sha»",
+    "anchor": "#recording"
+  },
+  "session": "session_01ABC…",
+
+  "chosen_slot": 4,
+  "chosen": "all agents as collaborators, PRs against main",
+  "operative_reason": "write friction defeats seamless recording — reintroduces manual journaling step",
+  "correction": false,
+  "rejections": [
+    {"option": "read-only deploy key",
+     "reason": "write friction defeats seamless recording — reintroduces manual journaling step",
+     "status": "operative", "reason_class": "TBD"},
+    {"option": "full-access direct push",
+     "reason": "agent could silently rewrite preference history",
+     "status": "presumed-false", "reason_class": "TBD"}
+  ],
+  "outcome": "miss",
+  "drill_down_of": null,
+
+  "related": ["20260715T141020Z-repo-hosting"],
+  "supersedes": null,
+  "notes": "Compromise adopted: CI-enforced append-only replaces access control"
+}
+```
+
+Required fields: `v`, `type`, `id`, `date`, `project`, `question`,
+`options`, `prediction_stream`, `artifact_ref`, `chosen_slot`,
+`chosen`, `rejections`, `outcome`. Unknown fields are TOLERATED
+everywhere — new optional fields need no migration.
+
+### Envelope
+
+- `v`: schema version, minted by the writer tool.
+- `type`: always `"decision"` in this repo — routes records in future
+  mixed dojo ledgers. The envelope `{v, id, type}` is the universal
+  write format shared with all future dojo record kinds; this repo is
+  a terminal store (no compaction — per-record PR review is the
+  point). `ts` is deliberately absent: the ID embeds it.
+- `id`: stable, unique, always equal to the filename stem.
+
+### Input side (pre-ruling)
+
+- `question`, `context`, `options` (the MC block verbatim: slot,
+  label, role, if-clause, reasoning, cited preference rules),
+  `prediction_stream`, `preference_set`, `artifact_ref`, `session`.
+- `options[].role`: `prediction` (slot 1 — what the preference set
+  predicts; `rules_cited` names the rules, empty = cold),
+  `recommendation` (slot 2 — the agent's independent best),
+  `prediction+recommendation` when merged, `wildcard` (slot 3).
+  Exactly ONE option carries a prediction role. Recommendations are
+  recorded as made in-session, NEVER back-filled after the choice is
+  known.
+- `prediction_stream`: `preference-driven` | `cold` — the two scoring
+  streams. `rules_cited` non-empty iff preference-driven. Cold misses
+  never count against the preference model (pure judgment
+  calibration, prime seeds for new rules).
+- `preference_set.commit`: SHA of this repo as injected at session
+  start — content-addresses the active preference set, so replay can
+  flag matching-but-uncited rules (false cold claims are detectable
+  provenance defects).
+- `artifact_ref`: REQUIRED when an artifact exists — repo-relative
+  path + commit SHA (content-addressed, survives rewrites) + anchor
+  when possible. Null only if genuinely no artifact.
+- `session`: opaque grouping key, NOT a locator — minted best-effort
+  by the writer tool, `null` when unavailable. Never load-bearing.
+
+### Output side (post-ruling)
+
+- `chosen_slot`, `chosen` (free text when slot 4),
+  `operative_reason` (the confirmed if-clause verbatim, or the stated
+  free-text reason — required when a listed non-prediction option is
+  chosen), `correction` ("N, but actually because…" — highest-signal
+  event, first-class flag), `rejections`, `outcome`.
+- `rejections[].status`: `operative` (confirmed by the choice,
+  recorded verbatim, no inference) | `presumed-false` (if-clauses of
+  other non-chosen options). Never conflate — only operative reasons
+  feed rule extraction.
+- `reason_class`: free text / `"TBD"` for now; a taxonomy emerges
+  after ~20 real entries, not before.
+- `outcome`: `hit` | `miss` | `near-tie` — scored against the
+  prediction slot per stream. Near-ties are never scored as misses
+  and never carry fabricated rejection reasons.
+- `drill_down_of`: ID of the parent record when this record is a
+  drill-down follow-up question (drill-downs are themselves
+  prediction-scored MC events with their own records); else null.
+
+### Links
+
+- `related` (informs/refines) and `supersedes` (replaces —
+  decision-level drift signal). Stable IDs + link fields ARE the
+  graph; no edge-type taxonomy beyond these two. All referenced IDs
+  must exist (CI-checked).
+- `closure_of`: optional — the number of a closed-unmerged PR in THIS
+  repo that the record explains ("why was PR #N rejected"). Doubles
+  as the stateless sweep watermark: the writer's `open` lists all
+  closed-unmerged PRs and prompts records only for those not yet
+  covered by a matching `closure_of` — the records themselves are the
+  state.
+
+## Active preference set (`preferences.md`)
+
+- Hard token budget: ~2k tokens, CI-enforced. Promoting a rule at
+  budget means merging or demoting another ("promote requires
+  demote").
+- Rules are conditional and falsifiable, one bullet each, with a
+  confirmation counter and last-confirmed date:
+  `[confirmed: «N», last: «YYYY-MM-DD»]`.
+- Counter-line updates are the ONE sanctioned edit in this repo,
+  executed mechanically: `submit` auto-generates `pref-confirm`
+  commits from in-session preference-driven hits; CI validates the
+  counter math (increment by exactly 1, rule text unchanged).
+- A rule only ever confirmed by choices its own recommendation caused
+  has zero independent evidence — extraction flags such rules, never
+  strengthens them (provenance is in the records: `rules_cited` +
+  `chosen_slot`).
+- Promotion is separate and human-only: agents write candidate rules
+  to `proposals/«YYYY-MM-DD»-«slug».md` (one rule per file); only a
+  human `pref-promote` commit moves content into `preferences.md`.
+  Merging a proposal file is NOT promotion.
+
+## Commit types
+
+This repo's own conventional-commit types, CI-linted on every PR
+commit:
+
+- `decision(«project»): «slug» — «chosen»`
+- `pref-proposal: «rule»`
+- `pref-promote: «rule»` (human only)
+- `pref-confirm: «rule» (n=«count»)` (counter bump)
+- `chore: ...` (structure, CI, docs)
+
+Examples:
+
+```text
+decision(factory): repo hosting — private GitHub over self-hosted/synced
+decision(factory): agent access — collaborators+PRs over read-only key
+pref-proposal: prefers CI-enforced integrity over access restrictions
+pref-confirm: rejects new infrastructure dependencies (n=4)
+```
+
+## PR flow
+
+- One PR per session (branch `session/«YYYYMMDDTHHMMSSZ»`); ONE
+  commit per record — atomic and dissectable. Partial accept =
+  hand-edit the branch, drop or revert individual commits before
+  merge.
+- Merging a decision-record PR = acceptance of the *record*.
+- Closing a PR without merge is itself signal: the next session's
+  `open` sweep prompts a closure record (`closure_of`), with the
+  `correction` flag where applicable.
+- `supersedes` claims must be surfaced in the PR description for
+  explicit human review.
+- The session-end PR description states prediction hit rates as two
+  streams (preference-driven vs cold — the control group).
+
+## CI guards
+
+`.github/guards/` — copier-vendored from the
+agentic-engineering-template guard subtemplate (single shared source;
+the writer tool imports the same validator from its session clone).
+Stdlib-only, no dependencies; fails soft on factory loss. Checks:
+
+- Append-only on `decisions/**` (no modify/delete/rename, no
+  exceptions); `preferences.md` line removals only from
+  `pref-confirm`/`pref-promote` commits, counter math validated.
+- Schema + consistency on the ENTIRE corpus every run — guard updates
+  can never retroactively invalidate or silently mis-accept records
+  without it showing.
+- Dangling-reference check on `related`/`supersedes`/`drill_down_of`.
+- Token budget on `preferences.md`.
+- Commit lint (the types above).

--- a/guard/docs/conventions.md
+++ b/guard/docs/conventions.md
@@ -119,9 +119,10 @@ everywhere — new optional fields need no migration.
 - `artifact_ref`: REQUIRED when an artifact exists — repo-relative
   path + commit SHA (content-addressed, survives rewrites) + anchor
   when possible. Null only if genuinely no artifact. Chat-extracted
-  drafts carry null refs by design (never guess SHAs); enrich them in
-  the drafts file at ingestion time, once the commits exist — drafts
-  are plain JSON, no tooling needed.
+  drafts carry null refs by design (never guess SHAs); PARTIAL refs
+  are welcome — repo/path/anchor with `commit: null` beats all-null.
+  Enrich them in the drafts file at ingestion time, once the commits
+  exist — drafts are plain JSON, no tooling needed.
 - `session`: opaque grouping key, NOT a locator — minted best-effort
   by the writer tool, `null` when unavailable. Never load-bearing.
 
@@ -132,6 +133,13 @@ everywhere — new optional fields need no migration.
   free-text reason — required when a listed non-prediction option is
   chosen), `correction` ("N, but actually because…" — highest-signal
   event, first-class flag), `rejections`, `outcome`.
+- `operative_reason_source`: `stated` (default — non-empty
+  `operative_reason` required) | `none` (silent pick: the decider
+  chose a listed non-prediction option without stating a reason;
+  `operative_reason` must be null — declared, never lazy).
+  Deliberately NO inferred tier: operative means decider-confirmed;
+  an inferred why-chosen lives in the chosen option's own `reasoning`
+  and in the rejections.
 - `rejections[].status`: `operative` (confirmed by the choice,
   recorded verbatim, no inference) | `presumed-false` (the likely
   reason the option lost, recorded as inference). Never conflate —

--- a/guard/docs/conventions.md
+++ b/guard/docs/conventions.md
@@ -12,10 +12,10 @@ subtemplate and change together there, in the same PR.
 
 ## Storage layout
 
-- `decisions/«id».json` — one immutable JSON **file** per decision,
+- `decisions/<id>.json` — one immutable JSON **file** per decision,
   flat directory. Append-only: existing files are NEVER modified,
   deleted, or renamed.
-- ID = filename stem = `«timestamp»-«slug»`, e.g.
+- ID = filename stem = `<timestamp>-<slug>`, e.g.
   `20260715T143205Z-agent-access`. The slug is a writer-chosen
   kebab-case title, ≤40 chars; the timestamp is minted (UTC) by the
   writer tool. No project prefix — `project` is a record field only;
@@ -50,11 +50,11 @@ Example (a real record):
      "if_clause": "if offline work dominates"}
   ],
   "prediction_stream": "cold",
-  "preference_set": {"commit": "«sha»"},
+  "preference_set": {"commit": "<sha>"},
   "artifact_ref": {
     "repo": "skills",
     "path": "skills/grilling/SKILL.md",
-    "commit": "«sha»",
+    "commit": "<sha>",
     "anchor": "#recording"
   },
   "session": "session_01ABC…",
@@ -161,7 +161,7 @@ everywhere — new optional fields need no migration.
   demote").
 - Rules are conditional and falsifiable, one bullet each, with a
   confirmation counter and last-confirmed date:
-  `[confirmed: «N», last: «YYYY-MM-DD»]`.
+  `[confirmed: <N>, last: <YYYY-MM-DD>]`.
 - Counter-line updates are the ONE sanctioned edit in this repo,
   executed mechanically: `submit` auto-generates `pref-confirm`
   commits from in-session preference-driven hits; CI validates the
@@ -171,7 +171,7 @@ everywhere — new optional fields need no migration.
   strengthens them (provenance is in the records: `rules_cited` +
   `chosen_slot`).
 - Promotion is separate and human-only: agents write candidate rules
-  to `proposals/«YYYY-MM-DD»-«slug».md` (one rule per file); only a
+  to `proposals/<YYYY-MM-DD>-<slug>.md` (one rule per file); only a
   human `pref-promote` commit moves content into `preferences.md`.
   Merging a proposal file is NOT promotion.
 
@@ -180,10 +180,10 @@ everywhere — new optional fields need no migration.
 This repo's own conventional-commit types, CI-linted on every PR
 commit:
 
-- `decision(«project»): «slug» — «chosen»`
-- `pref-proposal: «rule»`
-- `pref-promote: «rule»` (human only)
-- `pref-confirm: «rule» (n=«count»)` (counter bump)
+- `decision(<project>): <slug> — <chosen>`
+- `pref-proposal: <rule>`
+- `pref-promote: <rule>` (human only)
+- `pref-confirm: <rule> (n=<count>)` (counter bump)
 - `chore: ...` (structure, CI, docs)
 
 Examples:
@@ -197,7 +197,7 @@ pref-confirm: rejects new infrastructure dependencies (n=4)
 
 ## PR flow
 
-- One PR per session (branch `session/«YYYYMMDDTHHMMSSZ»`); ONE
+- One PR per session (branch `session/<YYYYMMDDTHHMMSSZ>`); ONE
   commit per record — atomic and dissectable. Partial accept =
   hand-edit the branch, drop or revert individual commits before
   merge.

--- a/guard/docs/extraction-prompt.md
+++ b/guard/docs/extraction-prompt.md
@@ -7,10 +7,13 @@ execution, or repo access are needed there: the output is plain JSON.
 Then ferry the output here: save it as `drafts.json` (or copy the
 fenced block) and, in a session with repo access, ingest it with the
 recorder — `record.py open`, then `record --from drafts.json`, then
-`check`, then `submit`. Validation happens ONLY at ingestion, against
-this repo's vendored validator; malformed drafts fail loudly there,
-where an agent can fix them with you. There is deliberately no
-chat-side validator to drift.
+`check`, then `submit`. Before ingesting, enrich `artifact_ref` in
+the drafts file wherever the referenced commits now exist —
+extraction leaves refs null by design (never guess SHAs), and drafts
+are plain JSON, editable freely until ingestion. Validation happens
+ONLY at ingestion, against this repo's vendored validator; malformed
+drafts fail loudly there, where an agent can fix them with you. There
+is deliberately no chat-side validator to drift.
 
 This prompt mirrors the record schema in
 [conventions.md](conventions.md); both are vendored from the template
@@ -27,9 +30,11 @@ reasons: design decisions, scope calls, convention adoptions, tool
 choices, process rules. Skip trivial or ephemeral choices that would
 not inform future decisions. Then emit one DRAFT RECORD per ruling.
 
-OUTPUT: a single fenced JSON array of draft records and nothing else.
-If you can produce downloadable files, also offer the array as
-drafts.json. Do not validate, do not add commentary inside the fence.
+OUTPUT: one JSON array of draft records and nothing else. Prefer a
+downloadable drafts.json when your environment supports file output
+(large batches are hostile to inline fences); otherwise emit a single
+fenced JSON array. Do not validate, do not add commentary inside the
+output.
 
 DRAFT RECORD FIELDS (a draft is the record schema MINUS tool-minted
 fields — do NOT invent v, type, id, date, or timestamps; the
@@ -64,20 +69,31 @@ ingestion tool mints them):
 - correction: true only when the decider corrected the reasoning ("N,
   but actually because..."), else false.
 - rejections: one entry per rejected option: {"option", "reason",
-  "status", "reason_class": "TBD"}. status "operative" = the decider
-  actually stated this reason (record verbatim, no inference);
-  status "presumed-false" = inferred from an option's own if-clause
-  not holding. NEVER invent reasons.
+  "reason_source", "status", "reason_class": "TBD"}. status
+  "operative" = the decider actually stated this reason (record
+  verbatim, no inference; "reason_source": "stated" or omitted).
+  status "presumed-false" = the most-likely reason the option lost,
+  with its provenance DECLARED in reason_source: "if_clause" (the
+  option's own if-clause did not hold — reuse it as the reason),
+  "inferred" (your best inference from context, marked as such), or
+  "none" (nothing stated or inferable — ONLY then set "reason": null;
+  never a filler string like "none stated", and never "none" as the
+  easy way out when context supports an inference).
 - outcome: "hit" if chosen_slot equals the prediction option's slot,
-  "miss" if not, "near-tie" when the decider declared it too close to
-  score.
+  "refined" if the chosen answer CONTAINS the prediction plus an
+  extension or qualification (right but incomplete — do not score
+  these as misses), "miss" if the prediction was actually wrong,
+  "near-tie" when the decider declared it too close to score.
+- supersedes_slug: when this ruling supersedes ANOTHER DRAFT IN THIS
+  BATCH, name that draft's slug here; the ingestion tool resolves it
+  to the minted ID. Use this — never prose in notes — for in-batch
+  supersession.
 - Optional, only when the conversation supports them: notes,
   closure_of (number of a closed-unmerged PR this ruling explains),
   session (the conversation/session identifier if known). Leave
   related / supersedes / drill_down_of OUT unless you are referencing
-  record IDs that already exist in the repository — cross-references
-  between drafts in this batch go into notes instead (final IDs do
-  not exist yet).
+  record IDs that already exist in the repository (for in-batch
+  references, use supersedes_slug above).
 
 RULES:
 - Input side before output side: report options and reasoning as they

--- a/guard/docs/extraction-prompt.md
+++ b/guard/docs/extraction-prompt.md
@@ -1,0 +1,92 @@
+# Extraction Prompt — Draft Decision Records from a Past Conversation
+
+Copy the fenced prompt below into any chat — the conversation you
+want to mine, or a chat that has it attached. No tools, code
+execution, or repo access are needed there: the output is plain JSON.
+
+Then ferry the output here: save it as `drafts.json` (or copy the
+fenced block) and, in a session with repo access, ingest it with the
+recorder — `record.py open`, then `record --from drafts.json`, then
+`check`, then `submit`. Validation happens ONLY at ingestion, against
+this repo's vendored validator; malformed drafts fail loudly there,
+where an agent can fix them with you. There is deliberately no
+chat-side validator to drift.
+
+This prompt mirrors the record schema in
+[conventions.md](conventions.md); both are vendored from the template
+repo's store subtemplate — change them together there, in the same
+PR.
+
+````text
+You are extracting decision records from THIS conversation, for an
+append-only decision-memory repository.
+
+TASK: Sweep the ENTIRE conversation and identify every durable ruling
+— a question that was resolved by choosing between alternatives, with
+reasons: design decisions, scope calls, convention adoptions, tool
+choices, process rules. Skip trivial or ephemeral choices that would
+not inform future decisions. Then emit one DRAFT RECORD per ruling.
+
+OUTPUT: a single fenced JSON array of draft records and nothing else.
+If you can produce downloadable files, also offer the array as
+drafts.json. Do not validate, do not add commentary inside the fence.
+
+DRAFT RECORD FIELDS (a draft is the record schema MINUS tool-minted
+fields — do NOT invent v, type, id, date, or timestamps; the
+ingestion tool mints them):
+
+- slug: short kebab-case title for the decision, lowercase, <= 40
+  chars, unique within this batch.
+- project: short logical project name the ruling belongs to.
+- question: the question that was decided.
+- context: session-local facts that informed the options, as known
+  BEFORE the ruling.
+- options: the alternatives actually on the table, as discussed —
+  never reconstructed after the fact. Each: {"slot": <int>, "label":
+  <text>} plus, where present in the conversation: "role",
+  "if_clause", "rules_cited", "reasoning". Exactly ONE option must
+  carry a prediction role ("prediction" or
+  "prediction+recommendation"); if the conversation had no explicit
+  prediction, give the option that was recommended at the time the
+  role "prediction+recommendation" with "rules_cited": [].
+- prediction_stream: "preference-driven" if the prediction explicitly
+  cited active preference rules (then rules_cited must name them),
+  else "cold" (then rules_cited must be empty).
+- artifact_ref: {"repo", "path", "commit", "anchor"} of the artifact
+  the decision was about, when one exists and is identifiable from
+  the conversation; otherwise null. Never guess commit SHAs — null is
+  honest.
+- chosen_slot: the slot that won; use a fresh slot number with
+  "chosen" free text when the ruling was none of the listed options.
+- chosen: what was chosen, in the decider's words.
+- operative_reason: the stated reason for the choice, verbatim where
+  possible. Required whenever a listed non-prediction option won.
+- correction: true only when the decider corrected the reasoning ("N,
+  but actually because..."), else false.
+- rejections: one entry per rejected option: {"option", "reason",
+  "status", "reason_class": "TBD"}. status "operative" = the decider
+  actually stated this reason (record verbatim, no inference);
+  status "presumed-false" = inferred from an option's own if-clause
+  not holding. NEVER invent reasons.
+- outcome: "hit" if chosen_slot equals the prediction option's slot,
+  "miss" if not, "near-tie" when the decider declared it too close to
+  score.
+- Optional, only when the conversation supports them: notes,
+  closure_of (number of a closed-unmerged PR this ruling explains),
+  session (the conversation/session identifier if known). Leave
+  related / supersedes / drill_down_of OUT unless you are referencing
+  record IDs that already exist in the repository — cross-references
+  between drafts in this batch go into notes instead (final IDs do
+  not exist yet).
+
+RULES:
+- Input side before output side: report options and reasoning as they
+  stood BEFORE the ruling; never back-fill a recommendation after the
+  choice is known.
+- Verbatim over paraphrase for reasons; paraphrase only to compress,
+  never to improve.
+- When conversation evidence for a field is missing, prefer omitting
+  the optional field or using null over inventing content.
+- One record per ruling; split multi-part rulings into separate
+  records rather than merging them.
+````

--- a/guard/docs/extraction-prompt.md
+++ b/guard/docs/extraction-prompt.md
@@ -59,13 +59,22 @@ ingestion tool mints them):
   else "cold" (then rules_cited must be empty).
 - artifact_ref: {"repo", "path", "commit", "anchor"} of the artifact
   the decision was about, when one exists and is identifiable from
-  the conversation; otherwise null. Never guess commit SHAs — null is
-  honest.
+  the conversation; otherwise null. Never guess commit SHAs — a
+  PARTIAL ref (repo/path/anchor with "commit": null) beats all-null
+  and gets enriched at ingestion.
 - chosen_slot: the slot that won; use a fresh slot number with
   "chosen" free text when the ruling was none of the listed options.
-- chosen: what was chosen, in the decider's words.
+- chosen: what was chosen, in the decider's words or the option
+  label — strip UI decorations such as "(Recommended)"; they are the
+  button caption, not the choice.
 - operative_reason: the stated reason for the choice, verbatim where
-  possible. Required whenever a listed non-prediction option won.
+  possible. Required whenever a listed non-prediction option won —
+  EXCEPT silent picks: when the decider chose without stating any
+  reason, set "operative_reason": null and declare
+  "operative_reason_source": "none". There is deliberately no
+  inferred tier here — operative means decider-confirmed; put your
+  inferred why-chosen in the chosen option's reasoning and in the
+  rejections instead.
 - correction: true only when the decider corrected the reasoning ("N,
   but actually because..."), else false.
 - rejections: one entry per rejected option: {"option", "reason",
@@ -73,8 +82,10 @@ ingestion tool mints them):
   "operative" = the decider actually stated this reason (record
   verbatim, no inference; "reason_source": "stated" or omitted).
   status "presumed-false" = the most-likely reason the option lost,
-  with its provenance DECLARED in reason_source: "if_clause" (the
-  option's own if-clause did not hold — reuse it as the reason),
+  with its provenance DECLARED in reason_source: "if_clause" (ONLY
+  when the option literally carries an if_clause field, which did not
+  hold — reuse it as the reason; text drawn from its reasoning is
+  "inferred"),
   "inferred" (your best inference from context, marked as such), or
   "none" (nothing stated or inferable — ONLY then set "reason": null;
   never a filler string like "none stated", and never "none" as the

--- a/guard/docs/extraction-prompt.md
+++ b/guard/docs/extraction-prompt.md
@@ -95,16 +95,17 @@ ingestion tool mints them):
   extension or qualification (right but incomplete — do not score
   these as misses), "miss" if the prediction was actually wrong,
   "near-tie" when the decider declared it too close to score.
-- supersedes_slug: when this ruling supersedes ANOTHER DRAFT IN THIS
-  BATCH, name that draft's slug here; the ingestion tool resolves it
-  to the minted ID. Use this — never prose in notes — for in-batch
-  supersession.
+- In-batch references — name OTHER DRAFTS IN THIS BATCH by slug;
+  the ingestion tool resolves them to minted IDs. Use these — never
+  prose in notes: supersedes_slug (this ruling replaces that one),
+  drill_down_of_slug (this ruling answers a follow-up question opened
+  by that one), related_slugs (list; informs/refines).
 - Optional, only when the conversation supports them: notes,
   closure_of (number of a closed-unmerged PR this ruling explains),
   session (the conversation/session identifier if known). Leave
   related / supersedes / drill_down_of OUT unless you are referencing
   record IDs that already exist in the repository (for in-batch
-  references, use supersedes_slug above).
+  references, use the slug fields above).
 
 RULES:
 - Input side before output side: report options and reasoning as they

--- a/guard/preferences.md
+++ b/guard/preferences.md
@@ -1,0 +1,9 @@
+# Active Preference Set
+
+The ONLY file injected into agent context. Hard ~2k-token budget,
+CI-enforced. Counter-line updates are the one sanctioned edit; see
+docs/conventions.md.
+
+<!-- Seeded once by the store subtemplate and never overwritten by
+     copier update — this file is owned by the store. Rules enter via
+     proposals/ and human pref-promote commits. -->

--- a/guard/{{ _copier_conf.answers_file }}.jinja
+++ b/guard/{{ _copier_conf.answers_file }}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ _copier_answers|to_nice_yaml -}}

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -128,19 +128,19 @@ done
 warn_tool ghx "not installed (deferred; agents use ghx for repo interaction)"
 
 
-# Decision-memory contract (grilling skill): warn when the env var is unset;
+# Decision-memory contract (tools/record.py + grilling skill): warn when the env var is unset;
 # when set, a cheap ls-remote surfaces bad URLs / missing credentials now
 # instead of mid-session. No clone here — session-start shallow-clone is the
-# skill's job, per-session and ephemeral by design.
+# recorder's job, per-session and ephemeral by design.
 decision_memory_failed=false
 echo
-if [[ -z "${DECISION_MEMORY_REPO:-}" ]]; then
-    echo "⚠ DECISION_MEMORY_REPO — unset; grilling skill skips decision recording. Set it in your shell profile (local), the environment config (remote sessions), or a CI secret."
-elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_REPO" >/dev/null 2>&1; then
-    echo "✓ DECISION_MEMORY_REPO (reachable)"
+if [[ -z "${DECISION_MEMORY_URL:-}" ]]; then
+    echo "⚠ DECISION_MEMORY_URL — unset; grilling skill skips decision recording. Set it (full git URL) in your shell profile (local), the environment config (remote sessions), or a CI secret."
+elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_URL" >/dev/null 2>&1; then
+    echo "✓ DECISION_MEMORY_URL (reachable)"
     pass=$((pass + 1))
 else
-    echo "✗ DECISION_MEMORY_REPO — set but not reachable (bad URL or missing credentials): git ls-remote failed"
+    echo "✗ DECISION_MEMORY_URL — set but not reachable (bad URL or missing credentials): git ls-remote failed"
     fail=$((fail + 1))
     decision_memory_failed=true
 fi

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -89,7 +89,7 @@ Code-specific skills:
 
 ### Skill Environment Variables
 
-- `DECISION_MEMORY_REPO` — URL of the decision-memory repo the `grilling` skill records decisions to. Recording requires this env var in the agent's execution environment; the skill reads exactly this name (shared contract with the skill — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
+- `DECISION_MEMORY_URL` — FULL git URL of the decision-memory repo that `tools/record.py` (and the `grilling` skill through it) records decisions to. A full URL rather than an owner/repo slug, so the hosting stays swappable. Recording requires this env var in the agent's execution environment; the tool and the skill read exactly this name (shared contract — renaming either side breaks recording silently). Never hardcode, commit, or echo the value into artifacts. Unset → grilling still works, skips recording, and says so. Where to set it: local sessions → shell profile / user-level agent settings; remote or cloud sessions → the environment's configuration; CI → a repository secret. `scripts/doctor.sh` warns when it's unset and checks reachability when set.
 
 ## Git
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -115,6 +115,10 @@ Placeholder syntax:
   `«` and `»` — e.g. `decisions/«id».json`, `«timestamp»-«slug»`.
   Never `<placeholder>` — it is stripped on programmatic reads and
   edits.
+- Guillemets are for tracker-posted content ONLY. In code (source
+  files, comments, error messages, help text) use plain
+  `<angle-bracket>` placeholders — committed files never pass through
+  a tracker sanitizer, and guillemets are alien there.
 
 Line wrapping:
 

--- a/template/scripts/doctor.sh.jinja
+++ b/template/scripts/doctor.sh.jinja
@@ -136,19 +136,19 @@ warn_tool {{ agentic_tracker_cli }} "not installed (deferred; agents use {{ agen
 {% endif -%}
 {% raw %}
 
-# Decision-memory contract (grilling skill): warn when the env var is unset;
+# Decision-memory contract (tools/record.py + grilling skill): warn when the env var is unset;
 # when set, a cheap ls-remote surfaces bad URLs / missing credentials now
 # instead of mid-session. No clone here — session-start shallow-clone is the
-# skill's job, per-session and ephemeral by design.
+# recorder's job, per-session and ephemeral by design.
 decision_memory_failed=false
 echo
-if [[ -z "${DECISION_MEMORY_REPO:-}" ]]; then
-    echo "⚠ DECISION_MEMORY_REPO — unset; grilling skill skips decision recording. Set it in your shell profile (local), the environment config (remote sessions), or a CI secret."
-elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_REPO" >/dev/null 2>&1; then
-    echo "✓ DECISION_MEMORY_REPO (reachable)"
+if [[ -z "${DECISION_MEMORY_URL:-}" ]]; then
+    echo "⚠ DECISION_MEMORY_URL — unset; grilling skill skips decision recording. Set it (full git URL) in your shell profile (local), the environment config (remote sessions), or a CI secret."
+elif GIT_TERMINAL_PROMPT=0 git ls-remote "$DECISION_MEMORY_URL" >/dev/null 2>&1; then
+    echo "✓ DECISION_MEMORY_URL (reachable)"
     pass=$((pass + 1))
 else
-    echo "✗ DECISION_MEMORY_REPO — set but not reachable (bad URL or missing credentials): git ls-remote failed"
+    echo "✗ DECISION_MEMORY_URL — set but not reachable (bad URL or missing credentials): git ls-remote failed"
     fail=$((fail + 1))
     decision_memory_failed=true
 fi

--- a/template/tools/record.py
+++ b/template/tools/record.py
@@ -9,9 +9,12 @@ backfilled decision records). The contract this tool must satisfy
 decision-memory repo's docs/conventions.md and CI guards.
 
 Verbs:
-  open     clone the data repo (ephemeral temp dir), capture the
-           preference-set SHA, create the session branch, run the
-           stateless closed-unmerged-PR sweep
+  open     make the store repo available — clone it into an ephemeral
+           temp dir, or reuse an already-attached checkout
+           (--use <path>, matched against DECISION_MEMORY_URL by
+           owner/repo) where cloning is impossible (e.g. managed
+           environments); capture the preference-set SHA, create the
+           session branch, run the stateless closed-unmerged-PR sweep
   record   mint + validate + write one decision record per input
            draft (stdin JSON object/array, or --from drafts.json),
            one commit per record
@@ -161,6 +164,20 @@ GITHUB_URL_RE = re.compile(
 )
 
 
+def repo_url_tail(url: str) -> str:
+    """Normalize a git URL to its trailing owner/repo pair (lowercase).
+
+    Managed environments rewrite remotes through local proxies, so two
+    URLs for the same repo rarely match textually — the owner/repo
+    tail is the stable identity across https/ssh/proxy forms.
+    """
+    path = url.rstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    parts = [p for p in path.replace(":", "/").split("/") if p]
+    return "/".join(parts[-2:]).lower()
+
+
 def fail(message: str) -> "SystemExit":
     return SystemExit(f"record.py: error: {message}")
 
@@ -293,6 +310,25 @@ def covered_closures(records: dict[str, dict]) -> set[int]:
     }
 
 
+def _attach_checkout(path_arg: str, url: str) -> Path:
+    """Validate an already-available checkout of the store repo."""
+    repo_dir = Path(path_arg).resolve()
+    if not (repo_dir / ".git").exists():
+        raise fail(f"--use {repo_dir}: not a git checkout")
+    origin = run_git(repo_dir, "config", "--get", "remote.origin.url").strip()
+    if repo_url_tail(origin) != repo_url_tail(url):
+        raise fail(
+            f"--use {repo_dir}: origin {origin!r} is not the store repo "
+            f"(DECISION_MEMORY_URL points at {repo_url_tail(url)!r})"
+        )
+    if run_git(repo_dir, "status", "--porcelain").strip():
+        raise fail(
+            f"--use {repo_dir}: worktree is dirty — commit or stash "
+            "before opening a recording session in it"
+        )
+    return repo_dir
+
+
 def cmd_open(args: argparse.Namespace) -> int:
     url = os.environ.get("DECISION_MEMORY_URL")
     if not url:
@@ -301,14 +337,23 @@ def cmd_open(args: argparse.Namespace) -> int:
             "your decision-memory repo (never commit it anywhere public)"
         )
     now = dt.datetime.now(dt.timezone.utc)
-    repo_dir = Path(tempfile.mkdtemp(prefix="decision-memory-"))
-    result = subprocess.run(
-        ["git", "clone", "--depth", "1", url, str(repo_dir)],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise fail(f"clone failed:\n{result.stderr}")
+    if args.use:
+        repo_dir = _attach_checkout(args.use, url)
+        print(f"Reusing attached checkout: {repo_dir}")
+    else:
+        repo_dir = Path(tempfile.mkdtemp(prefix="decision-memory-"))
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", url, str(repo_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise fail(
+                f"clone failed:\n{result.stderr}\n"
+                "If the store repo is already available in this session "
+                "(e.g. attached in a managed environment where outbound "
+                "cloning is blocked), re-run: open --use <path-to-checkout>"
+            )
 
     base_commit = run_git(repo_dir, "rev-parse", "HEAD").strip()
     branch = "session/" + now.strftime("%Y%m%dT%H%M%SZ")
@@ -335,7 +380,7 @@ def cmd_open(args: argparse.Namespace) -> int:
     covered = covered_closures(records)
     closed_prs = list_closed_unmerged_prs(url)
 
-    print(f"Cloned into: {repo_dir}")
+    print(f"Store checkout: {repo_dir}")
     print(f"Session branch: {branch}")
     print(f"preference_set.commit for this session: {base_commit}")
     print()
@@ -716,6 +761,12 @@ def main(argv: list[str] | None = None) -> int:
     p_open.add_argument(
         "--session",
         help="opaque session grouping key (default: $CLAUDE_SESSION_ID)",
+    )
+    p_open.add_argument(
+        "--use",
+        help="reuse an already-available checkout of the store repo "
+        "instead of cloning (validated against DECISION_MEMORY_URL by "
+        "owner/repo; worktree must be clean)",
     )
     p_open.set_defaults(func=cmd_open)
 

--- a/template/tools/record.py
+++ b/template/tools/record.py
@@ -17,12 +17,14 @@ Verbs:
            session branch, run the stateless closed-unmerged-PR sweep
   record   mint + validate + write one decision record per input
            draft (stdin JSON object/array, or --from drafts.json),
-           one commit per record
+           one commit per record; batch-local supersedes_slug
+           references resolve to the minted IDs
   check    validate the entire decisions/ corpus + dangling refs +
            preferences.md token budget
-  submit   compute two-stream hit rates, auto-bump pref-confirm
-           counters, push, open the PR (or emit the managed-
-           environment handoff)
+  submit   compute two-stream hit rates (refined and near-tie
+           bucketed separately), auto-bump pref-confirm counters for
+           clean preference-driven hits, push, open the PR (or emit
+           the managed-environment handoff)
   propose  write a preference-rule proposal file with its commit
 
 Configuration: DECISION_MEMORY_URL (full git URL of the data repo;
@@ -150,6 +152,39 @@ def draft_to_record(
 def serialize_record(record: dict) -> str:
     """Serialize a record for its immutable decisions/<id>.json file."""
     return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+def resolve_batch_supersedes(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local ``supersedes_slug`` references to minted IDs.
+
+    Drafts extracted from one conversation cannot know each other's
+    final IDs, so cross-draft supersession names the target by slug;
+    this maps every reference to the ID the batch will mint
+    (order-independent). Raises ValueError on unknown slugs or when a
+    draft carries both ``supersedes`` and ``supersedes_slug``.
+    """
+    minted = {}
+    for d in drafts:
+        slug = d.get("slug")
+        if isinstance(slug, str) and SLUG_RE.match(slug):
+            minted[slug] = mint_id(slug, now)
+    resolved = []
+    for d in drafts:
+        d = dict(d)
+        ref = d.pop("supersedes_slug", None)
+        if ref is not None:
+            if d.get("supersedes"):
+                raise ValueError(
+                    f"draft {d.get('slug')!r}: both supersedes and "
+                    "supersedes_slug given — use one"
+                )
+            if ref not in minted:
+                raise ValueError(
+                    f"supersedes_slug {ref!r} matches no slug in this batch"
+                )
+            d["supersedes"] = minted[ref]
+        resolved.append(d)
+    return resolved
 
 
 # ============================ IO shell =============================
@@ -437,6 +472,10 @@ def cmd_record(args: argparse.Namespace) -> int:
     now = dt.datetime.now(dt.timezone.utc)
 
     drafts = read_drafts(args)
+    try:
+        drafts = resolve_batch_supersedes(drafts, now)
+    except ValueError as exc:
+        raise fail(str(exc))
     records = []
     errors: list[str] = []
     for index, draft in enumerate(drafts):
@@ -555,8 +594,8 @@ def bump_preference_counter(
 
 def session_hit_rates(records: list[dict]) -> dict[str, dict[str, int]]:
     streams: dict[str, dict[str, int]] = {
-        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0},
-        "cold": {"hit": 0, "miss": 0, "near-tie": 0},
+        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0, "refined": 0},
+        "cold": {"hit": 0, "miss": 0, "near-tie": 0, "refined": 0},
     }
     for record in records:
         stream = record.get("prediction_stream")
@@ -582,8 +621,13 @@ def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> st
         counts = streams[stream]
         scored = counts["hit"] + counts["miss"]
         shown = f"{counts['hit']}/{scored} hits" if scored else "no scored"
-        if counts["near-tie"]:
-            shown += f" ({counts['near-tie']} near-tie)"
+        extras = [
+            f"{counts[bucket]} {bucket}"
+            for bucket in ("refined", "near-tie")
+            if counts[bucket]
+        ]
+        if extras:
+            shown += f" ({', '.join(extras)})"
         return shown
 
     lines = [

--- a/template/tools/record.py
+++ b/template/tools/record.py
@@ -17,8 +17,9 @@ Verbs:
            session branch, run the stateless closed-unmerged-PR sweep
   record   mint + validate + write one decision record per input
            draft (stdin JSON object/array, or --from drafts.json),
-           one commit per record; batch-local supersedes_slug
-           references resolve to the minted IDs
+           one commit per record; batch-local slug references
+           (supersedes_slug, drill_down_of_slug, related_slugs)
+           resolve to the minted IDs
   check    validate the entire decisions/ corpus + dangling refs +
            preferences.md token budget
   submit   compute two-stream hit rates (refined and near-tie
@@ -154,35 +155,54 @@ def serialize_record(record: dict) -> str:
     return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
 
 
-def resolve_batch_supersedes(drafts: list, now: dt.datetime) -> list:
-    """Resolve batch-local ``supersedes_slug`` references to minted IDs.
+def resolve_batch_refs(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local slug references to minted IDs.
 
     Drafts extracted from one conversation cannot know each other's
-    final IDs, so cross-draft supersession names the target by slug;
-    this maps every reference to the ID the batch will mint
+    final IDs, so cross-draft links name their target by slug:
+    ``supersedes_slug`` and ``drill_down_of_slug`` (single),
+    ``related_slugs`` (list, appended to any repo-ID ``related``
+    entries). This maps every reference to the ID the batch will mint
     (order-independent). Raises ValueError on unknown slugs or when a
-    draft carries both ``supersedes`` and ``supersedes_slug``.
+    draft carries both a slug reference and its resolved field.
     """
     minted = {}
     for d in drafts:
         slug = d.get("slug")
         if isinstance(slug, str) and SLUG_RE.match(slug):
             minted[slug] = mint_id(slug, now)
+
+    def resolve(draft_slug, ref):
+        if ref not in minted:
+            raise ValueError(
+                f"draft {draft_slug!r}: batch reference {ref!r} matches "
+                "no slug in this batch"
+            )
+        return minted[ref]
+
     resolved = []
     for d in drafts:
         d = dict(d)
-        ref = d.pop("supersedes_slug", None)
-        if ref is not None:
-            if d.get("supersedes"):
+        for slug_field, target in (
+            ("supersedes_slug", "supersedes"),
+            ("drill_down_of_slug", "drill_down_of"),
+        ):
+            ref = d.pop(slug_field, None)
+            if ref is not None:
+                if d.get(target):
+                    raise ValueError(
+                        f"draft {d.get('slug')!r}: both {target} and "
+                        f"{slug_field} given — use one"
+                    )
+                d[target] = resolve(d.get("slug"), ref)
+        refs = d.pop("related_slugs", None)
+        if refs is not None:
+            if not isinstance(refs, list):
                 raise ValueError(
-                    f"draft {d.get('slug')!r}: both supersedes and "
-                    "supersedes_slug given — use one"
+                    f"draft {d.get('slug')!r}: related_slugs must be a list"
                 )
-            if ref not in minted:
-                raise ValueError(
-                    f"supersedes_slug {ref!r} matches no slug in this batch"
-                )
-            d["supersedes"] = minted[ref]
+            existing = d.get("related") or []
+            d["related"] = existing + [resolve(d.get("slug"), r) for r in refs]
         resolved.append(d)
     return resolved
 
@@ -473,7 +493,7 @@ def cmd_record(args: argparse.Namespace) -> int:
 
     drafts = read_drafts(args)
     try:
-        drafts = resolve_batch_supersedes(drafts, now)
+        drafts = resolve_batch_refs(drafts, now)
     except ValueError as exc:
         raise fail(str(exc))
     records = []

--- a/template/tools/record.py
+++ b/template/tools/record.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""Decision recorder — writer-side tooling for a decision-memory repo.
+
+This docstring doubles as the CLI help text and is the AUTHORITATIVE
+description of the recorder's behavior — there is no separate spec
+file (design history: agentic-engineering-template issue #37 and the
+backfilled decision records). The contract this tool must satisfy
+(record schema, commit types, PR flow) lives with the data, in the
+decision-memory repo's docs/conventions.md and CI guards.
+
+Verbs:
+  open     clone the data repo (ephemeral temp dir), capture the
+           preference-set SHA, create the session branch, run the
+           stateless closed-unmerged-PR sweep
+  record   mint + validate + write one decision record per input
+           draft (stdin JSON object/array, or --from drafts.json),
+           one commit per record
+  check    validate the entire decisions/ corpus + dangling refs +
+           preferences.md token budget
+  submit   compute two-stream hit rates, auto-bump pref-confirm
+           counters, push, open the PR (or emit the managed-
+           environment handoff)
+  propose  write a preference-rule proposal file with its commit
+
+Configuration: DECISION_MEMORY_URL (full git URL of the data repo;
+never commit it anywhere public). Verbs after `open` find the clone
+via DECISION_MEMORY_DIR or --dir.
+
+Stdlib only. The file is split into a pure CONTRACT CORE (the dojo
+lift-target) and an IO SHELL; keep the seam strict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ========================== contract core ==========================
+# Pure functions, no IO — the functions a future dojo package lifts
+# verbatim. Validation is deliberately NOT defined here:
+# DECISION: the validator is imported from the data-repo clone's
+# vendored copy (single copier-vendored source shared with CI), so
+# writer-side and CI validation cannot drift.
+
+# Mint-side mirror of the envelope/ID grammar. The vendored
+# decision_validator in the store checkout stays authoritative —
+# minted records are re-validated against it; these constants only
+# make minting fail fast with better messages.
+SCHEMA_VERSION = 1
+RECORD_TYPE = "decision"
+MAX_SLUG_LENGTH = 40
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Replay-ready order: envelope, then input side (pre-ruling), then
+# output side (post-ruling), then links. Unknown fields keep their
+# draft order after these.
+FIELD_ORDER = (
+    "v",
+    "type",
+    "id",
+    "date",
+    "project",
+    "question",
+    "context",
+    "options",
+    "prediction_stream",
+    "preference_set",
+    "artifact_ref",
+    "session",
+    "chosen_slot",
+    "chosen",
+    "operative_reason",
+    "correction",
+    "rejections",
+    "outcome",
+    "drill_down_of",
+    "closure_of",
+    "related",
+    "supersedes",
+    "notes",
+)
+
+
+def mint_id(slug: str, now: dt.datetime) -> str:
+    """Mint a record ID: <UTC timestamp>Z-<slug>."""
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"slug {slug!r} must be lowercase kebab-case ([a-z0-9-])")
+    if len(slug) > MAX_SLUG_LENGTH:
+        raise ValueError(f"slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})")
+    timestamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{slug}"
+
+
+def mint_envelope(slug: str, now: dt.datetime) -> dict:
+    """Mint the universal envelope: v, type, id."""
+    return {
+        "v": SCHEMA_VERSION,
+        "type": RECORD_TYPE,
+        "id": mint_id(slug, now),
+    }
+
+
+def draft_to_record(
+    draft: dict,
+    now: dt.datetime,
+    session: str | None = None,
+    preference_commit: str | None = None,
+) -> dict:
+    """Turn a draft record (schema minus tool-minted fields, plus
+    ``slug``) into a full record.
+
+    Draft-supplied values always win over minted defaults; unknown
+    fields are preserved. Raises ValueError when ``slug`` is missing
+    or malformed.
+    """
+    payload = dict(draft)
+    slug = payload.pop("slug", None)
+    if not isinstance(slug, str) or not slug:
+        raise ValueError("draft is missing the writer-chosen 'slug' field")
+
+    merged = mint_envelope(slug, now)
+    merged["date"] = now.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
+    merged["session"] = payload.pop("session", None) or session
+    preference_set = payload.pop("preference_set", None)
+    if preference_set is None and preference_commit:
+        preference_set = {"commit": preference_commit}
+    if preference_set is not None:
+        merged["preference_set"] = preference_set
+    merged.update(payload)
+
+    record = {key: merged[key] for key in FIELD_ORDER if key in merged}
+    for key, value in merged.items():
+        if key not in record:
+            record[key] = value
+    return record
+
+
+def serialize_record(record: dict) -> str:
+    """Serialize a record for its immutable decisions/<id>.json file."""
+    return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+# ============================ IO shell =============================
+# CLI, clone/branch/commit mechanics, PR calls. The PR call is the one
+# forge-specific piece: a hosting supersession (or a managed
+# environment without gh) swaps/skips this function, never the core.
+
+STATE_FILE = ".recorder-session.json"
+VALIDATOR_RELPATH = Path(".github") / "guards" / "decision_validator.py"
+GITHUB_URL_RE = re.compile(
+    r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+def fail(message: str) -> "SystemExit":
+    return SystemExit(f"record.py: error: {message}")
+
+
+def run_git(repo_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise fail(f"git {' '.join(args)} failed in {repo_dir}:\n{result.stderr}")
+    return result.stdout
+
+
+def resolve_repo_dir(args: argparse.Namespace) -> Path:
+    raw = args.dir or os.environ.get("DECISION_MEMORY_DIR")
+    if not raw:
+        raise fail(
+            "no clone found — run `record.py open` first, then pass --dir "
+            "or export DECISION_MEMORY_DIR as it prints"
+        )
+    repo_dir = Path(raw)
+    if not (repo_dir / ".git").exists():
+        raise fail(f"{repo_dir} is not a git clone")
+    return repo_dir
+
+
+def load_state(repo_dir: Path) -> dict:
+    state_path = repo_dir / STATE_FILE
+    if not state_path.exists():
+        raise fail(
+            f"{state_path} missing — this clone was not created by `record.py open`"
+        )
+    return json.loads(state_path.read_text(encoding="utf-8"))
+
+
+def load_validator(repo_dir: Path):
+    """Import the copier-vendored validator from the data-repo clone."""
+    path = repo_dir / VALIDATOR_RELPATH
+    if not path.exists():
+        raise fail(
+            f"vendored validator missing at {path} — the data repo must "
+            "vendor the guard subtemplate (copier update from the "
+            "agentic-engineering-template guard subtemplate)"
+        )
+    spec = importlib.util.spec_from_file_location("decision_validator", path)
+    if spec is None or spec.loader is None:
+        raise fail(f"cannot import validator from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_corpus(repo_dir: Path) -> dict[str, dict]:
+    records: dict[str, dict] = {}
+    decisions_dir = repo_dir / "decisions"
+    if decisions_dir.is_dir():
+        for path in sorted(decisions_dir.glob("*.json")):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(record, dict) and isinstance(record.get("id"), str):
+                records[record["id"]] = record
+    return records
+
+
+def read_drafts(args: argparse.Namespace) -> list[dict]:
+    if getattr(args, "from_file", None):
+        text = Path(args.from_file).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise fail(f"input is not valid JSON: {exc}")
+    drafts = data if isinstance(data, list) else [data]
+    if not all(isinstance(d, dict) for d in drafts):
+        raise fail("input must be a JSON object or an array of objects")
+    return drafts
+
+
+def github_slug(url: str) -> str | None:
+    match = GITHUB_URL_RE.search(url)
+    return f"{match['owner']}/{match['repo']}" if match else None
+
+
+def list_closed_unmerged_prs(url: str) -> list[int] | None:
+    """Best-effort PR listing via gh. None = unavailable (handoff)."""
+    slug = github_slug(url)
+    if slug is None or shutil.which("gh") is None:
+        return None
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            slug,
+            "--state",
+            "closed",
+            "--json",
+            "number,mergedAt",
+            "--limit",
+            "500",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # DECISION: any gh failure falls through to the handoff path —
+    # managed environments sabotage gh, so failure is an expected mode,
+    # not an error.
+    if result.returncode != 0:
+        return None
+    try:
+        prs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return [
+        pr["number"] for pr in prs if isinstance(pr, dict) and not pr.get("mergedAt")
+    ]
+
+
+def covered_closures(records: dict[str, dict]) -> set[int]:
+    return {
+        record["closure_of"]
+        for record in records.values()
+        if isinstance(record.get("closure_of"), int)
+    }
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    url = os.environ.get("DECISION_MEMORY_URL")
+    if not url:
+        raise fail(
+            "DECISION_MEMORY_URL is unset — export the full git URL of "
+            "your decision-memory repo (never commit it anywhere public)"
+        )
+    now = dt.datetime.now(dt.timezone.utc)
+    repo_dir = Path(tempfile.mkdtemp(prefix="decision-memory-"))
+    result = subprocess.run(
+        ["git", "clone", "--depth", "1", url, str(repo_dir)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise fail(f"clone failed:\n{result.stderr}")
+
+    base_commit = run_git(repo_dir, "rev-parse", "HEAD").strip()
+    branch = "session/" + now.strftime("%Y%m%dT%H%M%SZ")
+    run_git(repo_dir, "checkout", "-b", branch)
+
+    session = args.session or os.environ.get("CLAUDE_SESSION_ID")
+    # DECISION: session state lives inside the ephemeral clone
+    # (untracked file, excluded from git status) — nothing persists
+    # outside the temp dir, keeping sessions stateless across machines.
+    state = {
+        "branch": branch,
+        "base_commit": base_commit,
+        "session": session,
+        "opened_at": now.isoformat(),
+    }
+    (repo_dir / STATE_FILE).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    exclude = repo_dir / ".git" / "info" / "exclude"
+    with open(exclude, "a", encoding="utf-8") as handle:
+        handle.write(f"{STATE_FILE}\n")
+
+    records = load_corpus(repo_dir)
+    covered = covered_closures(records)
+    closed_prs = list_closed_unmerged_prs(url)
+
+    print(f"Cloned into: {repo_dir}")
+    print(f"Session branch: {branch}")
+    print(f"preference_set.commit for this session: {base_commit}")
+    print()
+    if closed_prs is None:
+        print(
+            "Unmerged-PR sweep: could not list closed PRs here (no usable "
+            "gh). Handoff: list this repo's closed-UNMERGED PRs with your "
+            "environment's tooling and record one decision per PR number "
+            f"not in the covered set {sorted(covered)} (set closure_of)."
+        )
+    else:
+        pending = sorted(set(closed_prs) - covered)
+        if pending:
+            print(
+                f"Unmerged-PR sweep: PR(s) {pending} were closed without "
+                "merge and have no closure record yet. Record one decision "
+                "each ('why was PR #N rejected'), with closure_of set and "
+                "the correction flag where applicable."
+            )
+        else:
+            print("Unmerged-PR sweep: all closures covered.")
+    print()
+    print(
+        "Reminder: inject preferences.md (and ONLY preferences.md) into "
+        "the session context now, if not already injected."
+    )
+    print(f"export DECISION_MEMORY_DIR={repo_dir}")
+    return 0
+
+
+def commit_record(repo_dir: Path, record: dict) -> None:
+    record_id = record["id"]
+    path = repo_dir / "decisions" / f"{record_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise fail(f"{path} already exists — records are immutable")
+    path.write_text(serialize_record(record), encoding="utf-8")
+    slug = record_id.split("Z-", 1)[1]
+    chosen = " ".join(str(record.get("chosen", "")).split())
+    if len(chosen) > 100:
+        chosen = chosen[:99] + "…"
+    # Subject grammar authority: the store's docs/conventions.md
+    # (§ Commit types); the vendored guard lints what this composes.
+    subject = f"decision({record['project']}): {slug} — {chosen}"
+    run_git(repo_dir, "add", str(path))
+    run_git(repo_dir, "commit", "-m", subject)
+    print(f"Recorded {record_id} ({subject})")
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    state = load_state(repo_dir)
+    validator = load_validator(repo_dir)
+    now = dt.datetime.now(dt.timezone.utc)
+
+    drafts = read_drafts(args)
+    records = []
+    errors: list[str] = []
+    for index, draft in enumerate(drafts):
+        try:
+            record = draft_to_record(
+                draft,
+                now,
+                session=state.get("session"),
+                preference_commit=state.get("base_commit"),
+            )
+        except ValueError as exc:
+            errors.append(f"draft[{index}]: {exc}")
+            continue
+        for error in validator.validate_record(record, filename_stem=record["id"]):
+            errors.append(f"draft[{index}] ({record['id']}): {error}")
+        records.append(record)
+
+    if errors:
+        for error in errors:
+            print(f"INVALID: {error}", file=sys.stderr)
+        print(
+            f"{len(errors)} validation error(s) — nothing written.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for record in records:
+        commit_record(repo_dir, record)
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    validator = load_validator(repo_dir)
+
+    errors: list[str] = []
+    decisions_dir = repo_dir / "decisions"
+    records: dict[str, dict] = {}
+    if decisions_dir.is_dir():
+        for path in sorted(decisions_dir.iterdir()):
+            if path.name.startswith("."):
+                continue
+            if path.suffix != ".json":
+                errors.append(f"{path.name}: non-JSON file in decisions/")
+                continue
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"{path.name}: invalid JSON: {exc}")
+                continue
+            errors.extend(
+                f"{path.name}: {error}"
+                for error in validator.validate_record(record, filename_stem=path.stem)
+            )
+            if isinstance(record, dict) and isinstance(record.get("id"), str):
+                records[record["id"]] = record
+    errors.extend(validator.validate_corpus(records))
+
+    preferences = repo_dir / "preferences.md"
+    if preferences.exists():
+        errors.extend(
+            validator.check_preferences_budget(preferences.read_text(encoding="utf-8"))
+        )
+
+    for error in errors:
+        print(f"CHECK FAIL: {error}", file=sys.stderr)
+    if not errors:
+        print(f"check: {len(records)} record(s) valid, budget OK.")
+    return 1 if errors else 0
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def bump_preference_counter(
+    preferences_text: str, rule: str, today: str, counter_re: re.Pattern
+) -> tuple[str, int] | None:
+    """Bump the confirmation counter of the bullet matching ``rule``.
+
+    ``counter_re`` is the vendored validator's COUNTER_RE — the single
+    source of the counter-line grammar, shared with the CI guard.
+    Returns (new_text, new_count), or None when no bullet matches.
+    Handles wrapped bullets: an entry runs from its `- ` line to the
+    next bullet/heading/blank line; the counter sits on its last line.
+    """
+    lines = preferences_text.splitlines(keepends=True)
+    entries: list[tuple[int, int]] = []
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("- "):
+            if start is not None:
+                entries.append((start, i))
+            start = i
+        elif start is not None and (not line.strip() or line.startswith("#")):
+            entries.append((start, i))
+            start = None
+    if start is not None:
+        entries.append((start, len(lines)))
+
+    wanted = _normalize(rule)
+    for begin, end in entries:
+        entry_text = _normalize("".join(lines[begin:end]))
+        if wanted not in entry_text:
+            continue
+        for i in range(end - 1, begin - 1, -1):
+            match = counter_re.search(lines[i])
+            if match:
+                count = int(match.group(1)) + 1
+                lines[i] = counter_re.sub(
+                    f"[confirmed: {count}, last: {today}]", lines[i]
+                )
+                return "".join(lines), count
+    return None
+
+
+def session_hit_rates(records: list[dict]) -> dict[str, dict[str, int]]:
+    streams: dict[str, dict[str, int]] = {
+        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0},
+        "cold": {"hit": 0, "miss": 0, "near-tie": 0},
+    }
+    for record in records:
+        stream = record.get("prediction_stream")
+        outcome = record.get("outcome")
+        if stream in streams and outcome in streams[stream]:
+            streams[stream][outcome] += 1
+    return streams
+
+
+def prediction_rules(record: dict) -> list[str]:
+    for option in record.get("options", []):
+        if isinstance(option, dict) and option.get("role") in (
+            "prediction",
+            "prediction+recommendation",
+        ):
+            rules = option.get("rules_cited")
+            return [r for r in rules if isinstance(r, str)] if rules else []
+    return []
+
+
+def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> str:
+    def rate(stream: str) -> str:
+        counts = streams[stream]
+        scored = counts["hit"] + counts["miss"]
+        shown = f"{counts['hit']}/{scored} hits" if scored else "no scored"
+        if counts["near-tie"]:
+            shown += f" ({counts['near-tie']} near-tie)"
+        return shown
+
+    lines = [
+        f"Decision session PR: {len(records)} record(s).",
+        "",
+        "Prediction hit rates (two streams):",
+        f"- preference-driven: {rate('preference-driven')}",
+        f"- cold (control): {rate('cold')}",
+    ]
+    supersedes = [
+        (record["id"], record["supersedes"])
+        for record in records
+        if record.get("supersedes")
+    ]
+    if supersedes:
+        lines += ["", "Supersedes claims — review explicitly:"]
+        lines += [
+            f"- {record_id} supersedes {target}" for record_id, target in supersedes
+        ]
+    closures = [
+        (record["id"], record["closure_of"])
+        for record in records
+        if record.get("closure_of")
+    ]
+    if closures:
+        lines += ["", "Closure records (closed-unmerged PR sweep):"]
+        lines += [
+            f"- {record_id} explains the closure of PR #{number}"
+            for record_id, number in closures
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    state = load_state(repo_dir)
+    validator = load_validator(repo_dir)
+    branch = state["branch"]
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+
+    added = run_git(
+        repo_dir,
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{state['base_commit']}..HEAD",
+        "--",
+        "decisions/",
+    ).split()
+    records = []
+    for name in added:
+        path = repo_dir / name
+        records.append(json.loads(path.read_text(encoding="utf-8")))
+    if not records:
+        raise fail("no records on this session branch — nothing to submit")
+
+    streams = session_hit_rates(records)
+
+    preferences_path = repo_dir / "preferences.md"
+    for record in records:
+        if (
+            record.get("prediction_stream") != "preference-driven"
+            or record.get("outcome") != "hit"
+        ):
+            continue
+        for rule in prediction_rules(record):
+            if not preferences_path.exists():
+                print(f"WARN: no preferences.md — cannot bump {rule!r}")
+                continue
+            bumped = bump_preference_counter(
+                preferences_path.read_text(encoding="utf-8"),
+                rule,
+                today,
+                validator.COUNTER_RE,
+            )
+            if bumped is None:
+                print(
+                    f"WARN: cited rule {rule!r} not found in "
+                    "preferences.md — no counter bumped (proposal?)"
+                )
+                continue
+            new_text, count = bumped
+            preferences_path.write_text(new_text, encoding="utf-8")
+            run_git(repo_dir, "add", "preferences.md")
+            run_git(repo_dir, "commit", "-m", f"pref-confirm: {rule} (n={count})")
+            print(f"pref-confirm: {rule} (n={count})")
+
+    run_git(repo_dir, "push", "-u", "origin", branch)
+    print(f"Pushed {branch}.")
+
+    title = f"decision session {branch.split('/', 1)[1]} — " + (
+        f"{len(records)} record(s)"
+    )
+    body = build_pr_body(records, streams)
+
+    url = os.environ.get("DECISION_MEMORY_URL", "")
+    slug = github_slug(url)
+    if slug and shutil.which("gh"):
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                slug,
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print(result.stdout.strip())
+            return 0
+        print(
+            f"gh pr create failed ({result.stderr.strip()}) — falling back to handoff.",
+            file=sys.stderr,
+        )
+
+    print()
+    print("── PR handoff (managed environment / no usable gh) ──")
+    print("The branch is pushed; open the PR with the tooling your")
+    print("environment declares, using exactly this title and body:")
+    print()
+    print(f"Title: {title}")
+    print("Body:")
+    print(body)
+    return 0
+
+
+def cmd_propose(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    rule = " ".join(args.rule.split())
+    slug = args.slug or re.sub(
+        r"-+", "-", re.sub(r"[^a-z0-9]+", "-", rule.lower())
+    ).strip("-")[:MAX_SLUG_LENGTH].rstrip("-")
+    if not SLUG_RE.match(slug):
+        raise fail(f"cannot derive a kebab-case slug from {rule!r}")
+
+    path = repo_dir / "proposals" / f"{today}-{slug}.md"
+    if path.exists():
+        raise fail(f"{path} already exists")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"# Preference proposal: {slug}\n\n"
+        f"- {rule} [confirmed: 0, last: {today}]\n\n"
+        "Promotion is human-only: a `pref-promote` commit moves the rule "
+        "into preferences.md; merging this file is not promotion.\n",
+        encoding="utf-8",
+    )
+    run_git(repo_dir, "add", str(path))
+    run_git(repo_dir, "commit", "-m", f"pref-proposal: {rule}")
+    print(f"Proposed: {path.name}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="record.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dir",
+        help="path to the session clone (default: $DECISION_MEMORY_DIR)",
+    )
+    sub = parser.add_subparsers(dest="verb", required=True)
+
+    p_open = sub.add_parser("open", help="start a recording session")
+    p_open.add_argument(
+        "--session",
+        help="opaque session grouping key (default: $CLAUDE_SESSION_ID)",
+    )
+    p_open.set_defaults(func=cmd_open)
+
+    p_record = sub.add_parser("record", help="record decision drafts")
+    p_record.add_argument(
+        "--from",
+        dest="from_file",
+        help="JSON file with a draft record or an array of drafts "
+        "(default: read stdin)",
+    )
+    p_record.set_defaults(func=cmd_record)
+
+    p_check = sub.add_parser("check", help="validate the whole corpus")
+    p_check.set_defaults(func=cmd_check)
+
+    p_submit = sub.add_parser("submit", help="push and open the session PR")
+    p_submit.set_defaults(func=cmd_submit)
+
+    p_propose = sub.add_parser("propose", help="propose a preference rule")
+    p_propose.add_argument("--rule", required=True, help="the rule text")
+    p_propose.add_argument("--slug", help="override the derived file slug")
+    p_propose.set_defaults(func=cmd_propose)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ def render_project(tmp_path: Path, base_answers: dict[str, str]):
             defaults=True,
             unsafe=True,
             skip_tasks=True,
+            # Pin HEAD: with release tags present locally, copier would
+            # otherwise render the latest RELEASE instead of this branch
+            # (CI checkouts have no tags and already fall back to HEAD).
+            vcs_ref="HEAD",
         )
         return dst_path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 import copier
 import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    """Import a module from an explicit file path.
+
+    The guard scripts and tools are plain files, not packages; every
+    test module loads them through this single helper.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture

--- a/tests/test_decision_validator.py
+++ b/tests/test_decision_validator.py
@@ -276,3 +276,31 @@ def test_preferences_budget() -> None:
     assert dv.check_preferences_budget("## Rules\n- one short rule\n") == []
     errors = dv.check_preferences_budget("x" * 50_000)
     assert any("promote requires demote" in e for e in errors)
+
+
+def test_silent_pick_requires_declared_operative_reason_source() -> None:
+    # A listed non-prediction option chosen without any stated reason
+    # (silent MC tap): valid only under a declared 'none'.
+    record = valid_record()
+    record["chosen_slot"] = 2
+    record["operative_reason"] = None
+    assert any("operative_reason" in e for e in dv.validate_record(record))
+
+    record["operative_reason_source"] = "none"
+    assert dv.validate_record(record) == []
+
+
+def test_operative_reason_source_none_requires_null_reason() -> None:
+    record = valid_record()
+    record["operative_reason_source"] = "none"
+    assert any("operative_reason" in e for e in dv.validate_record(record))
+
+
+def test_operative_reason_source_vocabulary() -> None:
+    record = valid_record()
+    record["operative_reason_source"] = "inferred"
+    assert any("operative_reason_source" in e for e in dv.validate_record(record))
+
+    record = valid_record()
+    record["operative_reason_source"] = "stated"
+    assert dv.validate_record(record) == []

--- a/tests/test_decision_validator.py
+++ b/tests/test_decision_validator.py
@@ -1,0 +1,218 @@
+"""Fixture tests for the single-source decision-record validator.
+
+The validator is the guard subtemplate's core (vendored into the
+decision-memory repo via copier); every change to it must pass these
+tests in this repo's CI before it can be vendored downstream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+VALIDATOR_PATH = PROJECT_ROOT / "guard" / ".github" / "guards" / "decision_validator.py"
+
+dv = load_module("decision_validator", VALIDATOR_PATH)
+
+
+def valid_record() -> dict:
+    """A schema-complete record (adapted from the ticket's real example)."""
+    return {
+        "v": 1,
+        "type": "decision",
+        "id": "20260715T143205Z-agent-access",
+        "date": "2026-07-15",
+        "project": "factory",
+        "question": "How do agent environments access the preference repo?",
+        "context": "session-local facts informing the options",
+        "options": [
+            {
+                "slot": 1,
+                "label": "read-only deploy key, human-approved writes",
+                "role": "prediction+recommendation",
+                "rules_cited": [],
+                "reasoning": "integrity via least privilege",
+            },
+            {
+                "slot": 2,
+                "label": "full-access PAT everywhere",
+                "if_clause": "if write friction matters more than blast radius",
+            },
+            {
+                "slot": 3,
+                "label": "local clone, manual sync",
+                "if_clause": "if offline work dominates",
+            },
+        ],
+        "prediction_stream": "cold",
+        "preference_set": {"commit": "0000000000000000000000000000000000000000"},
+        "artifact_ref": {
+            "repo": "skills",
+            "path": "skills/grilling/SKILL.md",
+            "commit": "1111111111111111111111111111111111111111",
+            "anchor": "#recording",
+        },
+        "session": "session_01ABC",
+        "chosen_slot": 4,
+        "chosen": "all agents as collaborators, PRs against main",
+        "operative_reason": "write friction defeats seamless recording",
+        "correction": False,
+        "rejections": [
+            {
+                "option": "read-only deploy key",
+                "reason": "write friction defeats seamless recording",
+                "status": "operative",
+                "reason_class": "TBD",
+            },
+            {
+                "option": "full-access direct push",
+                "reason": "agent could silently rewrite preference history",
+                "status": "presumed-false",
+                "reason_class": "TBD",
+            },
+        ],
+        "outcome": "miss",
+        "drill_down_of": None,
+        "related": [],
+        "supersedes": None,
+        "notes": "CI-enforced append-only replaces access control",
+    }
+
+
+def test_valid_record_passes() -> None:
+    assert dv.validate_record(valid_record()) == []
+
+
+def test_filename_stem_must_match_id() -> None:
+    errors = dv.validate_record(valid_record(), filename_stem="20990101T000000Z-other")
+    assert any("filename" in e for e in errors)
+    assert (
+        dv.validate_record(
+            valid_record(), filename_stem="20260715T143205Z-agent-access"
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("field", list(dv.REQUIRED_FIELDS))
+def test_missing_required_field_fails(field: str) -> None:
+    record = valid_record()
+    del record[field]
+    assert any(field in e for e in dv.validate_record(record))
+
+
+def test_unknown_fields_tolerated() -> None:
+    record = valid_record()
+    record["closure_of"] = 2
+    record["some_future_field"] = {"nested": True}
+    assert dv.validate_record(record) == []
+
+
+def test_bad_closure_of_rejected() -> None:
+    record = valid_record()
+    record["closure_of"] = "PR #2"
+    assert any("closure_of" in e for e in dv.validate_record(record))
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "20260715T143205Z-Agent-Access",  # uppercase
+        "20260715T143205Z_agent",  # underscore separator
+        "agent-access",  # missing timestamp
+        "20260715T143205Z-" + "a" * 41,  # slug over 40 chars
+    ],
+)
+def test_bad_id_rejected(bad_id: str) -> None:
+    record = valid_record()
+    record["id"] = bad_id
+    assert any("id" in e for e in dv.validate_record(record))
+
+
+def test_envelope_type_must_be_decision() -> None:
+    record = valid_record()
+    record["type"] = "note"
+    assert any("type" in e for e in dv.validate_record(record))
+
+
+def test_exactly_one_prediction_role_required() -> None:
+    record = valid_record()
+    record["options"][1]["role"] = "prediction"
+    assert any("prediction" in e for e in dv.validate_record(record))
+
+    record = valid_record()
+    record["options"][0]["role"] = "recommendation"
+    assert any("prediction" in e for e in dv.validate_record(record))
+
+
+def test_rules_cited_iff_preference_driven() -> None:
+    # preference-driven with empty rules_cited: fail
+    record = valid_record()
+    record["prediction_stream"] = "preference-driven"
+    assert any("rules_cited" in e for e in dv.validate_record(record))
+
+    # cold with non-empty rules_cited: fail
+    record = valid_record()
+    record["options"][0]["rules_cited"] = ["some rule"]
+    assert any("rules_cited" in e for e in dv.validate_record(record))
+
+    # preference-driven with cited rules: pass
+    record = valid_record()
+    record["prediction_stream"] = "preference-driven"
+    record["options"][0]["rules_cited"] = ["some rule"]
+    assert dv.validate_record(record) == []
+
+
+def test_outcome_consistency_with_chosen_slot() -> None:
+    # chosen_slot != prediction slot, outcome hit: inconsistent
+    record = valid_record()
+    record["outcome"] = "hit"
+    assert any("outcome" in e for e in dv.validate_record(record))
+
+    # chosen_slot == prediction slot, outcome miss: inconsistent
+    record = valid_record()
+    record["chosen_slot"] = 1
+    record["operative_reason"] = None
+    assert any("outcome" in e for e in dv.validate_record(record))
+
+    # near-tie is never scored against the slots
+    record = valid_record()
+    record["outcome"] = "near-tie"
+    assert dv.validate_record(record) == []
+
+
+def test_operative_reason_required_for_listed_non_prediction_choice() -> None:
+    record = valid_record()
+    record["chosen_slot"] = 2
+    record["operative_reason"] = None
+    assert any("operative_reason" in e for e in dv.validate_record(record))
+
+
+def test_rejection_status_vocabulary() -> None:
+    record = valid_record()
+    record["rejections"][0]["status"] = "maybe"
+    assert any("status" in e for e in dv.validate_record(record))
+
+
+def test_corpus_dangling_references() -> None:
+    a = valid_record()
+    b = valid_record()
+    b["id"] = "20260716T090000Z-follow-up"
+    b["related"] = [a["id"]]
+    b["drill_down_of"] = a["id"]
+    corpus = {r["id"]: r for r in (a, b)}
+    assert dv.validate_corpus(corpus) == []
+
+    b["supersedes"] = "20990101T000000Z-missing"
+    errors = dv.validate_corpus(corpus)
+    assert any("supersedes" in e and "missing" in e for e in errors)
+
+
+def test_preferences_budget() -> None:
+    assert dv.check_preferences_budget("## Rules\n- one short rule\n") == []
+    errors = dv.check_preferences_budget("x" * 50_000)
+    assert any("promote requires demote" in e for e in errors)

--- a/tests/test_decision_validator.py
+++ b/tests/test_decision_validator.py
@@ -72,6 +72,7 @@ def valid_record() -> dict:
                 "option": "full-access direct push",
                 "reason": "agent could silently rewrite preference history",
                 "status": "presumed-false",
+                "reason_source": "inferred",
                 "reason_class": "TBD",
             },
         ],
@@ -196,6 +197,57 @@ def test_rejection_status_vocabulary() -> None:
     record = valid_record()
     record["rejections"][0]["status"] = "maybe"
     assert any("status" in e for e in dv.validate_record(record))
+
+
+def test_presumed_false_requires_reason_source() -> None:
+    record = valid_record()
+    del record["rejections"][1]["reason_source"]
+    assert any("reason_source" in e for e in dv.validate_record(record))
+
+
+def test_reason_source_none_requires_null_reason() -> None:
+    # Declared-none with null reason: valid (silent MC pick, nothing
+    # stated or inferable — never a filler string).
+    record = valid_record()
+    record["rejections"][1]["reason_source"] = "none"
+    record["rejections"][1]["reason"] = None
+    assert dv.validate_record(record) == []
+
+    # none + a reason string is contradictory.
+    record = valid_record()
+    record["rejections"][1]["reason_source"] = "none"
+    assert any("reason" in e for e in dv.validate_record(record))
+
+    # Lazy null without the declaration is rejected.
+    record = valid_record()
+    record["rejections"][1]["reason"] = None
+    record["rejections"][1]["reason_source"] = "inferred"
+    assert any("reason" in e for e in dv.validate_record(record))
+
+
+def test_if_clause_reason_source_accepted() -> None:
+    record = valid_record()
+    record["rejections"][1]["reason_source"] = "if_clause"
+    record["rejections"][1]["reason"] = "if write friction matters more"
+    assert dv.validate_record(record) == []
+
+
+def test_operative_rejections_are_stated_by_definition() -> None:
+    record = valid_record()
+    record["rejections"][0]["reason_source"] = "inferred"
+    assert any("operative" in e for e in dv.validate_record(record))
+
+    record = valid_record()
+    record["rejections"][0]["reason_source"] = "stated"
+    assert dv.validate_record(record) == []
+
+
+def test_refined_outcome_exempt_from_slot_consistency() -> None:
+    # chosen differs from the prediction slot but CONTAINS the
+    # prediction plus an extension: refined, not a miss.
+    record = valid_record()
+    record["outcome"] = "refined"
+    assert dv.validate_record(record) == []
 
 
 def test_corpus_dangling_references() -> None:

--- a/tests/test_decision_validator.py
+++ b/tests/test_decision_validator.py
@@ -242,12 +242,20 @@ def test_operative_rejections_are_stated_by_definition() -> None:
     assert dv.validate_record(record) == []
 
 
-def test_refined_outcome_exempt_from_slot_consistency() -> None:
+def test_refined_outcome_requires_slot_mismatch() -> None:
     # chosen differs from the prediction slot but CONTAINS the
     # prediction plus an extension: refined, not a miss.
     record = valid_record()
     record["outcome"] = "refined"
     assert dv.validate_record(record) == []
+
+    # refined with chosen_slot == prediction slot is really a hit —
+    # same slot rule as miss, distinguished only by containment.
+    record = valid_record()
+    record["chosen_slot"] = 1
+    record["operative_reason"] = None
+    record["outcome"] = "refined"
+    assert any("refined" in e for e in dv.validate_record(record))
 
 
 def test_corpus_dangling_references() -> None:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -33,6 +33,7 @@ COMMON_FILES = frozenset(
         "scripts/doctor.sh",
         "scripts/enable-agent-shims.sh",
         "skills-lock.json",
+        "tools/record.py",
     }
 )
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -199,6 +199,7 @@ def test_e2e_prek_install_registers_git_hooks(
         data=base_answers,
         defaults=True,
         unsafe=True,
+        vcs_ref="HEAD",
     )
 
     hook = dst_path / ".git" / "hooks" / "pre-commit"
@@ -226,6 +227,7 @@ def test_e2e_smoke_full_render_runs_tasks(
         data=base_answers,
         defaults=True,
         unsafe=True,
+        vcs_ref="HEAD",
     )
 
     # Post-render tasks add files (e.g. .agents/skills/), so the tree is a

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -435,22 +435,22 @@ def test_grilling_pinned_to_frankify_derivation(
     assert grilling["skillPath"] == "derived/grilling/SKILL.md"
 
 
-def test_decision_memory_repo_env_var_contract(
+def test_decision_memory_url_env_var_contract(
     tmp_path: Path,
     base_answers: dict[str, str],
 ) -> None:
-    """DECISION_MEMORY_REPO is an env-var-only contract: no copier question,
+    """DECISION_MEMORY_URL is an env-var-only contract: no copier question,
     no value in any committed artifact (.copier-answers* included); AGENTS.md
     documents the contract and doctor.sh checks the env var."""
     # Even if a consumer passes a URL as copier data, it must render nowhere.
     stray_url = "https://github.com/acme/decision-memory"
-    answers = {**base_answers, "agentic_decision_memory_repo": stray_url}
+    answers = {**base_answers, "agentic_decision_memory_url": stray_url}
     dst_path = _render(tmp_path, answers, "decision-memory")
 
     for path in dst_path.rglob("*"):
         if path.is_file():
             assert stray_url not in path.read_text(), (
-                f"DECISION_MEMORY_REPO value leaked into {path}"
+                f"DECISION_MEMORY_URL value leaked into {path}"
             )
 
     # Not an init-time answer: no question, so nothing recorded on update.
@@ -460,11 +460,16 @@ def test_decision_memory_repo_env_var_contract(
     )
     _check_file_contents(
         dst_path / "AGENTS.md",
-        ["DECISION_MEMORY_REPO", "skips recording"],
+        ["DECISION_MEMORY_URL", "skips recording"],
     )
     _check_file_contents(
         dst_path / "scripts" / "doctor.sh",
-        ["DECISION_MEMORY_REPO", 'git ls-remote "$DECISION_MEMORY_REPO"'],
+        ["DECISION_MEMORY_URL", 'git ls-remote "$DECISION_MEMORY_URL"'],
+    )
+    _check_file_contents(
+        dst_path / "tools" / "record.py",
+        ["DECISION_MEMORY_URL"],
+        unexpect_strs=["DECISION_MEMORY_REPO"],
     )
 
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -40,6 +40,10 @@ def test_slug_auto_derived(
         defaults=True,
         unsafe=True,
         skip_tasks=True,
+        # Pin HEAD: with release tags present locally, copier would
+        # otherwise render the latest RELEASE instead of this branch
+        # (CI checkouts have no tags and already fall back to HEAD).
+        vcs_ref="HEAD",
     )
 
     assert (dst_path / "docs" / "glossary" / "my-cool-app.md").exists()
@@ -62,6 +66,10 @@ def _render(tmp_path: Path, answers: dict[str, str], dst_name: str) -> Path:
         defaults=True,
         unsafe=True,
         skip_tasks=True,
+        # Pin HEAD: with release tags present locally, copier would
+        # otherwise render the latest RELEASE instead of this branch
+        # (CI checkouts have no tags and already fall back to HEAD).
+        vcs_ref="HEAD",
     )
     return dst_path
 
@@ -290,6 +298,7 @@ def test_conventions_file_seeded_once_and_never_overwritten(
         unsafe=True,
         skip_tasks=True,
         overwrite=True,
+        vcs_ref="HEAD",
     )
     assert conventions.read_text() == "# Hand-written vault rules\n"
 

--- a/tests/test_guard_subtemplate.py
+++ b/tests/test_guard_subtemplate.py
@@ -1,0 +1,111 @@
+"""Render tests for the guard subtemplate (agentic_subtemplate=guard).
+
+The guard subtemplate vendors the decision-memory CI guard — and
+nothing else — into a data repo, keyed by a minimal answers file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import copier
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+GUARD_FILES = frozenset(
+    {
+        ".copier-answers.agentic.yml",
+        ".github/guards/decision_validator.py",
+        ".github/guards/guards.py",
+        ".github/workflows/guards.yml",
+        ".gitignore",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "docs/conventions.md",
+        "docs/extraction-prompt.md",
+        "preferences.md",
+    }
+)
+
+
+def _render_guard(tmp_path: Path) -> Path:
+    dst_path = tmp_path / "decision-memory"
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data={"agentic_subtemplate": "guard"},
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        # Pin HEAD: with release tags present locally, copier would
+        # otherwise render the latest RELEASE instead of this branch.
+        vcs_ref="HEAD",
+    )
+    return dst_path
+
+
+def test_guard_render_produces_exactly_the_guard_files(tmp_path: Path) -> None:
+    dst_path = _render_guard(tmp_path)
+    rendered = {
+        str(p.relative_to(dst_path)) for p in dst_path.rglob("*") if p.is_file()
+    }
+    assert rendered == GUARD_FILES
+
+
+def test_vendored_validator_is_byte_identical_to_source(
+    tmp_path: Path,
+) -> None:
+    dst_path = _render_guard(tmp_path)
+    source_dir = PROJECT_ROOT / "guard" / ".github" / "guards"
+    for name in ("decision_validator.py", "guards.py"):
+        vendored = (dst_path / ".github" / "guards" / name).read_text()
+        assert vendored == (source_dir / name).read_text()
+
+
+def test_guard_answers_file_is_minimal(tmp_path: Path) -> None:
+    """Project-scaffold questions are skipped, so the data repo records
+    only the subtemplate choice — it stays consumer-ignorant."""
+    dst_path = _render_guard(tmp_path)
+    answers = (dst_path / ".copier-answers.agentic.yml").read_text()
+    assert "agentic_subtemplate: guard" in answers
+    for key in (
+        "agentic_project_name",
+        "agentic_tracker_cli",
+        "agentic_precommit",
+    ):
+        assert key not in answers
+
+
+def test_store_docs_are_vendored_and_preferences_seeded(
+    tmp_path: Path,
+) -> None:
+    """Docs travel with the schema (vendored, byte-identical); the
+    preference set is seeded once and never overwritten on update."""
+    dst_path = _render_guard(tmp_path)
+    source = PROJECT_ROOT / "guard" / "docs" / "conventions.md"
+    assert (dst_path / "docs" / "conventions.md").read_text() == source.read_text()
+
+    preferences = dst_path / "preferences.md"
+    assert "Seeded once by the store subtemplate" in preferences.read_text()
+    # Owned by the store: a local edit must survive a re-render.
+    preferences.write_text("# Active Preference Set\n\n- my rule\n")
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data={"agentic_subtemplate": "guard"},
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+    assert preferences.read_text() == "# Active Preference Set\n\n- my rule\n"
+
+
+def test_default_render_contains_no_guard_files(
+    render_project,
+) -> None:
+    dst_path = render_project()
+    assert not (dst_path / ".github" / "guards").exists()
+    assert not (dst_path / ".github" / "workflows" / "guards.yml").exists()

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,0 +1,75 @@
+"""Tests for the pure functions of the vendored CI guard (guards.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+GUARDS_PATH = PROJECT_ROOT / "guard" / ".github" / "guards" / "guards.py"
+
+guards = load_module("guards", GUARDS_PATH)
+
+
+def test_commit_subjects_of_the_repo_types_pass() -> None:
+    for subject in (
+        "decision(factory): repo hosting — private GitHub over self-hosted",
+        "pref-proposal: prefers CI-enforced integrity over access control",
+        "pref-promote: rejects new infrastructure dependencies",
+        "pref-confirm: rejects new infrastructure dependencies (n=4)",
+        "chore: initialize repository",
+        "chore(ci): tighten guards",
+    ):
+        assert guards.check_commit_subject(subject) is None, subject
+
+
+def test_foreign_commit_subjects_fail() -> None:
+    for subject in (
+        "feat: add a feature",
+        "decision: missing project scope",
+        "decision(factory): no separator between slug and chosen",
+        "pref-confirm: missing counter suffix",
+        "update stuff",
+    ):
+        assert guards.check_commit_subject(subject) is not None, subject
+
+
+def test_pref_confirm_counter_math_accepts_single_bump() -> None:
+    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
+    added = ["- Rejects new deps. [confirmed: 4, last: 2026-07-21]"]
+    assert guards.validate_pref_confirm_change(removed, added) == []
+
+
+def test_pref_confirm_counter_math_rejects_bad_increment() -> None:
+    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
+    added = ["- Rejects new deps. [confirmed: 5, last: 2026-07-21]"]
+    errors = guards.validate_pref_confirm_change(removed, added)
+    assert any("increment" in e for e in errors)
+
+
+def test_pref_confirm_counter_math_rejects_text_change() -> None:
+    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
+    added = ["- Accepts new deps. [confirmed: 4, last: 2026-07-21]"]
+    errors = guards.validate_pref_confirm_change(removed, added)
+    assert any("rule text" in e for e in errors)
+
+
+def test_pref_confirm_counter_math_rejects_line_removal() -> None:
+    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
+    errors = guards.validate_pref_confirm_change(removed, [])
+    assert errors
+
+
+def test_parse_unified_diff_pairs_changed_lines() -> None:
+    diff = (
+        "diff --git a/preferences.md b/preferences.md\n"
+        "--- a/preferences.md\n"
+        "+++ b/preferences.md\n"
+        "@@ -5 +5 @@\n"
+        "-- Old rule. [confirmed: 1, last: 2026-07-15]\n"
+        "+- Old rule. [confirmed: 2, last: 2026-07-21]\n"
+    )
+    removed, added = guards.parse_unified_diff(diff)
+    assert removed == ["- Old rule. [confirmed: 1, last: 2026-07-15]"]
+    assert added == ["- Old rule. [confirmed: 2, last: 2026-07-21]"]

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -164,12 +164,12 @@ def test_resolve_batch_supersedes_maps_slugs_to_minted_ids() -> None:
     drafts[0]["slug"] = "old-ruling"
     drafts[1]["slug"] = "new-ruling"
     drafts[1]["supersedes_slug"] = "old-ruling"
-    resolved = record_tool.resolve_batch_supersedes(drafts, NOW)
+    resolved = record_tool.resolve_batch_refs(drafts, NOW)
     assert resolved[1]["supersedes"] == record_tool.mint_id("old-ruling", NOW)
     assert "supersedes_slug" not in resolved[1]
     # Order-independent: a draft may supersede a LATER one too.
     drafts[0]["supersedes_slug"] = "new-ruling"
-    resolved = record_tool.resolve_batch_supersedes(drafts, NOW)
+    resolved = record_tool.resolve_batch_refs(drafts, NOW)
     assert resolved[0]["supersedes"] == record_tool.mint_id("new-ruling", NOW)
 
 
@@ -177,7 +177,7 @@ def test_resolve_batch_supersedes_rejects_unknown_slug() -> None:
     d = draft()
     d["supersedes_slug"] = "not-in-this-batch"
     with pytest.raises(ValueError):
-        record_tool.resolve_batch_supersedes([d], NOW)
+        record_tool.resolve_batch_refs([d], NOW)
 
 
 def test_resolve_batch_supersedes_rejects_conflicting_fields() -> None:
@@ -186,7 +186,7 @@ def test_resolve_batch_supersedes_rejects_conflicting_fields() -> None:
     drafts[1]["supersedes_slug"] = "old-ruling"
     drafts[1]["supersedes"] = "20260101T000000Z-existing"
     with pytest.raises(ValueError):
-        record_tool.resolve_batch_supersedes(drafts, NOW)
+        record_tool.resolve_batch_refs(drafts, NOW)
 
 
 def test_session_hit_rates_bucket_refined_separately() -> None:
@@ -199,3 +199,32 @@ def test_session_hit_rates_bucket_refined_separately() -> None:
     streams = record_tool.session_hit_rates(records)
     assert streams["cold"] == {"hit": 1, "miss": 1, "near-tie": 0, "refined": 1}
     assert streams["preference-driven"]["refined"] == 1
+
+
+def test_resolve_batch_refs_handles_drill_down_and_related() -> None:
+    drafts = [draft(), draft(), draft()]
+    drafts[0]["slug"] = "parent-ruling"
+    drafts[1]["slug"] = "sibling-ruling"
+    drafts[2]["slug"] = "follow-up"
+    drafts[2]["drill_down_of_slug"] = "parent-ruling"
+    drafts[2]["related_slugs"] = ["sibling-ruling"]
+    resolved = record_tool.resolve_batch_refs(drafts, NOW)
+    assert resolved[2]["drill_down_of"] == record_tool.mint_id("parent-ruling", NOW)
+    assert resolved[2]["related"] == [record_tool.mint_id("sibling-ruling", NOW)]
+    assert "drill_down_of_slug" not in resolved[2]
+    assert "related_slugs" not in resolved[2]
+
+    # related_slugs merges with pre-existing repo-ID references.
+    drafts[2]["related"] = ["20260101T000000Z-existing"]
+    resolved = record_tool.resolve_batch_refs(drafts, NOW)
+    assert resolved[2]["related"] == [
+        "20260101T000000Z-existing",
+        record_tool.mint_id("sibling-ruling", NOW),
+    ]
+
+
+def test_resolve_batch_refs_rejects_unknown_drill_down_slug() -> None:
+    d = draft()
+    d["drill_down_of_slug"] = "not-in-batch"
+    with pytest.raises(ValueError):
+        record_tool.resolve_batch_refs([d], NOW)

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -157,3 +157,45 @@ def test_repo_url_tail_matches_across_url_forms() -> None:
     assert tail("https://github.com/acme/OTHER") != tail(
         "https://github.com/acme/decision-memory"
     )
+
+
+def test_resolve_batch_supersedes_maps_slugs_to_minted_ids() -> None:
+    drafts = [draft(), draft()]
+    drafts[0]["slug"] = "old-ruling"
+    drafts[1]["slug"] = "new-ruling"
+    drafts[1]["supersedes_slug"] = "old-ruling"
+    resolved = record_tool.resolve_batch_supersedes(drafts, NOW)
+    assert resolved[1]["supersedes"] == record_tool.mint_id("old-ruling", NOW)
+    assert "supersedes_slug" not in resolved[1]
+    # Order-independent: a draft may supersede a LATER one too.
+    drafts[0]["supersedes_slug"] = "new-ruling"
+    resolved = record_tool.resolve_batch_supersedes(drafts, NOW)
+    assert resolved[0]["supersedes"] == record_tool.mint_id("new-ruling", NOW)
+
+
+def test_resolve_batch_supersedes_rejects_unknown_slug() -> None:
+    d = draft()
+    d["supersedes_slug"] = "not-in-this-batch"
+    with pytest.raises(ValueError):
+        record_tool.resolve_batch_supersedes([d], NOW)
+
+
+def test_resolve_batch_supersedes_rejects_conflicting_fields() -> None:
+    drafts = [draft(), draft()]
+    drafts[0]["slug"] = "old-ruling"
+    drafts[1]["supersedes_slug"] = "old-ruling"
+    drafts[1]["supersedes"] = "20260101T000000Z-existing"
+    with pytest.raises(ValueError):
+        record_tool.resolve_batch_supersedes(drafts, NOW)
+
+
+def test_session_hit_rates_bucket_refined_separately() -> None:
+    records = [
+        {"prediction_stream": "cold", "outcome": "hit"},
+        {"prediction_stream": "cold", "outcome": "refined"},
+        {"prediction_stream": "cold", "outcome": "miss"},
+        {"prediction_stream": "preference-driven", "outcome": "refined"},
+    ]
+    streams = record_tool.session_hit_rates(records)
+    assert streams["cold"] == {"hit": 1, "miss": 1, "near-tie": 0, "refined": 1}
+    assert streams["preference-driven"]["refined"] == 1

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -57,6 +57,7 @@ def draft() -> dict:
                 "option": "full-access PAT",
                 "reason": "blast radius",
                 "status": "presumed-false",
+                "reason_source": "inferred",
                 "reason_class": "TBD",
             }
         ],

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -1,0 +1,158 @@
+"""Tests for the recorder's contract core (tools/record.py).
+
+The contract core is pure (no IO) and is the dojo lift-target:
+mint_id, mint_envelope, draft_to_record, serialize_record. Validation
+itself is NOT tested here — it lives in the vendored validator (see
+test_decision_validator.py); these tests only cross-check that minted
+records satisfy it.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+record_tool = load_module(
+    "record_tool", PROJECT_ROOT / "template" / "tools" / "record.py"
+)
+dv = load_module(
+    "decision_validator",
+    PROJECT_ROOT / "guard" / ".github" / "guards" / "decision_validator.py",
+)
+
+NOW = dt.datetime(2026, 7, 21, 14, 32, 5, tzinfo=dt.timezone.utc)
+
+
+def draft() -> dict:
+    """A draft record: the schema minus tool-minted fields, plus slug."""
+    return {
+        "slug": "agent-access",
+        "project": "factory",
+        "question": "How do agent environments access the preference repo?",
+        "context": "session-local facts informing the options",
+        "options": [
+            {
+                "slot": 1,
+                "label": "read-only deploy key",
+                "role": "prediction+recommendation",
+                "rules_cited": [],
+                "reasoning": "integrity via least privilege",
+            },
+            {"slot": 2, "label": "full-access PAT", "if_clause": "if speed"},
+        ],
+        "prediction_stream": "cold",
+        "artifact_ref": None,
+        "chosen_slot": 1,
+        "chosen": "read-only deploy key",
+        "correction": False,
+        "rejections": [
+            {
+                "option": "full-access PAT",
+                "reason": "blast radius",
+                "status": "presumed-false",
+                "reason_class": "TBD",
+            }
+        ],
+        "outcome": "hit",
+    }
+
+
+def test_mint_id_format() -> None:
+    assert record_tool.mint_id("agent-access", NOW) == "20260721T143205Z-agent-access"
+
+
+@pytest.mark.parametrize(
+    "bad_slug",
+    ["Agent-Access", "agent_access", "agent access", "", "a" * 41],
+)
+def test_mint_id_rejects_bad_slugs(bad_slug: str) -> None:
+    with pytest.raises(ValueError):
+        record_tool.mint_id(bad_slug, NOW)
+
+
+def test_mint_envelope() -> None:
+    envelope = record_tool.mint_envelope("agent-access", NOW)
+    assert envelope == {
+        "v": 1,
+        "type": "decision",
+        "id": "20260721T143205Z-agent-access",
+    }
+
+
+def test_draft_to_record_mints_and_validates() -> None:
+    record = record_tool.draft_to_record(
+        draft(),
+        NOW,
+        session="session_01ABC",
+        preference_commit="0" * 40,
+    )
+    assert record["id"] == "20260721T143205Z-agent-access"
+    assert record["date"] == "2026-07-21"
+    assert record["session"] == "session_01ABC"
+    assert record["preference_set"] == {"commit": "0" * 40}
+    assert "slug" not in record
+    assert dv.validate_record(record, filename_stem=record["id"]) == []
+
+
+def test_draft_values_win_over_minted_defaults() -> None:
+    d = draft()
+    d["session"] = "session_from_chat"
+    d["preference_set"] = {"commit": "f" * 40}
+    record = record_tool.draft_to_record(
+        d, NOW, session="ignored", preference_commit="0" * 40
+    )
+    assert record["session"] == "session_from_chat"
+    assert record["preference_set"] == {"commit": "f" * 40}
+
+
+def test_draft_without_slug_is_an_error() -> None:
+    d = draft()
+    del d["slug"]
+    with pytest.raises(ValueError):
+        record_tool.draft_to_record(d, NOW)
+
+
+def test_record_field_order_groups_input_before_output() -> None:
+    record = record_tool.draft_to_record(draft(), NOW)
+    keys = list(record.keys())
+    assert keys[:3] == ["v", "type", "id"]
+    assert keys.index("question") < keys.index("chosen_slot")
+    assert keys.index("prediction_stream") < keys.index("outcome")
+
+
+def test_unknown_draft_fields_are_preserved() -> None:
+    d = draft()
+    d["some_future_field"] = {"nested": True}
+    record = record_tool.draft_to_record(d, NOW)
+    assert record["some_future_field"] == {"nested": True}
+
+
+def test_serialize_record_round_trips() -> None:
+    record = record_tool.draft_to_record(draft(), NOW)
+    text = record_tool.serialize_record(record)
+    assert text.endswith("\n")
+    assert json.loads(text) == record
+    # Serialization must preserve the constructed field order.
+    assert text.index('"question"') < text.index('"chosen_slot"')
+
+
+def test_repo_url_tail_matches_across_url_forms() -> None:
+    tail = record_tool.repo_url_tail
+    assert tail("https://github.com/acme/decision-memory.git") == (
+        "acme/decision-memory"
+    )
+    assert tail("git@github.com:acme/decision-memory.git") == ("acme/decision-memory")
+    # Managed environments rewrite remotes through a local proxy.
+    assert tail("http://local_proxy@127.0.0.1:41729/git/acme/decision-memory") == (
+        "acme/decision-memory"
+    )
+    assert tail("https://github.com/acme/OTHER") != tail(
+        "https://github.com/acme/decision-memory"
+    )

--- a/tools/record.py
+++ b/tools/record.py
@@ -1,0 +1,798 @@
+#!/usr/bin/env python3
+"""Decision recorder — writer-side tooling for a decision-memory repo.
+
+This docstring doubles as the CLI help text and is the AUTHORITATIVE
+description of the recorder's behavior — there is no separate spec
+file (design history: agentic-engineering-template issue #37 and the
+backfilled decision records). The contract this tool must satisfy
+(record schema, commit types, PR flow) lives with the data, in the
+decision-memory repo's docs/conventions.md and CI guards.
+
+Verbs:
+  open     make the store repo available — clone it into an ephemeral
+           temp dir, or reuse an already-attached checkout
+           (--use <path>, matched against DECISION_MEMORY_URL by
+           owner/repo) where cloning is impossible (e.g. managed
+           environments); capture the preference-set SHA, create the
+           session branch, run the stateless closed-unmerged-PR sweep
+  record   mint + validate + write one decision record per input
+           draft (stdin JSON object/array, or --from drafts.json),
+           one commit per record
+  check    validate the entire decisions/ corpus + dangling refs +
+           preferences.md token budget
+  submit   compute two-stream hit rates, auto-bump pref-confirm
+           counters, push, open the PR (or emit the managed-
+           environment handoff)
+  propose  write a preference-rule proposal file with its commit
+
+Configuration: DECISION_MEMORY_URL (full git URL of the data repo;
+never commit it anywhere public). Verbs after `open` find the clone
+via DECISION_MEMORY_DIR or --dir.
+
+Stdlib only. The file is split into a pure CONTRACT CORE (the dojo
+lift-target) and an IO SHELL; keep the seam strict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ========================== contract core ==========================
+# Pure functions, no IO — the functions a future dojo package lifts
+# verbatim. Validation is deliberately NOT defined here:
+# DECISION: the validator is imported from the data-repo clone's
+# vendored copy (single copier-vendored source shared with CI), so
+# writer-side and CI validation cannot drift.
+
+# Mint-side mirror of the envelope/ID grammar. The vendored
+# decision_validator in the store checkout stays authoritative —
+# minted records are re-validated against it; these constants only
+# make minting fail fast with better messages.
+SCHEMA_VERSION = 1
+RECORD_TYPE = "decision"
+MAX_SLUG_LENGTH = 40
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Replay-ready order: envelope, then input side (pre-ruling), then
+# output side (post-ruling), then links. Unknown fields keep their
+# draft order after these.
+FIELD_ORDER = (
+    "v",
+    "type",
+    "id",
+    "date",
+    "project",
+    "question",
+    "context",
+    "options",
+    "prediction_stream",
+    "preference_set",
+    "artifact_ref",
+    "session",
+    "chosen_slot",
+    "chosen",
+    "operative_reason",
+    "correction",
+    "rejections",
+    "outcome",
+    "drill_down_of",
+    "closure_of",
+    "related",
+    "supersedes",
+    "notes",
+)
+
+
+def mint_id(slug: str, now: dt.datetime) -> str:
+    """Mint a record ID: <UTC timestamp>Z-<slug>."""
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"slug {slug!r} must be lowercase kebab-case ([a-z0-9-])")
+    if len(slug) > MAX_SLUG_LENGTH:
+        raise ValueError(f"slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})")
+    timestamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{slug}"
+
+
+def mint_envelope(slug: str, now: dt.datetime) -> dict:
+    """Mint the universal envelope: v, type, id."""
+    return {
+        "v": SCHEMA_VERSION,
+        "type": RECORD_TYPE,
+        "id": mint_id(slug, now),
+    }
+
+
+def draft_to_record(
+    draft: dict,
+    now: dt.datetime,
+    session: str | None = None,
+    preference_commit: str | None = None,
+) -> dict:
+    """Turn a draft record (schema minus tool-minted fields, plus
+    ``slug``) into a full record.
+
+    Draft-supplied values always win over minted defaults; unknown
+    fields are preserved. Raises ValueError when ``slug`` is missing
+    or malformed.
+    """
+    payload = dict(draft)
+    slug = payload.pop("slug", None)
+    if not isinstance(slug, str) or not slug:
+        raise ValueError("draft is missing the writer-chosen 'slug' field")
+
+    merged = mint_envelope(slug, now)
+    merged["date"] = now.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
+    merged["session"] = payload.pop("session", None) or session
+    preference_set = payload.pop("preference_set", None)
+    if preference_set is None and preference_commit:
+        preference_set = {"commit": preference_commit}
+    if preference_set is not None:
+        merged["preference_set"] = preference_set
+    merged.update(payload)
+
+    record = {key: merged[key] for key in FIELD_ORDER if key in merged}
+    for key, value in merged.items():
+        if key not in record:
+            record[key] = value
+    return record
+
+
+def serialize_record(record: dict) -> str:
+    """Serialize a record for its immutable decisions/<id>.json file."""
+    return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+# ============================ IO shell =============================
+# CLI, clone/branch/commit mechanics, PR calls. The PR call is the one
+# forge-specific piece: a hosting supersession (or a managed
+# environment without gh) swaps/skips this function, never the core.
+
+STATE_FILE = ".recorder-session.json"
+VALIDATOR_RELPATH = Path(".github") / "guards" / "decision_validator.py"
+GITHUB_URL_RE = re.compile(
+    r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+def repo_url_tail(url: str) -> str:
+    """Normalize a git URL to its trailing owner/repo pair (lowercase).
+
+    Managed environments rewrite remotes through local proxies, so two
+    URLs for the same repo rarely match textually — the owner/repo
+    tail is the stable identity across https/ssh/proxy forms.
+    """
+    path = url.rstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    parts = [p for p in path.replace(":", "/").split("/") if p]
+    return "/".join(parts[-2:]).lower()
+
+
+def fail(message: str) -> "SystemExit":
+    return SystemExit(f"record.py: error: {message}")
+
+
+def run_git(repo_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise fail(f"git {' '.join(args)} failed in {repo_dir}:\n{result.stderr}")
+    return result.stdout
+
+
+def resolve_repo_dir(args: argparse.Namespace) -> Path:
+    raw = args.dir or os.environ.get("DECISION_MEMORY_DIR")
+    if not raw:
+        raise fail(
+            "no clone found — run `record.py open` first, then pass --dir "
+            "or export DECISION_MEMORY_DIR as it prints"
+        )
+    repo_dir = Path(raw)
+    if not (repo_dir / ".git").exists():
+        raise fail(f"{repo_dir} is not a git clone")
+    return repo_dir
+
+
+def load_state(repo_dir: Path) -> dict:
+    state_path = repo_dir / STATE_FILE
+    if not state_path.exists():
+        raise fail(
+            f"{state_path} missing — this clone was not created by `record.py open`"
+        )
+    return json.loads(state_path.read_text(encoding="utf-8"))
+
+
+def load_validator(repo_dir: Path):
+    """Import the copier-vendored validator from the data-repo clone."""
+    path = repo_dir / VALIDATOR_RELPATH
+    if not path.exists():
+        raise fail(
+            f"vendored validator missing at {path} — the data repo must "
+            "vendor the guard subtemplate (copier update from the "
+            "agentic-engineering-template guard subtemplate)"
+        )
+    spec = importlib.util.spec_from_file_location("decision_validator", path)
+    if spec is None or spec.loader is None:
+        raise fail(f"cannot import validator from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_corpus(repo_dir: Path) -> dict[str, dict]:
+    records: dict[str, dict] = {}
+    decisions_dir = repo_dir / "decisions"
+    if decisions_dir.is_dir():
+        for path in sorted(decisions_dir.glob("*.json")):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(record, dict) and isinstance(record.get("id"), str):
+                records[record["id"]] = record
+    return records
+
+
+def read_drafts(args: argparse.Namespace) -> list[dict]:
+    if getattr(args, "from_file", None):
+        text = Path(args.from_file).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise fail(f"input is not valid JSON: {exc}")
+    drafts = data if isinstance(data, list) else [data]
+    if not all(isinstance(d, dict) for d in drafts):
+        raise fail("input must be a JSON object or an array of objects")
+    return drafts
+
+
+def github_slug(url: str) -> str | None:
+    match = GITHUB_URL_RE.search(url)
+    return f"{match['owner']}/{match['repo']}" if match else None
+
+
+def list_closed_unmerged_prs(url: str) -> list[int] | None:
+    """Best-effort PR listing via gh. None = unavailable (handoff)."""
+    slug = github_slug(url)
+    if slug is None or shutil.which("gh") is None:
+        return None
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            slug,
+            "--state",
+            "closed",
+            "--json",
+            "number,mergedAt",
+            "--limit",
+            "500",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # DECISION: any gh failure falls through to the handoff path —
+    # managed environments sabotage gh, so failure is an expected mode,
+    # not an error.
+    if result.returncode != 0:
+        return None
+    try:
+        prs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return [
+        pr["number"] for pr in prs if isinstance(pr, dict) and not pr.get("mergedAt")
+    ]
+
+
+def covered_closures(records: dict[str, dict]) -> set[int]:
+    return {
+        record["closure_of"]
+        for record in records.values()
+        if isinstance(record.get("closure_of"), int)
+    }
+
+
+def _attach_checkout(path_arg: str, url: str) -> Path:
+    """Validate an already-available checkout of the store repo."""
+    repo_dir = Path(path_arg).resolve()
+    if not (repo_dir / ".git").exists():
+        raise fail(f"--use {repo_dir}: not a git checkout")
+    origin = run_git(repo_dir, "config", "--get", "remote.origin.url").strip()
+    if repo_url_tail(origin) != repo_url_tail(url):
+        raise fail(
+            f"--use {repo_dir}: origin {origin!r} is not the store repo "
+            f"(DECISION_MEMORY_URL points at {repo_url_tail(url)!r})"
+        )
+    if run_git(repo_dir, "status", "--porcelain").strip():
+        raise fail(
+            f"--use {repo_dir}: worktree is dirty — commit or stash "
+            "before opening a recording session in it"
+        )
+    return repo_dir
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    url = os.environ.get("DECISION_MEMORY_URL")
+    if not url:
+        raise fail(
+            "DECISION_MEMORY_URL is unset — export the full git URL of "
+            "your decision-memory repo (never commit it anywhere public)"
+        )
+    now = dt.datetime.now(dt.timezone.utc)
+    if args.use:
+        repo_dir = _attach_checkout(args.use, url)
+        print(f"Reusing attached checkout: {repo_dir}")
+    else:
+        repo_dir = Path(tempfile.mkdtemp(prefix="decision-memory-"))
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", url, str(repo_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise fail(
+                f"clone failed:\n{result.stderr}\n"
+                "If the store repo is already available in this session "
+                "(e.g. attached in a managed environment where outbound "
+                "cloning is blocked), re-run: open --use <path-to-checkout>"
+            )
+
+    base_commit = run_git(repo_dir, "rev-parse", "HEAD").strip()
+    branch = "session/" + now.strftime("%Y%m%dT%H%M%SZ")
+    run_git(repo_dir, "checkout", "-b", branch)
+
+    session = args.session or os.environ.get("CLAUDE_SESSION_ID")
+    # DECISION: session state lives inside the ephemeral clone
+    # (untracked file, excluded from git status) — nothing persists
+    # outside the temp dir, keeping sessions stateless across machines.
+    state = {
+        "branch": branch,
+        "base_commit": base_commit,
+        "session": session,
+        "opened_at": now.isoformat(),
+    }
+    (repo_dir / STATE_FILE).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    exclude = repo_dir / ".git" / "info" / "exclude"
+    with open(exclude, "a", encoding="utf-8") as handle:
+        handle.write(f"{STATE_FILE}\n")
+
+    records = load_corpus(repo_dir)
+    covered = covered_closures(records)
+    closed_prs = list_closed_unmerged_prs(url)
+
+    print(f"Store checkout: {repo_dir}")
+    print(f"Session branch: {branch}")
+    print(f"preference_set.commit for this session: {base_commit}")
+    print()
+    if closed_prs is None:
+        print(
+            "Unmerged-PR sweep: could not list closed PRs here (no usable "
+            "gh). Handoff: list this repo's closed-UNMERGED PRs with your "
+            "environment's tooling and record one decision per PR number "
+            f"not in the covered set {sorted(covered)} (set closure_of)."
+        )
+    else:
+        pending = sorted(set(closed_prs) - covered)
+        if pending:
+            print(
+                f"Unmerged-PR sweep: PR(s) {pending} were closed without "
+                "merge and have no closure record yet. Record one decision "
+                "each ('why was PR #N rejected'), with closure_of set and "
+                "the correction flag where applicable."
+            )
+        else:
+            print("Unmerged-PR sweep: all closures covered.")
+    print()
+    print(
+        "Reminder: inject preferences.md (and ONLY preferences.md) into "
+        "the session context now, if not already injected."
+    )
+    print(f"export DECISION_MEMORY_DIR={repo_dir}")
+    return 0
+
+
+def commit_record(repo_dir: Path, record: dict) -> None:
+    record_id = record["id"]
+    path = repo_dir / "decisions" / f"{record_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise fail(f"{path} already exists — records are immutable")
+    path.write_text(serialize_record(record), encoding="utf-8")
+    slug = record_id.split("Z-", 1)[1]
+    chosen = " ".join(str(record.get("chosen", "")).split())
+    if len(chosen) > 100:
+        chosen = chosen[:99] + "…"
+    # Subject grammar authority: the store's docs/conventions.md
+    # (§ Commit types); the vendored guard lints what this composes.
+    subject = f"decision({record['project']}): {slug} — {chosen}"
+    run_git(repo_dir, "add", str(path))
+    run_git(repo_dir, "commit", "-m", subject)
+    print(f"Recorded {record_id} ({subject})")
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    state = load_state(repo_dir)
+    validator = load_validator(repo_dir)
+    now = dt.datetime.now(dt.timezone.utc)
+
+    drafts = read_drafts(args)
+    records = []
+    errors: list[str] = []
+    for index, draft in enumerate(drafts):
+        try:
+            record = draft_to_record(
+                draft,
+                now,
+                session=state.get("session"),
+                preference_commit=state.get("base_commit"),
+            )
+        except ValueError as exc:
+            errors.append(f"draft[{index}]: {exc}")
+            continue
+        for error in validator.validate_record(record, filename_stem=record["id"]):
+            errors.append(f"draft[{index}] ({record['id']}): {error}")
+        records.append(record)
+
+    if errors:
+        for error in errors:
+            print(f"INVALID: {error}", file=sys.stderr)
+        print(
+            f"{len(errors)} validation error(s) — nothing written.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for record in records:
+        commit_record(repo_dir, record)
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    validator = load_validator(repo_dir)
+
+    errors: list[str] = []
+    decisions_dir = repo_dir / "decisions"
+    records: dict[str, dict] = {}
+    if decisions_dir.is_dir():
+        for path in sorted(decisions_dir.iterdir()):
+            if path.name.startswith("."):
+                continue
+            if path.suffix != ".json":
+                errors.append(f"{path.name}: non-JSON file in decisions/")
+                continue
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"{path.name}: invalid JSON: {exc}")
+                continue
+            errors.extend(
+                f"{path.name}: {error}"
+                for error in validator.validate_record(record, filename_stem=path.stem)
+            )
+            if isinstance(record, dict) and isinstance(record.get("id"), str):
+                records[record["id"]] = record
+    errors.extend(validator.validate_corpus(records))
+
+    preferences = repo_dir / "preferences.md"
+    if preferences.exists():
+        errors.extend(
+            validator.check_preferences_budget(preferences.read_text(encoding="utf-8"))
+        )
+
+    for error in errors:
+        print(f"CHECK FAIL: {error}", file=sys.stderr)
+    if not errors:
+        print(f"check: {len(records)} record(s) valid, budget OK.")
+    return 1 if errors else 0
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def bump_preference_counter(
+    preferences_text: str, rule: str, today: str, counter_re: re.Pattern
+) -> tuple[str, int] | None:
+    """Bump the confirmation counter of the bullet matching ``rule``.
+
+    ``counter_re`` is the vendored validator's COUNTER_RE — the single
+    source of the counter-line grammar, shared with the CI guard.
+    Returns (new_text, new_count), or None when no bullet matches.
+    Handles wrapped bullets: an entry runs from its `- ` line to the
+    next bullet/heading/blank line; the counter sits on its last line.
+    """
+    lines = preferences_text.splitlines(keepends=True)
+    entries: list[tuple[int, int]] = []
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("- "):
+            if start is not None:
+                entries.append((start, i))
+            start = i
+        elif start is not None and (not line.strip() or line.startswith("#")):
+            entries.append((start, i))
+            start = None
+    if start is not None:
+        entries.append((start, len(lines)))
+
+    wanted = _normalize(rule)
+    for begin, end in entries:
+        entry_text = _normalize("".join(lines[begin:end]))
+        if wanted not in entry_text:
+            continue
+        for i in range(end - 1, begin - 1, -1):
+            match = counter_re.search(lines[i])
+            if match:
+                count = int(match.group(1)) + 1
+                lines[i] = counter_re.sub(
+                    f"[confirmed: {count}, last: {today}]", lines[i]
+                )
+                return "".join(lines), count
+    return None
+
+
+def session_hit_rates(records: list[dict]) -> dict[str, dict[str, int]]:
+    streams: dict[str, dict[str, int]] = {
+        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0},
+        "cold": {"hit": 0, "miss": 0, "near-tie": 0},
+    }
+    for record in records:
+        stream = record.get("prediction_stream")
+        outcome = record.get("outcome")
+        if stream in streams and outcome in streams[stream]:
+            streams[stream][outcome] += 1
+    return streams
+
+
+def prediction_rules(record: dict) -> list[str]:
+    for option in record.get("options", []):
+        if isinstance(option, dict) and option.get("role") in (
+            "prediction",
+            "prediction+recommendation",
+        ):
+            rules = option.get("rules_cited")
+            return [r for r in rules if isinstance(r, str)] if rules else []
+    return []
+
+
+def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> str:
+    def rate(stream: str) -> str:
+        counts = streams[stream]
+        scored = counts["hit"] + counts["miss"]
+        shown = f"{counts['hit']}/{scored} hits" if scored else "no scored"
+        if counts["near-tie"]:
+            shown += f" ({counts['near-tie']} near-tie)"
+        return shown
+
+    lines = [
+        f"Decision session PR: {len(records)} record(s).",
+        "",
+        "Prediction hit rates (two streams):",
+        f"- preference-driven: {rate('preference-driven')}",
+        f"- cold (control): {rate('cold')}",
+    ]
+    supersedes = [
+        (record["id"], record["supersedes"])
+        for record in records
+        if record.get("supersedes")
+    ]
+    if supersedes:
+        lines += ["", "Supersedes claims — review explicitly:"]
+        lines += [
+            f"- {record_id} supersedes {target}" for record_id, target in supersedes
+        ]
+    closures = [
+        (record["id"], record["closure_of"])
+        for record in records
+        if record.get("closure_of")
+    ]
+    if closures:
+        lines += ["", "Closure records (closed-unmerged PR sweep):"]
+        lines += [
+            f"- {record_id} explains the closure of PR #{number}"
+            for record_id, number in closures
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    state = load_state(repo_dir)
+    validator = load_validator(repo_dir)
+    branch = state["branch"]
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+
+    added = run_git(
+        repo_dir,
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{state['base_commit']}..HEAD",
+        "--",
+        "decisions/",
+    ).split()
+    records = []
+    for name in added:
+        path = repo_dir / name
+        records.append(json.loads(path.read_text(encoding="utf-8")))
+    if not records:
+        raise fail("no records on this session branch — nothing to submit")
+
+    streams = session_hit_rates(records)
+
+    preferences_path = repo_dir / "preferences.md"
+    for record in records:
+        if (
+            record.get("prediction_stream") != "preference-driven"
+            or record.get("outcome") != "hit"
+        ):
+            continue
+        for rule in prediction_rules(record):
+            if not preferences_path.exists():
+                print(f"WARN: no preferences.md — cannot bump {rule!r}")
+                continue
+            bumped = bump_preference_counter(
+                preferences_path.read_text(encoding="utf-8"),
+                rule,
+                today,
+                validator.COUNTER_RE,
+            )
+            if bumped is None:
+                print(
+                    f"WARN: cited rule {rule!r} not found in "
+                    "preferences.md — no counter bumped (proposal?)"
+                )
+                continue
+            new_text, count = bumped
+            preferences_path.write_text(new_text, encoding="utf-8")
+            run_git(repo_dir, "add", "preferences.md")
+            run_git(repo_dir, "commit", "-m", f"pref-confirm: {rule} (n={count})")
+            print(f"pref-confirm: {rule} (n={count})")
+
+    run_git(repo_dir, "push", "-u", "origin", branch)
+    print(f"Pushed {branch}.")
+
+    title = f"decision session {branch.split('/', 1)[1]} — " + (
+        f"{len(records)} record(s)"
+    )
+    body = build_pr_body(records, streams)
+
+    url = os.environ.get("DECISION_MEMORY_URL", "")
+    slug = github_slug(url)
+    if slug and shutil.which("gh"):
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                slug,
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print(result.stdout.strip())
+            return 0
+        print(
+            f"gh pr create failed ({result.stderr.strip()}) — falling back to handoff.",
+            file=sys.stderr,
+        )
+
+    print()
+    print("── PR handoff (managed environment / no usable gh) ──")
+    print("The branch is pushed; open the PR with the tooling your")
+    print("environment declares, using exactly this title and body:")
+    print()
+    print(f"Title: {title}")
+    print("Body:")
+    print(body)
+    return 0
+
+
+def cmd_propose(args: argparse.Namespace) -> int:
+    repo_dir = resolve_repo_dir(args)
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    rule = " ".join(args.rule.split())
+    slug = args.slug or re.sub(
+        r"-+", "-", re.sub(r"[^a-z0-9]+", "-", rule.lower())
+    ).strip("-")[:MAX_SLUG_LENGTH].rstrip("-")
+    if not SLUG_RE.match(slug):
+        raise fail(f"cannot derive a kebab-case slug from {rule!r}")
+
+    path = repo_dir / "proposals" / f"{today}-{slug}.md"
+    if path.exists():
+        raise fail(f"{path} already exists")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"# Preference proposal: {slug}\n\n"
+        f"- {rule} [confirmed: 0, last: {today}]\n\n"
+        "Promotion is human-only: a `pref-promote` commit moves the rule "
+        "into preferences.md; merging this file is not promotion.\n",
+        encoding="utf-8",
+    )
+    run_git(repo_dir, "add", str(path))
+    run_git(repo_dir, "commit", "-m", f"pref-proposal: {rule}")
+    print(f"Proposed: {path.name}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="record.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dir",
+        help="path to the session clone (default: $DECISION_MEMORY_DIR)",
+    )
+    sub = parser.add_subparsers(dest="verb", required=True)
+
+    p_open = sub.add_parser("open", help="start a recording session")
+    p_open.add_argument(
+        "--session",
+        help="opaque session grouping key (default: $CLAUDE_SESSION_ID)",
+    )
+    p_open.add_argument(
+        "--use",
+        help="reuse an already-available checkout of the store repo "
+        "instead of cloning (validated against DECISION_MEMORY_URL by "
+        "owner/repo; worktree must be clean)",
+    )
+    p_open.set_defaults(func=cmd_open)
+
+    p_record = sub.add_parser("record", help="record decision drafts")
+    p_record.add_argument(
+        "--from",
+        dest="from_file",
+        help="JSON file with a draft record or an array of drafts "
+        "(default: read stdin)",
+    )
+    p_record.set_defaults(func=cmd_record)
+
+    p_check = sub.add_parser("check", help="validate the whole corpus")
+    p_check.set_defaults(func=cmd_check)
+
+    p_submit = sub.add_parser("submit", help="push and open the session PR")
+    p_submit.set_defaults(func=cmd_submit)
+
+    p_propose = sub.add_parser("propose", help="propose a preference rule")
+    p_propose.add_argument("--rule", required=True, help="the rule text")
+    p_propose.add_argument("--slug", help="override the derived file slug")
+    p_propose.set_defaults(func=cmd_propose)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/record.py
+++ b/tools/record.py
@@ -17,12 +17,14 @@ Verbs:
            session branch, run the stateless closed-unmerged-PR sweep
   record   mint + validate + write one decision record per input
            draft (stdin JSON object/array, or --from drafts.json),
-           one commit per record
+           one commit per record; batch-local supersedes_slug
+           references resolve to the minted IDs
   check    validate the entire decisions/ corpus + dangling refs +
            preferences.md token budget
-  submit   compute two-stream hit rates, auto-bump pref-confirm
-           counters, push, open the PR (or emit the managed-
-           environment handoff)
+  submit   compute two-stream hit rates (refined and near-tie
+           bucketed separately), auto-bump pref-confirm counters for
+           clean preference-driven hits, push, open the PR (or emit
+           the managed-environment handoff)
   propose  write a preference-rule proposal file with its commit
 
 Configuration: DECISION_MEMORY_URL (full git URL of the data repo;
@@ -150,6 +152,39 @@ def draft_to_record(
 def serialize_record(record: dict) -> str:
     """Serialize a record for its immutable decisions/<id>.json file."""
     return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+def resolve_batch_supersedes(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local ``supersedes_slug`` references to minted IDs.
+
+    Drafts extracted from one conversation cannot know each other's
+    final IDs, so cross-draft supersession names the target by slug;
+    this maps every reference to the ID the batch will mint
+    (order-independent). Raises ValueError on unknown slugs or when a
+    draft carries both ``supersedes`` and ``supersedes_slug``.
+    """
+    minted = {}
+    for d in drafts:
+        slug = d.get("slug")
+        if isinstance(slug, str) and SLUG_RE.match(slug):
+            minted[slug] = mint_id(slug, now)
+    resolved = []
+    for d in drafts:
+        d = dict(d)
+        ref = d.pop("supersedes_slug", None)
+        if ref is not None:
+            if d.get("supersedes"):
+                raise ValueError(
+                    f"draft {d.get('slug')!r}: both supersedes and "
+                    "supersedes_slug given — use one"
+                )
+            if ref not in minted:
+                raise ValueError(
+                    f"supersedes_slug {ref!r} matches no slug in this batch"
+                )
+            d["supersedes"] = minted[ref]
+        resolved.append(d)
+    return resolved
 
 
 # ============================ IO shell =============================
@@ -437,6 +472,10 @@ def cmd_record(args: argparse.Namespace) -> int:
     now = dt.datetime.now(dt.timezone.utc)
 
     drafts = read_drafts(args)
+    try:
+        drafts = resolve_batch_supersedes(drafts, now)
+    except ValueError as exc:
+        raise fail(str(exc))
     records = []
     errors: list[str] = []
     for index, draft in enumerate(drafts):
@@ -555,8 +594,8 @@ def bump_preference_counter(
 
 def session_hit_rates(records: list[dict]) -> dict[str, dict[str, int]]:
     streams: dict[str, dict[str, int]] = {
-        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0},
-        "cold": {"hit": 0, "miss": 0, "near-tie": 0},
+        "preference-driven": {"hit": 0, "miss": 0, "near-tie": 0, "refined": 0},
+        "cold": {"hit": 0, "miss": 0, "near-tie": 0, "refined": 0},
     }
     for record in records:
         stream = record.get("prediction_stream")
@@ -582,8 +621,13 @@ def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> st
         counts = streams[stream]
         scored = counts["hit"] + counts["miss"]
         shown = f"{counts['hit']}/{scored} hits" if scored else "no scored"
-        if counts["near-tie"]:
-            shown += f" ({counts['near-tie']} near-tie)"
+        extras = [
+            f"{counts[bucket]} {bucket}"
+            for bucket in ("refined", "near-tie")
+            if counts[bucket]
+        ]
+        if extras:
+            shown += f" ({', '.join(extras)})"
         return shown
 
     lines = [

--- a/tools/record.py
+++ b/tools/record.py
@@ -17,8 +17,9 @@ Verbs:
            session branch, run the stateless closed-unmerged-PR sweep
   record   mint + validate + write one decision record per input
            draft (stdin JSON object/array, or --from drafts.json),
-           one commit per record; batch-local supersedes_slug
-           references resolve to the minted IDs
+           one commit per record; batch-local slug references
+           (supersedes_slug, drill_down_of_slug, related_slugs)
+           resolve to the minted IDs
   check    validate the entire decisions/ corpus + dangling refs +
            preferences.md token budget
   submit   compute two-stream hit rates (refined and near-tie
@@ -154,35 +155,54 @@ def serialize_record(record: dict) -> str:
     return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
 
 
-def resolve_batch_supersedes(drafts: list, now: dt.datetime) -> list:
-    """Resolve batch-local ``supersedes_slug`` references to minted IDs.
+def resolve_batch_refs(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local slug references to minted IDs.
 
     Drafts extracted from one conversation cannot know each other's
-    final IDs, so cross-draft supersession names the target by slug;
-    this maps every reference to the ID the batch will mint
+    final IDs, so cross-draft links name their target by slug:
+    ``supersedes_slug`` and ``drill_down_of_slug`` (single),
+    ``related_slugs`` (list, appended to any repo-ID ``related``
+    entries). This maps every reference to the ID the batch will mint
     (order-independent). Raises ValueError on unknown slugs or when a
-    draft carries both ``supersedes`` and ``supersedes_slug``.
+    draft carries both a slug reference and its resolved field.
     """
     minted = {}
     for d in drafts:
         slug = d.get("slug")
         if isinstance(slug, str) and SLUG_RE.match(slug):
             minted[slug] = mint_id(slug, now)
+
+    def resolve(draft_slug, ref):
+        if ref not in minted:
+            raise ValueError(
+                f"draft {draft_slug!r}: batch reference {ref!r} matches "
+                "no slug in this batch"
+            )
+        return minted[ref]
+
     resolved = []
     for d in drafts:
         d = dict(d)
-        ref = d.pop("supersedes_slug", None)
-        if ref is not None:
-            if d.get("supersedes"):
+        for slug_field, target in (
+            ("supersedes_slug", "supersedes"),
+            ("drill_down_of_slug", "drill_down_of"),
+        ):
+            ref = d.pop(slug_field, None)
+            if ref is not None:
+                if d.get(target):
+                    raise ValueError(
+                        f"draft {d.get('slug')!r}: both {target} and "
+                        f"{slug_field} given — use one"
+                    )
+                d[target] = resolve(d.get("slug"), ref)
+        refs = d.pop("related_slugs", None)
+        if refs is not None:
+            if not isinstance(refs, list):
                 raise ValueError(
-                    f"draft {d.get('slug')!r}: both supersedes and "
-                    "supersedes_slug given — use one"
+                    f"draft {d.get('slug')!r}: related_slugs must be a list"
                 )
-            if ref not in minted:
-                raise ValueError(
-                    f"supersedes_slug {ref!r} matches no slug in this batch"
-                )
-            d["supersedes"] = minted[ref]
+            existing = d.get("related") or []
+            d["related"] = existing + [resolve(d.get("slug"), r) for r in refs]
         resolved.append(d)
     return resolved
 
@@ -473,7 +493,7 @@ def cmd_record(args: argparse.Namespace) -> int:
 
     drafts = read_drafts(args)
     try:
-        drafts = resolve_batch_supersedes(drafts, now)
+        drafts = resolve_batch_refs(drafts, now)
     except ValueError as exc:
         raise fail(str(exc))
     records = []


### PR DESCRIPTION
Closes #37

## What's included

**Store subtemplate (new `guard/` subtemplate, selected via `agentic_subtemplate`):** the copier template now hosts a second subtemplate using the documented templated-`_subdirectory` pattern. `agentic_subtemplate=guard` stamps a complete decision store: the CI guard (`decision_validator.py` — the single validation source; `guards.py` — append-only checks, full-corpus schema + consistency validation, dangling refs, preferences token budget, pref-confirm counter math, repo-type commit lint; the `guards.yml` workflow) AND the vendored store docs (`docs/conventions.md`, `docs/extraction-prompt.md`, README/AGENTS/CLAUDE, `.gitignore`) plus a seeded, store-owned `preferences.md` (conditional `_skip_if_exists`, never overwritten on update). Docs travel with the schema so N stores (one per principal — person or team) cannot silently drift from it: a schema change lands once here and reaches every store via `copier update`, human-gated per store. All project-scaffold questions and post-copy tasks are gated on the default `template` choice, so existing consumers see no change and a store's answers file stays minimal.

**`tools/record.py` (stamped into projects, self-applied at root):** single-file stdlib-only recorder with a strict contract-core / IO-shell seam. Verbs: `open` (ephemeral shallow clone — or `--use «path»` to reuse an already-attached checkout where cloning is blocked, matched against `DECISION_MEMORY_URL` by owner/repo tail since proxy-rewritten remotes never match textually; SHA capture, session branch, stateless closed-unmerged-PR sweep via `closure_of`), `record` (stdin draft or `--from drafts.json` batch ingest, one commit per record), `check` (full-corpus validation), `submit` (two-stream hit rates, mechanical `pref-confirm` bumps, push, `gh` PR with managed-environment handoff fallback), `propose`.

**No committed spec file:** `record.py`'s module docstring (= `--help`) is the authoritative behavior doc — reviewed in the same diff as the code, so it cannot drift. The data contract is the vendored `docs/conventions.md` + validator; design rationale lands as backfilled decision records. One home per layer.

**`DECISION_MEMORY_URL` (breaking):** replaces `DECISION_MEMORY_REPO`; the variable now carries the full git URL. AGENTS.md, doctor.sh, and tests updated.

**Tests:** validator fixtures, guard pure functions, subtemplate render (exact file set, byte-identical vendoring, seeded-preferences survival on re-render), recorder contract core, URL-tail matching. 81 passed locally; 2 environmental failures are the host-tool smoke tests needing `gh` (absent in the dev sandbox; CI has it); all prek hooks pass except shellcheck, whose binary download the sandbox proxy blocks — CI runs it.

## Obstacles / notes

- Local test runs were silently rendering the latest **release tag** instead of the working branch (release tags exist locally; CI checkouts have none and fall back to HEAD). Fixed by pinning `vcs_ref="HEAD"` in the test render helpers — local runs now match CI.
- Validation deliberately lives in ONE file (`guard/.github/guards/decision_validator.py`); `record.py` imports the copier-vendored copy from the store checkout at runtime.
- `open --use` was verified live against a proxy-rewritten checkout (CCoW-style origin vs GitHub `DECISION_MEMORY_URL`).

## DECISION markers

- `DECISION:` (record.py, contract core) — the validator is imported from the store checkout's vendored copy (single copier-vendored source shared with CI), so writer-side and CI validation cannot drift.
- `DECISION:` (record.py, `open`) — session state lives inside the ephemeral clone (untracked file, excluded from git status); nothing persists outside the temp dir, keeping sessions stateless across machines.
- `DECISION:` (record.py, PR listing) — any `gh` failure falls through to the managed-environment handoff path; in sabotaged environments failure is an expected mode, not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dUrs8wH2HRRB4JG58bVQR