### PR TITLE
fix: bootstrap prek enforcement in fresh clones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,8 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
 - Implement the minimal code to pass tests, then the remaining code per the ticket spec. Place `DECISION:` markers per the `documenting-decisions` skill (refs: `decision-markers.md`, `marker-examples.md`).
 - Commit discipline:
   - One test → one commit → one implementation for that test → one commit
-  - `prek` must pass on every commit (lint/format hooks only — prek never runs unit tests).
-  - TDD red-step commits are expected and required (a commit whose new tests fail but whose lint/format passes). **CI evaluates at PR HEAD, not per-commit**, so a red-step commit does not constitute a CI failure — do not treat it as one.
+  - `prek` must pass on every commit (lint/format hooks only — prek never runs unit tests). Enforce it, don't assume it: after **every** commit run `prek run --all-files` and require exit 0 with a clean tree — an auto-fixer modifying files counts as failure; amend the fix into the commit that introduced it (per the `tdd` skill's commit protocol). The SessionStart hook (`scripts/ensure-prek.sh`) installs the git hook so dirty commits are blocked even in fresh clones; a missing prek is a `scripts/doctor.sh --install` failure, not a license to skip.
+  - TDD red-step commits are expected and required — red on **tests only**: lint, format, and type checks still pass. A test needing a not-yet-existing API surface gets a signature-only `chore(stub):` commit first (see the `tdd` skill). **CI evaluates at PR HEAD, not per-commit**, so a red-step commit does not constitute a CI failure — do not treat it as one.
   - Don't fix lint manually — run the formatter. Only touch code directly if the tools can't resolve it.
 - Push → `git push` *(plain git; git is not routed through `ghx`)*
 - Create the PR if not already present, and link it to the issue both ways → `ghx pr create` (start with `Closes #<number>` in description), then `ghx issue edit` if a back-reference is needed. **If a PR already exists for this branch, do not create or re-link it** — skip to CI.
@@ -255,6 +255,10 @@ Add packages using the package manager only, never edit requirements/dependencie
 - Document all params, return shapes, and every possible error response
 - Test cases must cover edge cases for inputs and every @returns line in the contract
 - Non-trivial decisions or behavior should be documented via inline comments
+
+## Failures Become Rules
+
+When something fails that automation or an instruction could have prevented — a lint run nobody made, a tool nobody installed, a convention discovered only in review — the fix is incomplete until the prevention is encoded: a hook, a doctor check, or a rule in the template repo's AGENTS.md/skills (preferred, so every generated repo inherits it); [docs/conventions.md](docs/conventions.md) only when it is genuinely repo-local. File the ticket on the owning repo in the same session the failure surfaced. Fixing only the instance guarantees a repeat.
 
 ## Project Conventions
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -99,14 +99,18 @@ install_tool() {
             esac
             ;;
         prek)
-            case "$mgr" in
-                brew) brew install prek ;;
-                apt)
-                    echo "Cannot auto-install prek via apt."
-                    manual_install_hint prek
-                    return 1
-                    ;;
-            esac
+            if command -v uv >/dev/null 2>&1; then
+                uv tool install prek
+            else
+                case "$mgr" in
+                    brew) brew install prek ;;
+                    apt)
+                        echo "Cannot auto-install prek via apt (and uv is missing)."
+                        manual_install_hint prek
+                        return 1
+                        ;;
+                esac
+            fi
             ;;
         *)
             echo "No install recipe for $tool."
@@ -127,6 +131,27 @@ done
 
 warn_tool ghx "not installed (deferred; agents use ghx for repo interaction)"
 
+
+# prek only bites if its git hook is installed, and hooks do not survive
+# git clone. No-op when the repo carries no prek config.
+if [[ -f .pre-commit-config.yaml ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo
+    hook_path="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || echo .git/hooks/pre-commit)"
+    if [[ -f "$hook_path" ]]; then
+        echo "✓ prek git hook"
+        pass=$((pass + 1))
+    elif [[ "$INSTALL" == true ]] && command -v prek >/dev/null 2>&1; then
+        if prek install --install-hooks >/dev/null 2>&1; then
+            echo "✓ prek git hook (just installed)"
+            pass=$((pass + 1))
+        else
+            echo "✗ prek git hook — 'prek install' failed"
+            fail=$((fail + 1))
+        fi
+    else
+        echo "⚠ prek git hook — not installed; lint-dirty commits are not blocked (run scripts/ensure-prek.sh or doctor --install)"
+    fi
+fi
 
 # Decision-memory contract (tools/record.py + grilling skill): warn when the env var is unset;
 # when set, a cheap ls-remote surfaces bad URLs / missing credentials now

--- a/scripts/ensure-prek.sh
+++ b/scripts/ensure-prek.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart bootstrap: make "prek must pass on every commit" enforceable.
+#
+# Copier runs `prek install` at generation time, but git hooks do not
+# survive `git clone` — a fresh checkout (every remote agent session)
+# has no pre-commit hook and nothing blocking lint-dirty commits.
+# Best-effort and quiet: a broken bootstrap must never block a session.
+set -u
+
+if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
+    uv tool install prek >/dev/null 2>&1 || true
+    hash -r 2>/dev/null || true
+fi
+
+if command -v prek >/dev/null 2>&1; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        prek install --install-hooks >/dev/null 2>&1 \
+            || echo "ensure-prek: 'prek install' failed — lint-dirty commits are NOT blocked; run scripts/doctor.sh" >&2
+    fi
+else
+    echo "ensure-prek: prek unavailable (and uv missing to install it) — lint-dirty commits are NOT blocked; run scripts/doctor.sh --install" >&2
+fi

--- a/template/.claude/settings.json.jinja
+++ b/template/.claude/settings.json.jinja
@@ -6,7 +6,11 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/enable-agent-shims.sh\""
-          }
+          }{% if agentic_precommit == 'prek' %},
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/ensure-prek.sh\""
+          }{% endif %}
         ]
       }
     ]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -229,9 +229,9 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
 - Commit discipline:
   - One test → one commit → one implementation for that test → one commit
 {%- if agentic_precommit == 'prek' %}
-  - `prek` must pass on every commit (lint/format hooks only — prek never runs unit tests).
+  - `prek` must pass on every commit (lint/format hooks only — prek never runs unit tests). Enforce it, don't assume it: after **every** commit run `prek run --all-files` and require exit 0 with a clean tree — an auto-fixer modifying files counts as failure; amend the fix into the commit that introduced it (per the `tdd` skill's commit protocol). The SessionStart hook (`scripts/ensure-prek.sh`) installs the git hook so dirty commits are blocked even in fresh clones; a missing prek is a `scripts/doctor.sh --install` failure, not a license to skip.
 {%- endif %}
-  - TDD red-step commits are expected and required (a commit whose new tests fail but whose lint/format passes). **CI evaluates at PR HEAD, not per-commit**, so a red-step commit does not constitute a CI failure — do not treat it as one.
+  - TDD red-step commits are expected and required — red on **tests only**: lint, format, and type checks still pass. A test needing a not-yet-existing API surface gets a signature-only `chore(stub):` commit first (see the `tdd` skill). **CI evaluates at PR HEAD, not per-commit**, so a red-step commit does not constitute a CI failure — do not treat it as one.
   - Don't fix lint manually — run the formatter. Only touch code directly if the tools can't resolve it.
 - Push → `git push` *(plain git; git is not routed through `{{ agentic_tracker_cli }}`)*
 - Create the PR if not already present, and link it to the issue both ways → `{{ agentic_tracker_cli }} pr create` (start with `Closes #<number>` in description), then `{{ agentic_tracker_cli }} issue edit` if a back-reference is needed. **If a PR already exists for this branch, do not create or re-link it** — skip to CI.
@@ -270,6 +270,10 @@ Add packages using the package manager only, never edit requirements/dependencie
 - Test cases must cover edge cases for inputs and every @returns line in the contract
 - Non-trivial decisions or behavior should be documented via inline comments
 {%- endif %}
+
+## Failures Become Rules
+
+When something fails that automation or an instruction could have prevented — a lint run nobody made, a tool nobody installed, a convention discovered only in review — the fix is incomplete until the prevention is encoded: a hook, a doctor check, or a rule in the template repo's AGENTS.md/skills (preferred, so every generated repo inherits it); [docs/conventions.md](docs/conventions.md) only when it is genuinely repo-local. File the ticket on the owning repo in the same session the failure surfaced. Fixing only the instance guarantees a repeat.
 
 ## Project Conventions
 

--- a/template/scripts/doctor.sh.jinja
+++ b/template/scripts/doctor.sh.jinja
@@ -102,14 +102,18 @@ install_tool() {
             esac
             ;;
         prek)
-            case "$mgr" in
-                brew) brew install prek ;;
-                apt)
-                    echo "Cannot auto-install prek via apt."
-                    manual_install_hint prek
-                    return 1
-                    ;;
-            esac
+            if command -v uv >/dev/null 2>&1; then
+                uv tool install prek
+            else
+                case "$mgr" in
+                    brew) brew install prek ;;
+                    apt)
+                        echo "Cannot auto-install prek via apt (and uv is missing)."
+                        manual_install_hint prek
+                        return 1
+                        ;;
+                esac
+            fi
             ;;
         *)
             echo "No install recipe for $tool."
@@ -135,6 +139,27 @@ done
 warn_tool {{ agentic_tracker_cli }} "not installed (deferred; agents use {{ agentic_tracker_cli }} for repo interaction)"
 {% endif -%}
 {% raw %}
+
+# prek only bites if its git hook is installed, and hooks do not survive
+# git clone. No-op when the repo carries no prek config.
+if [[ -f .pre-commit-config.yaml ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo
+    hook_path="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || echo .git/hooks/pre-commit)"
+    if [[ -f "$hook_path" ]]; then
+        echo "✓ prek git hook"
+        pass=$((pass + 1))
+    elif [[ "$INSTALL" == true ]] && command -v prek >/dev/null 2>&1; then
+        if prek install --install-hooks >/dev/null 2>&1; then
+            echo "✓ prek git hook (just installed)"
+            pass=$((pass + 1))
+        else
+            echo "✗ prek git hook — 'prek install' failed"
+            fail=$((fail + 1))
+        fi
+    else
+        echo "⚠ prek git hook — not installed; lint-dirty commits are not blocked (run scripts/ensure-prek.sh or doctor --install)"
+    fi
+fi
 
 # Decision-memory contract (tools/record.py + grilling skill): warn when the env var is unset;
 # when set, a cheap ls-remote surfaces bad URLs / missing credentials now

--- a/template/scripts/{% if agentic_precommit == 'prek' %}ensure-prek.sh{% endif %}
+++ b/template/scripts/{% if agentic_precommit == 'prek' %}ensure-prek.sh{% endif %}
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart bootstrap: make "prek must pass on every commit" enforceable.
+#
+# Copier runs `prek install` at generation time, but git hooks do not
+# survive `git clone` — a fresh checkout (every remote agent session)
+# has no pre-commit hook and nothing blocking lint-dirty commits.
+# Best-effort and quiet: a broken bootstrap must never block a session.
+set -u
+
+if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
+    uv tool install prek >/dev/null 2>&1 || true
+    hash -r 2>/dev/null || true
+fi
+
+if command -v prek >/dev/null 2>&1; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        prek install --install-hooks >/dev/null 2>&1 \
+            || echo "ensure-prek: 'prek install' failed — lint-dirty commits are NOT blocked; run scripts/doctor.sh" >&2
+    fi
+else
+    echo "ensure-prek: prek unavailable (and uv missing to install it) — lint-dirty commits are NOT blocked; run scripts/doctor.sh --install" >&2
+fi

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -46,7 +46,14 @@ GITHUB_ONLY_FILES = frozenset(
     }
 )
 
-EXPECTED_WITH_PREK = COMMON_FILES | GITHUB_ONLY_FILES | {".pre-commit-config.yaml"}
+EXPECTED_WITH_PREK = (
+    COMMON_FILES
+    | GITHUB_ONLY_FILES
+    | {
+        ".pre-commit-config.yaml",
+        "scripts/ensure-prek.sh",
+    }
+)
 EXPECTED_WITHOUT_PREK = COMMON_FILES | GITHUB_ONLY_FILES
 
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import copier
+import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
@@ -515,4 +516,30 @@ def test_lint_workflow_without_prek_keeps_marker_check(
         dst_path / ".github" / "workflows" / "lint.yml",
         ["git grep -nE", "::error::"],
         unexpect_strs=["prek"],
+    )
+
+
+@pytest.mark.xfail(strict=True)
+def test_prek_bootstrap_rendered_and_wired(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Template#53: prek enforcement ships with every prek-enabled render.
+
+    Copier's generation-time `prek install` task does not survive a fresh
+    `git clone`, so remote agent sessions need a SessionStart bootstrap.
+    """
+    dst_path = _render(tmp_path, base_answers, "prek-bootstrap")
+
+    assert (dst_path / "scripts" / "ensure-prek.sh").exists()
+    settings = json.loads((dst_path / ".claude" / "settings.json").read_text())
+    commands = [
+        hook["command"]
+        for group in settings["hooks"]["SessionStart"]
+        for hook in group["hooks"]
+    ]
+    assert any("ensure-prek.sh" in command for command in commands)
+    _check_file_contents(
+        dst_path / "AGENTS.md",
+        expected_strs=["prek run --all-files", "chore(stub):"],
     )

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 
 import copier
-import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
@@ -519,7 +518,6 @@ def test_lint_workflow_without_prek_keeps_marker_check(
     )
 
 
-@pytest.mark.xfail(strict=True)
 def test_prek_bootstrap_rendered_and_wired(
     tmp_path: Path,
     base_answers: dict[str, str],
@@ -543,3 +541,20 @@ def test_prek_bootstrap_rendered_and_wired(
         dst_path / "AGENTS.md",
         expected_strs=["prek run --all-files", "chore(stub):"],
     )
+
+
+def test_precommit_none_omits_prek_bootstrap(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    answers = {**base_answers, "agentic_precommit": "none"}
+    dst_path = _render(tmp_path, answers, "prek-bootstrap-none")
+
+    assert not (dst_path / "scripts" / "ensure-prek.sh").exists()
+    settings = json.loads((dst_path / ".claude" / "settings.json").read_text())
+    commands = [
+        hook["command"]
+        for group in settings["hooks"]["SessionStart"]
+        for hook in group["hooks"]
+    ]
+    assert not any("ensure-prek.sh" in command for command in commands)


### PR DESCRIPTION
Closes #53

## What

Makes "`prek` must pass on every commit" enforceable instead of aspirational — extracted from the frankify-app/disambiguate#46 review, where 7 of 9 ladder commits shipped lint-dirty because fresh remote clones have no pre-commit hook and no explicit lint-after-commit loop step.

- **`template/scripts/ensure-prek.sh`** (new, prek-only render): SessionStart bootstrap — installs prek via `uv tool install` when missing, then `prek install --install-hooks`. Best-effort and quiet; never blocks a session. Copier's generation-time `prek install` task (`copier.yml`) doesn't survive `git clone`, which is exactly the remote-session gap.
- **`template/.claude/settings.json` → `.jinja`**: conditionally wires the bootstrap as a second SessionStart hook.
- **`template/AGENTS.md.jinja`**: the prek bullet now mandates `prek run --all-files` after **every** commit (exit 0, clean tree, auto-fixer modifications = failure amended into the offending commit); the red-step bullet is now red-on-tests-only with the `chore(stub):` signature-stub rule (details live in the `tdd` skill — frankify-app/skills#13); new **Failures Become Rules** section encodes the meta-rule from the review.
- **`template/scripts/doctor.sh.jinja`**: prek install recipe prefers `uv tool install prek` (previously apt had no path at all); new check that the git pre-commit hook is actually installed, with `--install` remediation.

## Tests

TDD ladder: `test(red)` commit (strict xfail, watched failing on the missing bootstrap) → green commit implementing it, plus a `agentic_precommit: none` negative guard and the e2e expected-tree manifest update. Full suite: **97 passed, 2 skipped**; every commit verified `prek run --all-files` clean individually.

## Notes / obstacles

- `skills-lock.json` still pins the pre-#13 `tdd` skill hash — the lock's `computedHash` is not a plain sha256 of the file, so refreshing it needs the `skills` CLI after frankify-app/skills#13 merges (follow-up).
- Root `.claude/settings.json` is deliberately not self-applied — the repo root has never carried one; kept that exclusion rather than widening self-application in this PR.
- Self-apply commit (`chore: reapply template to self`) covers `AGENTS.md`, `scripts/doctor.sh`, `scripts/ensure-prek.sh`.

## DECISION markers

None in diff — behavior follows the ticket spec; the one judgment call (stub-commit vs relaxing `lint-red.sh`) is documented in the `tdd` skill PR where that protocol lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Y1kVb7zPiUcZNnFQzfTLK

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y1kVb7zPiUcZNnFQzfTLK)_