### PR TITLE
docs(decision-memory): add the pre-merge link pass to adjudicate-drafts

### DIFF
--- a/decision-memory/.agents/skills/adjudicate-drafts/SKILL.md
+++ b/decision-memory/.agents/skills/adjudicate-drafts/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: adjudicate-drafts
-description: Resolve the ingestion gate's flagged draft clusters before ingestion. Use when drafts are flagged duplicate, re-decision or uncertain, or before ingesting a drafts batch.
+description: Resolve the ingestion gate's flagged clusters — in drafts before ingestion, in a branch's records before merge. Use when drafts are flagged duplicate/re-decision/uncertain, or before merging any PR that adds decision records.
 ---
 
-# Adjudicating flagged drafts before ingestion
+# Adjudicating flagged records
 
 > Copier-vendored from the agentic-engineering-template decision-memory
 > subtemplate — do NOT edit it in the store repo;
@@ -11,6 +11,14 @@ description: Resolve the ingestion gate's flagged draft clusters before ingestio
 
 The gate finds clusters and does not resolve them. This skill turns
 each cluster into a decision the human answers in one pass.
+
+Two moments, and every record-adding PR hits at least the second:
+
+1. **Drafts, before ingestion** — sections 1-5. The full remedy set is
+   available because nothing is written yet.
+2. **A branch's records, before merge** — the pre-merge link pass at
+   the end. A session that recorded natively through the recorder
+   never had drafts and starts there.
 
 `decisions/` is append-only with no carve-out: after ingestion a
 duplicate cannot be withdrawn and a missing link cannot be added.
@@ -124,9 +132,88 @@ Then, while the drafts are still mutable:
 
 ## Afterwards
 
-Ingest through the recorder. The records are immutable from that
-moment.
+Ingest through the recorder, then run the pre-merge link pass below
+before the PR merges.
 
 A ruling worth remembering from this pass — a policy on when two
 extractions count as one decision, say — is a decision like any other
 and belongs in a grilling session, not here.
+
+## The pre-merge link pass
+
+Run this on **every** record-adding PR, drafts or not, immediately
+before merge. A session that recorded natively through the recorder
+never had drafts and so never ran the sections above — this pass is the
+part that still applies to it.
+
+**Why immediately before merge.** At record time the corpus is whatever
+`main` was then; other PRs land in between. Merge is the last moment
+the corpus is complete AND the branch is still mutable. Records are not
+immutable until merge — merging is the acceptance, and
+`docs/conventions.md` § PR flow already sanctions hand-editing the
+branch before it.
+
+```bash
+git rebase origin/main
+python .github/store/similarity.py --out /tmp/gate.json
+```
+
+Rebase first, or the gate checks against a corpus missing everything
+merged since the branch was cut.
+
+### What you can do here, and what you cannot
+
+The remedy set is narrower than for drafts. The records exist as
+commits, so there is no `discarded-drafts.json` to move anything into.
+
+| Remedy | Available |
+| --- | --- |
+| Add a link | yes — the point of this pass |
+| Drop the record | only by dropping its commit |
+| Discard to `discarded-drafts.json` | no — that is a drafts-only remedy |
+| Edit the record on the other side | **never** — it is merged and immutable |
+
+Amending a record already committed on this branch is fine: the
+append-only guard diffs `base...HEAD`, so a record added and later
+amended within one PR still reads as an addition.
+
+### Links only ever point backwards
+
+A link target must already exist in `decisions/` — the validator
+rejects a dangling ref, and correctly, since a record must not point at
+something that may never merge.
+
+So two PRs open at once cannot reference each other. **The edge is
+written by whichever merges second**, pointing back at the first, and
+the first can never gain the reverse edge once it is merged.
+
+That is why this pass has to run on every PR rather than only on ones
+that looked interesting at record time: applied uniformly, the
+second-merging PR always catches the pair, and nothing has to see
+across open PRs at all.
+
+### Judging what surfaces
+
+Most pairs will be noise. Containment on a short record fires easily —
+most of a five-token record is contained in anything sharing two of its
+words — so read the questions, not the score.
+
+The judgement is different from the drafts case. There, the question is
+*"are these one ruling?"* Here both records are staying, so the
+question is only *"does an edge belong between them, and which way?"*
+
+- **`related`** — two rulings that inform each other.
+- **`supersedes`** — the later one replaces the earlier. Only when it
+  genuinely overrides; a later ruling that refined or re-confirmed the
+  same answer is `related`.
+- **nothing** — same subject, independent rulings. A legitimate
+  outcome; record that you looked.
+
+Two records sharing a slug are worth reading closely and are **not**
+thereby duplicates. Slugs follow the topic, so two rulings on one topic
+collide naturally — the deliberation tells you which it is: option
+count, rejection depth, and whether the outcome was a plain hit or a
+refinement.
+
+Commit the links as `chore:` — they are not new decisions, and no other
+commit type fits.

--- a/decision-memory/.agents/skills/adjudicate-drafts/SKILL.md
+++ b/decision-memory/.agents/skills/adjudicate-drafts/SKILL.md
@@ -141,79 +141,51 @@ and belongs in a grilling session, not here.
 
 ## The pre-merge link pass
 
-Run this on **every** record-adding PR, drafts or not, immediately
-before merge. A session that recorded natively through the recorder
-never had drafts and so never ran the sections above — this pass is the
-part that still applies to it.
+Run on **every** record-adding PR, immediately before merge. A session
+that recorded natively never had drafts and starts here.
 
-**Why immediately before merge.** At record time the corpus is whatever
-`main` was then; other PRs land in between. Merge is the last moment
-the corpus is complete AND the branch is still mutable. Records are not
-immutable until merge — merging is the acceptance, and
-`docs/conventions.md` § PR flow already sanctions hand-editing the
-branch before it.
+Rebase first, or the gate checks against a corpus missing everything
+merged since the branch was cut.
 
 ```bash
 git rebase origin/main
 python .github/store/similarity.py --out /tmp/gate.json
 ```
 
-Rebase first, or the gate checks against a corpus missing everything
-merged since the branch was cut.
+Amending a record already committed on this branch is fine — the
+append-only guard diffs `base...HEAD`, so a record added and later
+amended in one PR still reads as an addition.
 
-### What you can do here, and what you cannot
-
-The remedy set is narrower than for drafts. The records exist as
-commits, so there is no `discarded-drafts.json` to move anything into.
+### Remedies
 
 | Remedy | Available |
 | --- | --- |
-| Add a link | yes — the point of this pass |
+| Add a link | yes |
 | Drop the record | only by dropping its commit |
-| Discard to `discarded-drafts.json` | no — that is a drafts-only remedy |
-| Edit the record on the other side | **never** — it is merged and immutable |
+| Discard to `discarded-drafts.json` | no — drafts only |
+| Edit the record on the other side | never — merged and immutable |
 
-Amending a record already committed on this branch is fine: the
-append-only guard diffs `base...HEAD`, so a record added and later
-amended within one PR still reads as an addition.
+### Links point backwards only
 
-### Links only ever point backwards
+A link target must already exist in `decisions/`; the validator rejects
+a dangling ref. Two open PRs therefore cannot reference each other:
+**the edge is written by whichever merges second**, and the first never
+gains the reverse edge.
 
-A link target must already exist in `decisions/` — the validator
-rejects a dangling ref, and correctly, since a record must not point at
-something that may never merge.
+Run the pass on every PR and the second one always catches the pair.
 
-So two PRs open at once cannot reference each other. **The edge is
-written by whichever merges second**, pointing back at the first, and
-the first can never gain the reverse edge once it is merged.
+### Judging
 
-That is why this pass has to run on every PR rather than only on ones
-that looked interesting at record time: applied uniformly, the
-second-merging PR always catches the pair, and nothing has to see
-across open PRs at all.
-
-### Judging what surfaces
-
-Most pairs will be noise. Containment on a short record fires easily —
-most of a five-token record is contained in anything sharing two of its
-words — so read the questions, not the score.
-
-The judgement is different from the drafts case. There, the question is
-*"are these one ruling?"* Here both records are staying, so the
-question is only *"does an edge belong between them, and which way?"*
+Read the questions, not the score — containment fires easily on short
+records.
 
 - **`related`** — two rulings that inform each other.
-- **`supersedes`** — the later one replaces the earlier. Only when it
-  genuinely overrides; a later ruling that refined or re-confirmed the
-  same answer is `related`.
-- **nothing** — same subject, independent rulings. A legitimate
-  outcome; record that you looked.
+- **`supersedes`** — the later genuinely overrides. A later ruling that
+  refined or re-confirmed the same answer is `related`.
+- **nothing** — independent. A legitimate outcome; say you looked.
 
-Two records sharing a slug are worth reading closely and are **not**
-thereby duplicates. Slugs follow the topic, so two rulings on one topic
-collide naturally — the deliberation tells you which it is: option
-count, rejection depth, and whether the outcome was a plain hit or a
-refinement.
+A shared slug is not a duplicate. Slugs follow the topic, so two
+rulings on one topic collide. Tell them apart by option count,
+rejection depth, and whether the outcome was a hit or a refinement.
 
-Commit the links as `chore:` — they are not new decisions, and no other
-commit type fits.
+Commit links as `chore:`.


### PR DESCRIPTION
Closes the discovery half of #87.

## The two gaps

The gate's remedies were all drafts-side, which left records unreachable in two situations:

1. **A session that records natively** through the recorder never produces drafts, so it never ran the gate at all.
2. **Even a batch that did run it** was gated against the corpus as it stood at record time. Other PRs land in between, so the check was already stale by the time the PR merged.

Both were found on real data: two records on one subject, one merged and one in an open PR, with no link between them and no moment at which anything would have proposed one.

## The pass

Runs on **every** record-adding PR, immediately before merge and after rebasing — the last moment the corpus is complete and the branch is still mutable.

That window exists and is already sanctioned:

- `check_append_only` diffs `base...HEAD`, so a record added and later amended within one PR still reads as an addition. An ordinary follow-up commit works; no history rewriting.
- `docs/conventions.md` § PR flow: *"Partial accept = hand-edit the branch, drop or revert individual commits before merge."* Merging **is** the acceptance.

## The ordering constraint is documented, not worked around

A link target must already exist in `decisions/` — the validator rejects a dangling ref, correctly, since a record must not point at something that may never merge.

So two open PRs cannot reference each other. The edge is written by **whichever merges second**, pointing back at the first, and the first can never gain the reverse edge.

**Applied uniformly that is sufficient.** The later PR always sees the earlier one, so nothing needs to read across open PRs — which is why this PR closes #87's discovery problem without building the cross-PR machinery that ticket originally proposed.

## Narrower remedy set, stated plainly

| Remedy | Available |
| --- | --- |
| Add a link | yes — the point of the pass |
| Drop the record | only by dropping its commit |
| Discard to `discarded-drafts.json` | no — drafts-only |
| Edit the other side | never — merged and immutable |

## A shared slug is not evidence of a duplicate

Documented explicitly, because the real pair that motivated this looks exactly like a duplicate and is not: same slug, same final answer, but one record has a single option and no rejections while the other has four options, five rejections and a `refined` outcome.

Slugs follow the topic, so two rulings on one topic collide naturally. That pair scored **0.08 jaccard / 0.40 containment** — below both channels. The scoring fix stays in #87; this documents the judgement so nobody discards a record on a slug match.

## Description broadened

A natively-recorded session would not otherwise load this skill — the old description only mentioned drafts.

## Verified

115 template tests, 120 store tests, all hooks green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJ7c5rzeXMCMvZTofawmwn)_