### PR TITLE
refactor: extract the shared record cores so a second store can compose on them

### DIFF
--- a/decision-memory/.github/guards/decision_validator.py
+++ b/decision-memory/.github/guards/decision_validator.py
@@ -16,14 +16,29 @@ working, only updates stop).
 All validators return a list of human-readable error strings (empty =
 valid) and TOLERATE unknown fields: new optional fields need no
 migration.
+
+The store-independent half — ID grammar, envelope, required-field
+presence, corpus link integrity — lives in ``validator_core.py`` next
+to this file and is shared with every other store's validator. What
+stays here is the decision contract itself.
 """
 
 from __future__ import annotations
 
+import os
 import re
+import sys
 
-SCHEMA_VERSION = 1
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validator_core  # noqa: E402  (path bootstrap above)
+
+SCHEMA_VERSION = validator_core.SCHEMA_VERSION
 RECORD_TYPE = "decision"
+
+# The store's own link vocabulary, walked by the corpus check.
+LINK_FIELDS = ("related", "supersedes", "drill_down_of")
+STORE_DIR = "decisions"
 
 REQUIRED_FIELDS = (
     "v",
@@ -57,9 +72,9 @@ PRESUMED_REASON_SOURCES = frozenset({"if_clause", "inferred", "none"})
 # silent pick: the decider chose without stating a reason.
 OPERATIVE_REASON_SOURCES = frozenset({"stated", "none"})
 
-MAX_SLUG_LENGTH = 40
-ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
-DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+MAX_SLUG_LENGTH = validator_core.MAX_SLUG_LENGTH
+ID_RE = validator_core.ID_RE
+DATE_RE = validator_core.DATE_RE
 
 # Single source for the preferences counter-line grammar
 # ("[confirmed: N, last: YYYY-MM-DD]"): the guard's counter-math check
@@ -78,35 +93,12 @@ def estimate_tokens(text: str) -> int:
     return len(text) // CHARS_PER_TOKEN
 
 
-def validate_id(record_id: object) -> list[str]:
-    """Check the ID grammar: <YYYYMMDDTHHMMSSZ>-<kebab-slug>, slug <= 40."""
-    if not isinstance(record_id, str):
-        return ["id: must be a string"]
-    match = ID_RE.match(record_id)
-    if not match:
-        return [
-            f"id: {record_id!r} does not match "
-            "<UTC-timestamp>Z-<kebab-slug> (lowercase kebab-case slug)"
-        ]
-    slug = match.group(2)
-    if len(slug) > MAX_SLUG_LENGTH:
-        return [f"id: slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})"]
-    return []
+validate_id = validator_core.validate_id
 
 
 def validate_envelope(record: dict) -> list[str]:
-    """Check the universal envelope: v, type, id."""
-    errors: list[str] = []
-    v = record.get("v")
-    if not isinstance(v, int) or isinstance(v, bool) or v < 1:
-        errors.append("v: must be a positive integer schema version")
-    record_type = record.get("type")
-    if record_type != RECORD_TYPE:
-        errors.append(
-            f"type: must be {RECORD_TYPE!r} in this repo, got {record_type!r}"
-        )
-    errors.extend(validate_id(record.get("id")))
-    return errors
+    """Check the universal envelope against this store's record type."""
+    return validator_core.validate_envelope(record, RECORD_TYPE)
 
 
 def _validate_options(record: dict, errors: list[str]) -> dict | None:
@@ -352,9 +344,7 @@ def validate_record(record: object, filename_stem: str | None = None) -> list[st
     if not isinstance(record, dict):
         return ["record: must be a JSON object"]
     errors = validate_envelope(record)
-    for field in REQUIRED_FIELDS:
-        if field not in record:
-            errors.append(f"{field}: required field missing")
+    errors.extend(validator_core.validate_required(record, REQUIRED_FIELDS))
     if filename_stem is not None and record.get("id") != filename_stem:
         errors.append(
             f"id: {record.get('id')!r} does not equal the filename stem "
@@ -368,30 +358,13 @@ def validate_record(record: object, filename_stem: str | None = None) -> list[st
 
 
 def validate_corpus(records: dict) -> list[str]:
-    """Cross-record checks: no dangling related/supersedes/drill_down_of.
+    """Cross-record checks: no dangling link into a record that is not
+    in the corpus.
 
     ``records`` maps record ID -> record dict (normally the whole
     ``decisions/`` directory).
     """
-    errors: list[str] = []
-    for record_id, record in sorted(records.items()):
-        if not isinstance(record, dict):
-            continue
-        refs = []
-        related = record.get("related")
-        if isinstance(related, list):
-            refs.extend(("related", ref) for ref in related)
-        for link_field in ("supersedes", "drill_down_of"):
-            ref = record.get(link_field)
-            if ref is not None:
-                refs.append((link_field, ref))
-        for field, ref in refs:
-            if ref not in records:
-                errors.append(
-                    f"{record_id}: {field} points to {ref!r}, "
-                    "which does not exist in decisions/"
-                )
-    return errors
+    return validator_core.validate_corpus(records, LINK_FIELDS, STORE_DIR)
 
 
 def check_preferences_budget(

--- a/decision-memory/.github/guards/validator_core.py
+++ b/decision-memory/.github/guards/validator_core.py
@@ -1,0 +1,97 @@
+"""Universal validation core — the checks every store's records share.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+a store repo; change it in the template and pull via `copier update`.
+
+The reading-side mirror of ``record_core.py``: one writer core and one
+validation core serve every store, and only lifecycle policy differs
+per store. What lives here is what cannot know which store it is
+checking — ID grammar, the envelope, required-field presence, and link
+integrity across a corpus. Which fields are required, which links
+exist, and what a record means are the store's own contract, and
+arrive as arguments.
+
+Stdlib only, so a guard runs with no install step.
+"""
+
+from __future__ import annotations
+
+import re
+
+SCHEMA_VERSION = 1
+MAX_SLUG_LENGTH = 40
+ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def validate_id(record_id: object) -> list[str]:
+    """Check the ID grammar: <YYYYMMDDTHHMMSSZ>-<kebab-slug>, slug <= 40."""
+    if not isinstance(record_id, str):
+        return ["id: must be a string"]
+    match = ID_RE.match(record_id)
+    if not match:
+        return [
+            f"id: {record_id!r} does not match "
+            "<UTC-timestamp>Z-<kebab-slug> (lowercase kebab-case slug)"
+        ]
+    slug = match.group(2)
+    if len(slug) > MAX_SLUG_LENGTH:
+        return [f"id: slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})"]
+    return []
+
+
+def validate_envelope(record: dict, record_type: str) -> list[str]:
+    """Check the universal envelope: v, type, id.
+
+    ``record_type`` is the type this store's records must carry — the
+    envelope routes records in a mixed ledger, so which value is
+    correct is the store's policy rather than the core's.
+    """
+    errors: list[str] = []
+    v = record.get("v")
+    if not isinstance(v, int) or isinstance(v, bool) or v < 1:
+        errors.append("v: must be a positive integer schema version")
+    actual = record.get("type")
+    if actual != record_type:
+        errors.append(f"type: must be {record_type!r} in this repo, got {actual!r}")
+    errors.extend(validate_id(record.get("id")))
+    return errors
+
+
+def validate_required(record: dict, required_fields: tuple) -> list[str]:
+    """Report every required field the record does not carry."""
+    return [
+        f"{field}: required field missing"
+        for field in required_fields
+        if field not in record
+    ]
+
+
+def validate_corpus(records: dict, link_fields: tuple, store_dir: str) -> list[str]:
+    """Check that no link points outside the corpus.
+
+    ``records`` maps record ID -> record dict (normally a whole store
+    directory). ``link_fields`` is the store's own link vocabulary; a
+    field's value may be a single reference or a list of them, so both
+    are walked. ``store_dir`` only names the directory in the message.
+
+    A dangling reference is an error rather than a warning because a
+    record must not point at something that may never exist: records
+    are immutable, so a link that is wrong when written stays wrong.
+    """
+    errors: list[str] = []
+    for record_id, record in sorted(records.items()):
+        if not isinstance(record, dict):
+            continue
+        for field in link_fields:
+            value = record.get(field)
+            if value is None:
+                continue
+            refs = value if isinstance(value, list) else [value]
+            for ref in refs:
+                if ref not in records:
+                    errors.append(
+                        f"{record_id}: {field} points to {ref!r}, "
+                        f"which does not exist in {store_dir}/"
+                    )
+    return errors

--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -43,8 +43,10 @@ session's PR to that session's own records. Where cloning is
 impossible, run the copy inside whatever store checkout is available
 — same invariant, no special flag.
 
-Stdlib only. The file is split into a pure CONTRACT CORE (the dojo
-lift-target) and an IO SHELL; keep the seam strict.
+Stdlib only. The universal half of the contract lives in
+``record_core.py``, shared with every other store's writer; what stays
+here is this store's own policy and its IO SHELL. Keep the seam
+strict.
 """
 
 from __future__ import annotations
@@ -60,21 +62,31 @@ import subprocess
 import sys
 from pathlib import Path
 
-# ========================== contract core ==========================
-# Pure functions, no IO — the functions a future dojo package lifts
-# verbatim. Validation is deliberately NOT defined here:
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import record_core  # noqa: E402  (path bootstrap above)
+
+# ======================= store record policy ========================
+# The universal contract — envelope grammar, ID minting, field
+# ordering, serialization, batch-ref resolution — lives in
+# record_core.py, one copy shared by every store's writer. It is
+# re-exported here so this module's public surface is unchanged.
 # DECISION: the validator is imported from the data-repo clone's
 # vendored copy (single copier-vendored source shared with CI), so
-# writer-side and CI validation cannot drift.
+# writer-side and CI validation cannot drift. That is why validation
+# is defined neither here nor in the core.
 
-# Mint-side mirror of the envelope/ID grammar. The vendored
-# decision_validator in the store checkout stays authoritative —
-# minted records are re-validated against it; these constants only
-# make minting fail fast with better messages.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = record_core.SCHEMA_VERSION
+MAX_SLUG_LENGTH = record_core.MAX_SLUG_LENGTH
+SLUG_RE = record_core.SLUG_RE
+
+mint_id = record_core.mint_id
+serialize_record = record_core.serialize_record
+resolve_batch_refs = record_core.resolve_batch_refs
+
+# What makes a record from this store a decision rather than any other
+# kind sharing the envelope.
 RECORD_TYPE = "decision"
-MAX_SLUG_LENGTH = 40
-SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 # Replay-ready order: envelope, then input side (pre-ruling), then
 # output side (post-ruling), then links. Unknown fields keep their
@@ -106,23 +118,9 @@ FIELD_ORDER = (
 )
 
 
-def mint_id(slug: str, now: dt.datetime) -> str:
-    """Mint a record ID: <UTC timestamp>Z-<slug>."""
-    if not SLUG_RE.match(slug):
-        raise ValueError(f"slug {slug!r} must be lowercase kebab-case ([a-z0-9-])")
-    if len(slug) > MAX_SLUG_LENGTH:
-        raise ValueError(f"slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})")
-    timestamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return f"{timestamp}-{slug}"
-
-
 def mint_envelope(slug: str, now: dt.datetime) -> dict:
-    """Mint the universal envelope: v, type, id."""
-    return {
-        "v": SCHEMA_VERSION,
-        "type": RECORD_TYPE,
-        "id": mint_id(slug, now),
-    }
+    """Mint this store's envelope: v, type, id."""
+    return record_core.mint_envelope(slug, now, RECORD_TYPE)
 
 
 def draft_to_record(
@@ -153,68 +151,7 @@ def draft_to_record(
         merged["preference_set"] = preference_set
     merged.update(payload)
 
-    record = {key: merged[key] for key in FIELD_ORDER if key in merged}
-    for key, value in merged.items():
-        if key not in record:
-            record[key] = value
-    return record
-
-
-def serialize_record(record: dict) -> str:
-    """Serialize a record for its immutable decisions/<id>.json file."""
-    return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
-
-
-def resolve_batch_refs(drafts: list, now: dt.datetime) -> list:
-    """Resolve batch-local slug references to minted IDs.
-
-    Drafts extracted from one conversation cannot know each other's
-    final IDs, so cross-draft links name their target by slug:
-    ``supersedes_slug`` and ``drill_down_of_slug`` (single),
-    ``related_slugs`` (list, appended to any repo-ID ``related``
-    entries). This maps every reference to the ID the batch will mint
-    (order-independent). Raises ValueError on unknown slugs or when a
-    draft carries both a slug reference and its resolved field.
-    """
-    minted = {}
-    for d in drafts:
-        slug = d.get("slug")
-        if isinstance(slug, str) and SLUG_RE.match(slug):
-            minted[slug] = mint_id(slug, now)
-
-    def resolve(draft_slug, ref):
-        if ref not in minted:
-            raise ValueError(
-                f"draft {draft_slug!r}: batch reference {ref!r} matches "
-                "no slug in this batch"
-            )
-        return minted[ref]
-
-    resolved = []
-    for d in drafts:
-        d = dict(d)
-        for slug_field, target in (
-            ("supersedes_slug", "supersedes"),
-            ("drill_down_of_slug", "drill_down_of"),
-        ):
-            ref = d.pop(slug_field, None)
-            if ref is not None:
-                if d.get(target):
-                    raise ValueError(
-                        f"draft {d.get('slug')!r}: both {target} and "
-                        f"{slug_field} given — use one"
-                    )
-                d[target] = resolve(d.get("slug"), ref)
-        refs = d.pop("related_slugs", None)
-        if refs is not None:
-            if not isinstance(refs, list):
-                raise ValueError(
-                    f"draft {d.get('slug')!r}: related_slugs must be a list"
-                )
-            existing = d.get("related") or []
-            d["related"] = existing + [resolve(d.get("slug"), r) for r in refs]
-        resolved.append(d)
-    return resolved
+    return record_core.order_fields(merged, FIELD_ORDER)
 
 
 # ============================ IO shell =============================

--- a/decision-memory/tools/record_core.py
+++ b/decision-memory/tools/record_core.py
@@ -1,0 +1,124 @@
+"""Universal record contract core — the write format every store shares.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+a store repo; change it in the template and pull via `copier update`.
+
+Pure functions, no IO: this is the dojo lift-target, the part a future
+dojo package lifts verbatim. Everything here is common to every record
+kind. What a store calls its fields, and which of them it writes
+first, is that store's own policy and arrives as data.
+
+Validation is deliberately NOT defined here: each store's validator is
+vendored beside its own records, so writer-side and CI validation
+cannot drift.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+
+# Mint-side mirror of the envelope/ID grammar. The vendored validator
+# in a store checkout stays authoritative — minted records are
+# re-validated against it; these constants only make minting fail fast
+# with better messages.
+SCHEMA_VERSION = 1
+MAX_SLUG_LENGTH = 40
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def mint_id(slug: str, now: dt.datetime) -> str:
+    """Mint a record ID: <UTC timestamp>Z-<slug>."""
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"slug {slug!r} must be lowercase kebab-case ([a-z0-9-])")
+    if len(slug) > MAX_SLUG_LENGTH:
+        raise ValueError(f"slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})")
+    timestamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{slug}"
+
+
+def mint_envelope(slug: str, now: dt.datetime, record_type: str) -> dict:
+    """Mint the universal envelope: v, type, id.
+
+    ``record_type`` is what routes a record in a mixed ledger, so it is
+    the calling store's to supply rather than a constant here.
+    """
+    return {
+        "v": SCHEMA_VERSION,
+        "type": record_type,
+        "id": mint_id(slug, now),
+    }
+
+
+def order_fields(merged: dict, field_order: tuple) -> dict:
+    """Order a record's fields by its store's declared order.
+
+    Fields the order does not name keep their incoming order after the
+    ones it does, so an unrecognized field is preserved rather than
+    silently dropped.
+    """
+    record = {key: merged[key] for key in field_order if key in merged}
+    for key, value in merged.items():
+        if key not in record:
+            record[key] = value
+    return record
+
+
+def serialize_record(record: dict) -> str:
+    """Serialize a record for its immutable ``<id>.json`` file."""
+    return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+def resolve_batch_refs(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local slug references to minted IDs.
+
+    Drafts written in one pass cannot know each other's final IDs, so
+    cross-draft links name their target by slug: ``supersedes_slug``
+    and ``drill_down_of_slug`` (single), ``related_slugs`` (list,
+    appended to any repo-ID ``related`` entries). This maps every
+    reference to the ID the batch will mint (order-independent).
+    Raises ValueError on unknown slugs or when a draft carries both a
+    slug reference and its resolved field.
+    """
+    minted = {}
+    for d in drafts:
+        slug = d.get("slug")
+        if isinstance(slug, str) and SLUG_RE.match(slug):
+            minted[slug] = mint_id(slug, now)
+
+    def resolve(draft_slug, ref):
+        if ref not in minted:
+            raise ValueError(
+                f"draft {draft_slug!r}: batch reference {ref!r} matches "
+                "no slug in this batch"
+            )
+        return minted[ref]
+
+    resolved = []
+    for d in drafts:
+        d = dict(d)
+        for slug_field, target in (
+            ("supersedes_slug", "supersedes"),
+            ("drill_down_of_slug", "drill_down_of"),
+        ):
+            ref = d.pop(slug_field, None)
+            if ref is not None:
+                if d.get(target):
+                    raise ValueError(
+                        f"draft {d.get('slug')!r}: both {target} and "
+                        f"{slug_field} given — use one"
+                    )
+                d[target] = resolve(d.get("slug"), ref)
+        refs = d.pop("related_slugs", None)
+        if refs is not None:
+            if not isinstance(refs, list):
+                raise ValueError(
+                    f"draft {d.get('slug')!r}: related_slugs must be a list"
+                )
+            existing = d.get("related") or []
+            d["related"] = existing + [resolve(d.get("slug"), r) for r in refs]
+        resolved.append(d)
+    return resolved

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -23,6 +23,7 @@ STORE_FILES = frozenset(
         ".copier-answers.agentic.yml",
         ".github/guards/decision_validator.py",
         ".github/guards/guards.py",
+        ".github/guards/validator_core.py",
         ".github/store/README.md",
         ".github/store/budget.py",
         ".github/store/config.py",

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -43,6 +43,7 @@ STORE_FILES = frozenset(
         "preferences.md",
         "store.config.json",
         "tools/record.py",
+        "tools/record_core.py",
     }
 )
 

--- a/tests/test_record_core_shared.py
+++ b/tests/test_record_core_shared.py
@@ -1,0 +1,78 @@
+"""Tests for the shared record contract core (``record_core.py``).
+
+The core is what a second store's writer composes on: the universal
+envelope/ID grammar and serialization, carrying no vocabulary from any
+one store's schema. ``test_record_core.py`` covers the decision
+writer's own surface and is the regression guard that extracting this
+core did not change it.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+CORE_PATH = PROJECT_ROOT / "decision-memory" / "tools" / "record_core.py"
+
+core = load_module("record_core", CORE_PATH)
+
+NOW = dt.datetime(2026, 7, 21, 14, 32, 5, tzinfo=dt.timezone.utc)
+
+
+def test_mint_envelope_takes_the_record_type() -> None:
+    """The seam itself: the envelope is the universal write format, so
+    the type is an argument rather than a module constant."""
+    assert core.mint_envelope("capsule-leak", NOW, "evidence") == {
+        "v": 1,
+        "type": "evidence",
+        "id": "20260721T143205Z-capsule-leak",
+    }
+
+
+def test_mint_id_is_type_independent() -> None:
+    assert core.mint_id("capsule-leak", NOW) == "20260721T143205Z-capsule-leak"
+
+
+@pytest.mark.parametrize(
+    "bad_slug",
+    ["Capsule-Leak", "capsule_leak", "capsule leak", "", "a" * 41],
+)
+def test_mint_id_rejects_bad_slugs(bad_slug: str) -> None:
+    with pytest.raises(ValueError):
+        core.mint_id(bad_slug, NOW)
+
+
+def test_order_fields_applies_the_callers_field_order() -> None:
+    """Field order is per-store policy, so the core takes it as data."""
+    ordered = core.order_fields({"notes": "n", "id": "x", "v": 1}, ("v", "id"))
+    assert list(ordered) == ["v", "id", "notes"]
+
+
+def test_order_fields_keeps_unknown_fields_after_the_known_ones() -> None:
+    ordered = core.order_fields({"extra": 1, "v": 1}, ("v", "id"))
+    assert list(ordered) == ["v", "extra"]
+
+
+def test_serialize_record_round_trips() -> None:
+    import json
+
+    text = core.serialize_record({"v": 1, "type": "evidence", "id": "x"})
+    assert text.endswith("\n")
+    assert json.loads(text) == {"v": 1, "type": "evidence", "id": "x"}
+
+
+def test_the_core_carries_no_store_specific_vocabulary() -> None:
+    """Guard on the seam, not on the behavior.
+
+    A term from one store's schema appearing here means the split
+    leaked, and every later store inherits the leak. Cheaper to catch
+    as a string than as a design review.
+    """
+    source = CORE_PATH.read_text().lower()
+    for term in ("preference", "prediction", "chosen_slot", "rejection", "capsule"):
+        assert term not in source, f"contract core mentions {term!r}"

--- a/tests/test_validator_core_shared.py
+++ b/tests/test_validator_core_shared.py
@@ -1,0 +1,104 @@
+"""Tests for the shared validation core (``validator_core.py``).
+
+The mirror of ``record_core.py`` on the reading side: meta#13 rules
+that one writer core and one validator core serve every store, and
+only lifecycle policy differs per store. What lives here is the part
+that cannot know which store it is checking — ID grammar, the
+envelope, required-field presence, and link integrity across a corpus.
+
+``test_decision_validator.py`` covers the decision contract itself and
+is the regression guard that extracting this core did not change it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+CORE_PATH = (
+    PROJECT_ROOT / "decision-memory" / ".github" / "guards" / "validator_core.py"
+)
+
+core = load_module("validator_core", CORE_PATH)
+
+VALID_ID = "20260721T143205Z-agent-access"
+
+
+def test_validate_envelope_takes_the_expected_record_type() -> None:
+    """The seam: which type is correct is the store's policy, not the
+    core's, so it arrives as an argument."""
+    record = {"v": 1, "type": "evidence", "id": VALID_ID}
+    assert core.validate_envelope(record, "evidence") == []
+
+
+def test_validate_envelope_rejects_a_foreign_record_type() -> None:
+    record = {"v": 1, "type": "decision", "id": VALID_ID}
+    errors = core.validate_envelope(record, "evidence")
+    assert len(errors) == 1
+    assert "evidence" in errors[0]
+
+
+@pytest.mark.parametrize("bad_v", [0, -1, "1", True, None])
+def test_validate_envelope_rejects_a_bad_schema_version(bad_v: object) -> None:
+    record = {"v": bad_v, "type": "evidence", "id": VALID_ID}
+    assert any(e.startswith("v:") for e in core.validate_envelope(record, "evidence"))
+
+
+def test_validate_id_is_type_independent() -> None:
+    assert core.validate_id(VALID_ID) == []
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "20260721T143205Z-Agent-Access",
+        "20260721-agent-access",
+        "agent-access",
+        "20260721T143205Z-" + "a" * 41,
+        42,
+    ],
+)
+def test_validate_id_rejects_bad_ids(bad_id: object) -> None:
+    assert core.validate_id(bad_id) != []
+
+
+def test_validate_required_reports_each_missing_field() -> None:
+    errors = core.validate_required({"v": 1}, ("v", "symptom", "tier"))
+    assert errors == [
+        "symptom: required field missing",
+        "tier: required field missing",
+    ]
+
+
+def test_validate_corpus_takes_the_stores_link_fields() -> None:
+    """Link vocabulary is per-store — evidence links by
+    same_symptom_as and regression_of, decisions by related and
+    friends — so the core is told which fields to walk."""
+    records = {
+        "a": {"same_symptom_as": "missing-record"},
+        "b": {"same_symptom_as": "a"},
+    }
+    errors = core.validate_corpus(records, ("same_symptom_as",), "records")
+    assert errors == [
+        "a: same_symptom_as points to 'missing-record', "
+        "which does not exist in records/"
+    ]
+
+
+def test_validate_corpus_walks_list_valued_link_fields() -> None:
+    records = {"a": {"related": ["b", "gone"]}, "b": {}}
+    errors = core.validate_corpus(records, ("related",), "decisions")
+    assert len(errors) == 1
+    assert "'gone'" in errors[0]
+
+
+def test_the_core_carries_no_store_specific_vocabulary() -> None:
+    """Same guard as the writer core, for the same reason: a leak here
+    is inherited by every store that composes on it."""
+    source = CORE_PATH.read_text().lower()
+    for term in ("preference", "prediction", "chosen_slot", "rejection", "capsule"):
+        assert term not in source, f"validation core mentions {term!r}"


### PR DESCRIPTION
### Description of change

Groundwork for the evidence store (meta#13, now `pandoscope/evidence-memory`). The writer ruling is **sibling writer on a shared core**, not a `type` switch — and meta#13 states the principle for both sides: *one writer core and one validator core serve every store; only lifecycle policy differs per store*. This PR cuts both cores.

| New | Holds | What stays behind |
| --- | --- | --- |
| `tools/record_core.py` | envelope grammar, ID minting, field ordering, serialization, batch-ref resolution | `RECORD_TYPE`, `FIELD_ORDER`, the `preference_set` default, the IO shell |
| `.github/guards/validator_core.py` | ID grammar, envelope check, required-field presence, corpus link integrity | the decision contract — options, streams, ruling, rejections, budget |

Three things become **store policy passed as data** instead of module constants: the record type the envelope carries, the field order a record is written in, and the link vocabulary the corpus check walks.

**Both modules' public surfaces are unchanged.** `mint_id`, `serialize_record`, `resolve_batch_refs` and `validate_id` are re-exported; `mint_envelope` and `validate_envelope` keep their existing signatures. `tests/test_record_core.py` and `tests/test_decision_validator.py` pass **untouched** — that is what makes them regression guards for the extraction rather than tests bent to fit it.

### Why the link vocabulary had to move

The evidence store links by `same_symptom_as` and `regression_of`, and deliberately does **not** reuse `related` / `supersedes` / `drill_down_of`. Those carry decision-memory meanings, and a shared spelling with a different meaning is worse than two spellings. `duplicate_of` was considered and rejected: under the `kata-capture` protocol a literal duplicate is *skipped*, so it never mints a record — the field would name the one case that is never filed.

Consequently `validate_corpus` now walks a link field whose value is either a single reference or a list, rather than special-casing `related`. Same behavior for this store; one less thing for the next store to special-case.

### Deliberately out of scope

Sharing these cores **across subtemplates**. Copier renders one `_subdirectory` at a time, so an `evidence-memory` subtemplate cannot import from `decision-memory/`. The current call is to copy, then assess DRY options with both copies in front of us rather than in the abstract — so the copy and the assessment land with the evidence subtemplate, not here.

### Verification

- `uv run pytest` → **140 passed, 3 skipped**
- `uvx prek run --all-files` → clean
- Each extraction has its own `test(red):` commit, failing before the module existed

### Note on the vocabulary guards

Both cores carry a test asserting their **source text** contains no store-specific terms (`preference`, `prediction`, `chosen_slot`, `rejection`, `capsule`). That tests text rather than behavior, which is unusual, and it follows #84's reasoning: a schema term leaking from one store into a shared core is inherited by every store that composes on it afterwards, and catching that as a string costs nothing next to catching it in a design review two stores later.

### Decisions requiring review

- **ARCH** `tools/record_core.py` — the writer core/policy split.
- **ARCH** `.github/guards/validator_core.py` — the validation core/policy split; `estimate_tokens` and the budget check stay in the decision validator deliberately, as no other store needs them yet.
- **IFACE** `record_core.mint_envelope`, `validator_core.validate_envelope` — record type becomes a parameter.
- **IFACE** `record_core.order_fields` — the ordering half of `draft_to_record`, extracted as a named function taking field order as data.
- **IFACE** `validator_core.validate_corpus` — takes the store's link fields and directory name; walks scalar and list-valued links uniformly.
- **SCOPE** `resolve_batch_refs` moved to the writer core with its link-field names still hardcoded. This is the one I am least sure of: it is now the only place in either core that names decision-specific link fields, and the evidence store will not use them. Flagging rather than fixing, since the alternative is parameterising a function no second caller exists for yet.

### Routine (skip review)

Re-exports for API stability; adding both new files to the store's rendered-file manifest in `test_decision_memory_subtemplate.py`.

Refs #99

---
_Recreated from #94, which was opened from the wrong account. Same branch, same commits; description copied verbatim (there were no comments)._

_Two sessions recreated the tracking ticket concurrently. #99 is kept because its acceptance criteria cover **both** cores, matching what this PR delivers; #101 was a verbatim copy of the older body describing only the writer core, and is closed as a duplicate._