### PR TITLE
feat: converge the shared glossary on every stamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Repo: <https://github.com/frankify-app/agentic-engineering-template>
 Ubiquitous language is defined in docs/glossary/. Use
 
 ```bash
-uvx disambiguate==0.2.0 <term>
+uvx disambiguate==0.3.0 <term>
 ```
 
 to get a topologically ordered glossary disambiguating all relevant terms
@@ -18,13 +18,13 @@ to understand the given term.
 Before working on a ticket, run:
 
 ```bash
-uvx disambiguate==0.2.0 --from <ticket-file>
+uvx disambiguate==0.3.0 --from <ticket-file>
 ```
 
 or for GitHub issues:
 
 ```bash
-ghx issue view <number> --json body -q .body | uvx disambiguate==0.2.0 --from -
+ghx issue view <number> --json body -q .body | uvx disambiguate==0.3.0 --from -
 ```
 
 to resolve all referenced terms at once.

--- a/copier.yml
+++ b/copier.yml
@@ -49,8 +49,8 @@ agentic_language:
 
 agentic_disambiguate_version:
   type: str
-  help: "Pinned disambiguate version (pre-alpha — breaking changes between releases; hook and docs commands use this pin)."
-  default: "0.2.0"
+  help: "Pinned disambiguate version (pre-alpha — breaking changes between releases; hook, docs commands and the post-stamp prune use this pin)."
+  default: "0.3.0"
   when: "{{ agentic_subtemplate == 'template' }}"
 
 agentic_disambiguate_roots:
@@ -162,3 +162,10 @@ _tasks:
   - >-
     {% if agentic_subtemplate == 'template' and agentic_precommit == 'prek' %}git rev-parse --is-inside-work-tree
     >/dev/null 2>&1 && prek install || true{% else %}true{% endif %}
+  # Converge the glossary: a repo receives every shared term and keeps only the
+  # ones it links, so the orphan check needs no exemption and no repo curates
+  # the set by hand. Advisory for the same reason as the report above — an
+  # unconverged glossary is a lint finding, not a reason to lose the stamp.
+  - >-
+    {% if agentic_subtemplate == 'template' %}uvx disambiguate=={{ agentic_disambiguate_version }} prune
+    || true{% else %}true{% endif %}

--- a/copier.yml
+++ b/copier.yml
@@ -150,7 +150,12 @@ _jinja_extensions:
 # and must not install skills, run doctor, or register hooks there.
 _tasks:
   - "{% if agentic_subtemplate == 'template' %}npx skills@latest experimental_install{% else %}true{% endif %}"
-  - "{% if agentic_subtemplate == 'template' %}bash scripts/doctor.sh{% else %}true{% endif %}"
+  # Advisory, never a gate: copier rolls the whole render back on a non-zero
+  # task, so a missing host tool would lose the stamp over a report. Doctor's
+  # own exit code is untouched — a direct run still fails hard.
+  - >-
+    {% if agentic_subtemplate == 'template' %}bash scripts/doctor.sh
+    || true{% else %}true{% endif %}
   # Register prek git hooks so commits actually run them. A config file alone
   # does nothing — `prek install` must write .git/hooks. Guard on a git work
   # tree (copier may render into a plain dir) and on prek being selected.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import copier
 import pytest
+import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
@@ -189,6 +190,28 @@ def test_e2e_copy_non_english_omits_codespell(
 # Host tools the post-render _tasks invoke. Missing any → skip the smoke test
 # rather than fail, so the suite stays green on machines without the toolchain.
 SMOKE_REQUIRED_TOOLS = ("git", "npx", "uvx", "prek")
+
+
+@pytest.mark.xfail(strict=True, reason="red: the doctor task can abort a render")
+def test_reporting_tasks_cannot_roll_back_a_render() -> None:
+    """A task that reports rather than gates must not abort the run.
+
+    Copier rolls the whole render back on a non-zero task, so
+    `scripts/doctor.sh` exiting on a missing host tool loses the stamp
+    entirely. `gh` is deliberately absent from remote agent sessions —
+    the repo CLAUDE.md files say to use forge MCP tools instead — which
+    makes the abort the normal case there rather than an edge one.
+
+    Asserted on the task string because that is where the tolerance
+    lives: doctor's own exit code stays meaningful when invoked directly,
+    so CI and humans still get a hard signal.
+    """
+    tasks = yaml.safe_load((PROJECT_ROOT / "copier.yml").read_text())["_tasks"]
+    reporting = [task for task in tasks if "doctor.sh" in task]
+
+    assert reporting, "the doctor report task must still be in _tasks"
+    for task in reporting:
+        assert "|| true" in task, f"doctor task can abort a render: {task}"
 
 
 def test_e2e_prek_install_registers_git_hooks(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -192,7 +192,6 @@ def test_e2e_copy_non_english_omits_codespell(
 SMOKE_REQUIRED_TOOLS = ("git", "npx", "uvx", "prek")
 
 
-@pytest.mark.xfail(strict=True, reason="red: the doctor task can abort a render")
 def test_reporting_tasks_cannot_roll_back_a_render() -> None:
     """A task that reports rather than gates must not abort the run.
 

--- a/tests/test_shared_glossary.py
+++ b/tests/test_shared_glossary.py
@@ -147,7 +147,6 @@ def test_shared_terms_are_repo_neutral() -> None:
 PRUNE_REQUIRED_TOOLS = ("git", "npx", "uvx", "prek")
 
 
-@pytest.mark.xfail(strict=True, reason="red: no post-stamp prune task yet")
 def test_a_stamped_repo_keeps_only_the_shared_terms_it_links(
     tmp_path: Path,
     base_answers: dict[str, str],

--- a/tests/test_shared_glossary.py
+++ b/tests/test_shared_glossary.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
+import shutil
+import subprocess
 
 import copier
+import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
 SOURCE_DIR = PROJECT_ROOT / "template" / "docs" / "glossary"
@@ -138,3 +141,49 @@ def test_shared_terms_are_repo_neutral() -> None:
         assert body.startswith("## "), f"{term}: entry must open with its H2 name"
         assert "factory" not in body.lower(), f"{term}: references un-promoted term"
         assert "this repo" not in body.lower(), f"{term}: repo-specific framing"
+
+
+# Host tools the post-render _tasks invoke.
+PRUNE_REQUIRED_TOOLS = ("git", "npx", "uvx", "prek")
+
+
+@pytest.mark.xfail(strict=True, reason="red: no post-stamp prune task yet")
+def test_a_stamped_repo_keeps_only_the_shared_terms_it_links(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """The stamp converges the glossary instead of accumulating it.
+
+    A consumer receives all eight terms and keeps the ones it links, so
+    `disambiguate --lint` passes on a repo that did nothing wrong. Here
+    the README links none of them, so the whole consenting branch goes
+    and the repo's own seed term — which never consented — stays.
+
+    Runs the real task list: the convergence has to happen during the
+    stamp, or every consumer carries the same cleanup by hand.
+    """
+    missing = [tool for tool in PRUNE_REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        pytest.skip(f"post-stamp prune needs host tools on PATH: {missing}")
+
+    dst_path = tmp_path / "consumer"
+    dst_path.mkdir()
+    subprocess.run(["git", "init"], cwd=dst_path, check=True, capture_output=True)
+    (dst_path / "README.md").write_text("# Consumer\n", encoding="utf-8")
+
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=base_answers,
+        defaults=True,
+        unsafe=True,
+        vcs_ref="HEAD",
+    )
+
+    glossary = dst_path / "docs" / "glossary"
+    survivors = {path.stem for path in glossary.glob("*.md")}
+
+    assert not (survivors & SHARED_TERMS), "unlinked shared terms must be pruned"
+    assert base_answers["agentic_project_slug"] in survivors, (
+        "the repo's own seed term never consented and must survive"
+    )


### PR DESCRIPTION
Closes #67, closes #60.

A post-stamp `_task` runs `uvx disambiguate==0.3.0 prune`, so a consumer receives the full shared term set and keeps exactly the terms it links. No orphan-check exemption, no roots override, no index document, and no per-repo curation. disambiguate stays repo-local — it never learns that templates or vendoring exist, only that some terms consent to removal when nothing links them.

#60 comes along because it has to: doctor exits non-zero on a missing host tool, copier rolls the whole render back on a non-zero task, and `gh` is deliberately absent from remote agent sessions. Without that fix the prune task never runs in the environment the fleet is actually stamped from — and the two e2e tests that exercise the real task list were already red there, on `main`.

## Changes

| | |
| --- | --- |
| `copier.yml` | doctor task becomes advisory; new prune task gated on the `template` subtemplate; pin default 0.2.0 → 0.3.0 |
| `AGENTS.md` | render output — the pin in its Terminology commands |
| `tests/test_e2e.py` | a reporting task must not be able to roll back a render |
| `tests/test_shared_glossary.py` | a stamped repo keeps only the shared terms it links, exercised through the real task list |

Both tasks are advisory. An unconverged glossary is a lint finding; losing a whole stamp over a cleanup step is the worse failure.

## #67's open question, answered

Whether a downstream-deleted vendored term stays deleted across a later `copier update` — **it does**, and the interesting half is that it stays deleted even when the term changes upstream.

Probed on a throwaway consumer stamped at v3.0.0: deleted four of the eight terms, then updated to this branch from a template clone carrying an edit to one deleted term (`session`) and one kept term (`decision-record`).

- the four deleted terms did not return — no `.rej`, no conflict, nothing to resolve
- the kept term received its upstream edit

So prune converges once rather than fighting the template on every stamp. The consequence to know: a repo that pruned a term stops tracking upstream edits to it, and if it later starts linking that term it has to re-add the file — the stamp will not bring it back. That is the intended reading of "converge to exactly the terms it links", not a gap.

## One consequence the ticket did not name

A *fresh* render has no root document — the template ships no README — so prune cannot resolve reachability and no-ops there. A brand-new project therefore starts with eight orphans and its first commit's lint hook is what prompts the author. The update path (every existing consumer) is unaffected. Worth a follow-up: either seed a README under `_skip_if_exists` or have the seed term document the choice.

## Restamping consumers

Pass the new pin explicitly:

```
copier update -a .copier-answers.agentic.yml --defaults --trust \
  --data agentic_disambiguate_version=0.3.0 <dst>
```

A recorded answer of `0.2.0` runs a version with no `prune` verb, and the task's tolerance would swallow that silently.

## Verification

- 113 tests pass, including the two task-running e2e tests that were red on `main` in any environment without `gh`
- `prek run --all-files` exit 0, no files modified
- self-application gate green after the reapply commit; `uvx disambiguate==0.3.0 prune` on this repo is a no-op, since it links all nine of its terms


---
_Generated by [Claude Code](https://claude.ai/code/session_013bmY2VqQ4S6gR8NJ7TjW1G)_