### PR TITLE
Add AGENTS.md rule: avoid drift-prone prose references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Read [docs/architecture.md](docs/architecture.md) before touching any code.
 - Small, single-purpose files
 - Readability over brevity — straightforward, easy-to-follow code. No compact "one-liners" stretching across multiple lines (e.g. nested ternaries). Stretching across multiple lines is only allowed if it aids readability.
 - When removing a feature, erase every mention of it — docs, help text, comments, tests. Don't leave "no longer supported" notes: readers who never knew it existed pay to learn it did. State what is, not what stopped being. (Migration notes belong in the commit's `BREAKING CHANGE:` footer, which is where someone upgrading looks.)
+- In prose, don't state facts maintained elsewhere — counts ("the seven examples above"), far positional references, restated section names. Link the target instead. Immediate-adjacency words ("the examples above", "the following table") are fine — they only break if adjacency breaks.
 - All routes and non-trivial functions: docstring contracts (params, returns, errors)
 - Test cases cover edge cases and every `@returns` line
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -40,6 +40,7 @@ Read [docs/architecture.md](docs/architecture.md) before touching any code.
 - Small, single-purpose files
 - Readability over brevity — straightforward, easy-to-follow code. No compact "one-liners" stretching across multiple lines (e.g. nested ternaries). Stretching across multiple lines is only allowed if it aids readability.
 - When removing a feature, erase every mention of it — docs, help text, comments, tests. Don't leave "no longer supported" notes: readers who never knew it existed pay to learn it did. State what is, not what stopped being. (Migration notes belong in the commit's `BREAKING CHANGE:` footer, which is where someone upgrading looks.)
+- In prose, don't state facts maintained elsewhere — counts ("the seven examples above"), far positional references, restated section names. Link the target instead. Immediate-adjacency words ("the examples above", "the following table") are fine — they only break if adjacency breaks.
 {%- if agentic_project_kind == 'code' %}
 - All routes and non-trivial functions: docstring contracts (params, returns, errors)
 - Test cases cover edge cases and every `@returns` line


### PR DESCRIPTION
Closes #48

Supersedes #51 — that branch's base rotted (conflict), so its two commits are replayed on current `main`.

**`feat`** — one bullet in `## Rules` of `template/AGENTS.md.jinja`, outside the `agentic_project_kind == 'code'` conditional so every project kind gets it:

> In prose, don't state facts maintained elsewhere — counts ("the seven examples above"), far positional references, restated section names. Link the target instead. Immediate-adjacency words ("the examples above", "the following table") are fine — they only break if adjacency breaks.

**`chore`** — reapply template to self, per docs/conventions.md § Template-First Changes. Root `AGENTS.md` adopted verbatim from the render.

Rebase notes: #51 also carried the whole `### Avoid Duplication` section, which landed on `main` in the meantime (identical text) — dropped as already-present, leaving the single bullet. The stale reapply commit was discarded and the render re-run against current `HEAD`; `tests/test_self_application.py` named `AGENTS.md` as the only file to adopt.

Verification: `prek run --all-files` clean, `uv run pytest` 115 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTFdJpy3hjgHZc2u7UGDgi)_