### PR TITLE
docs(agents): add rule against drift-prone prose references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Read [docs/architecture.md](docs/architecture.md) before touching any code.
 
 - Small, single-purpose files
 - Readability over brevity — straightforward, easy-to-follow code. No compact "one-liners" stretching across multiple lines (e.g. nested ternaries). Stretching across multiple lines is only allowed if it aids readability.
+- In prose, avoid facts that edits elsewhere silently invalidate — counts ("the seven examples above"), positions ("as shown below"), restated section names. Prefer edit-proof references: "the examples above", a link to the section.
 - All routes and non-trivial functions: docstring contracts (params, returns, errors)
 - Test cases cover edge cases and every `@returns` line
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -39,6 +39,7 @@ Read [docs/architecture.md](docs/architecture.md) before touching any code.
 
 - Small, single-purpose files
 - Readability over brevity — straightforward, easy-to-follow code. No compact "one-liners" stretching across multiple lines (e.g. nested ternaries). Stretching across multiple lines is only allowed if it aids readability.
+- In prose, avoid facts that edits elsewhere silently invalidate — counts ("the seven examples above"), positions ("as shown below"), restated section names. Prefer edit-proof references: "the examples above", a link to the section.
 {%- if agentic_project_kind == 'code' %}
 - All routes and non-trivial functions: docstring contracts (params, returns, errors)
 - Test cases cover edge cases and every `@returns` line


### PR DESCRIPTION
Prose facts like counts ("the seven examples above"), positions ("as shown below"), and restated section names go stale silently when the referenced content changes. Adds a Rules bullet telling agents to prefer edit-proof references instead.

Applied to both the repo's own `AGENTS.md` and `template/AGENTS.md.jinja` so generated projects pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wVPNLrDXFWDG3nVvhWJxb

---
_Generated by [Claude Code](https://claude.ai/code/session_017wVPNLrDXFWDG3nVvhWJxb)_