### PR TITLE
feat(evidence): stamp the evidence store from the template

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -6,12 +6,15 @@ agentic_subtemplate:
     `decision-memory` stamps a decision-memory STORE — the recorder, the
     CI guards (validator + guard runner + workflow), the preference-set
     lifecycle (budget, carve-out gate, replay, compaction skill), the
-    vendored store docs, and a seeded preference set. With
-    `decision-memory`, all project-scaffold questions are skipped,
-    keeping the store's answers file minimal.
+    vendored store docs, and a seeded preference set;
+    `evidence-memory` stamps an evidence STORE — the capture writer, the
+    CI guards (validator + guard runner + workflow), and the vendored
+    store docs. With either store subtemplate, all project-scaffold
+    questions are skipped, keeping the store's answers file minimal.
   choices:
     - template
     - decision-memory
+    - evidence-memory
   default: template
 
 agentic_project_name:

--- a/evidence-memory/.github/guards/evidence_validator.py
+++ b/evidence-memory/.github/guards/evidence_validator.py
@@ -1,0 +1,196 @@
+"""Single-source validator for evidence-memory records.
+
+This file is the one validation authority for the evidence-memory
+contract. It lives in the agentic-engineering-template repo (evidence
+subtemplate) and is copier-vendored into the evidence-memory repo,
+where BOTH consumers import it:
+
+- the CI guard (guards.py, next to this file), and
+- the writer tool (tools/capture.py), which imports it from the
+  data-repo clone at runtime.
+
+Stdlib only, no dependencies — the vendored copy must keep working
+even if the template repo disappears (fails soft: guard keeps working,
+only updates stop).
+
+The store-independent half — ID grammar, envelope, required-field
+presence, corpus link integrity — lives in ``validator_core.py`` next
+to this file, shared with every other store's validator. What stays
+here is the evidence contract itself.
+
+All validators return a list of human-readable error strings (empty =
+valid) and TOLERATE unknown fields: new optional fields need no
+migration.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validator_core  # noqa: E402  (path bootstrap above)
+
+SCHEMA_VERSION = validator_core.SCHEMA_VERSION
+RECORD_TYPE = "evidence"
+
+# This store's link vocabulary. Deliberately NOT related/supersedes/
+# drill_down_of: those carry decision-memory meanings, and a shared
+# spelling with a different meaning is worse than two spellings.
+LINK_FIELDS = ("same_symptom_as", "regression_of")
+STORE_DIR = "records"
+
+REQUIRED_FIELDS = (
+    "v",
+    "type",
+    "id",
+    "date",
+    "symptom",
+    "triage",
+    "tier",
+    "ticket",
+    "environment",
+    "expected",
+    "observed",
+    "rung",
+)
+
+# The meta-loop taxonomy plus 'feature': a feature-kata's capsule is a
+# test failing because the capability is absent, which is TDD red — so
+# bug-vs-feature is a triage value, not a separate record kind.
+TRIAGE = frozenset({"code-bug", "doc-bug", "expectation-bug", "feature"})
+
+# 1: capsule can be synthesized leak-free and lives in the public
+# ticket. 2: capsule cannot be sanitized and lives here instead, the
+# ticket carrying a leak-free summary.
+TIERS = frozenset({1, 2})
+
+# The filing ladder, monotonic: capacity decides how high it goes.
+RUNGS = ("record", "ticket", "capsule", "repro-branch")
+CAPSULE_RUNGS = frozenset({"capsule", "repro-branch"})
+
+validate_id = validator_core.validate_id
+
+
+def validate_envelope(record: dict) -> list[str]:
+    """Check the universal envelope against this store's record type."""
+    return validator_core.validate_envelope(record, RECORD_TYPE)
+
+
+def _validate_symptom(record: dict, errors: list[str]) -> None:
+    """The symptom is the grep-able fingerprint, so it must stay one line.
+
+    Dedup starts with a human or an agent grepping this field across a
+    local clone. A multi-line symptom is invisible to that grep for
+    every line after the first, which defeats the field's only job.
+    """
+    symptom = record.get("symptom")
+    if not isinstance(symptom, str) or not symptom.strip():
+        errors.append("symptom: must be a non-empty string")
+        return
+    if "\n" in symptom:
+        errors.append(
+            "symptom: must be a single line — it is the grep-able "
+            "fingerprint; detail belongs in observed/expected"
+        )
+
+
+def _validate_vocabularies(record: dict, errors: list[str]) -> None:
+    triage = record.get("triage")
+    if triage not in TRIAGE:
+        errors.append(f"triage: {triage!r} not in {sorted(TRIAGE)}")
+
+    tier = record.get("tier")
+    if not isinstance(tier, int) or isinstance(tier, bool) or tier not in TIERS:
+        errors.append(f"tier: {tier!r} not in {sorted(TIERS)}")
+
+    rung = record.get("rung")
+    if rung not in RUNGS:
+        errors.append(f"rung: {rung!r} not in {list(RUNGS)}")
+
+
+def _validate_placement(record: dict, errors: list[str]) -> None:
+    """Tier 2 keeps its capsule here; that is the whole point of tier 2.
+
+    A tier-2 record that reached the capsule rung with no capsule in
+    the store means the capsule went somewhere public, which is the
+    leak this tier exists to prevent.
+    """
+    if record.get("tier") != 2:
+        return
+    if record.get("rung") not in CAPSULE_RUNGS:
+        return
+    capsule = record.get("capsule")
+    if not isinstance(capsule, str) or not capsule.strip():
+        errors.append(
+            "capsule: required for a tier-2 record at the capsule rung "
+            "or above — tier 2 exists because the capsule cannot be "
+            "public, so it has to be here"
+        )
+
+
+def _validate_ticket(record: dict, errors: list[str]) -> None:
+    """Every record names its forge ticket: the store is memory, the
+    forge is the actionable backlog, and the link is what keeps them
+    from drifting into two trackers."""
+    ticket = record.get("ticket")
+    if not isinstance(ticket, str) or not ticket.startswith("http"):
+        errors.append("ticket: must be the forge ticket URL")
+
+
+def _validate_links_point_backward(record: dict, errors: list[str]) -> None:
+    """Links only ever point at older records.
+
+    Records are immutable, so an earlier record can never gain an edge
+    to a later one; every link is therefore backward by construction.
+    IDs lead with a UTC timestamp, so this is checkable from the IDs
+    alone — no corpus needed. Ties are tolerated: two records minted in
+    the same second are not evidence of a forward link.
+    """
+    record_id = record.get("id")
+    if not isinstance(record_id, str) or not validator_core.ID_RE.match(record_id):
+        return
+    own_stamp = record_id.split("-", 1)[0]
+    for field in LINK_FIELDS:
+        ref = record.get(field)
+        if not isinstance(ref, str) or not validator_core.ID_RE.match(ref):
+            continue
+        if ref.split("-", 1)[0] > own_stamp:
+            errors.append(
+                f"{field}: points to {ref!r}, which is newer than this "
+                "record — links are backward-only"
+            )
+
+
+def validate_record(record: object, filename_stem: str | None = None) -> list[str]:
+    """Validate a single evidence record against the full contract.
+
+    Returns a list of error strings; empty means valid. Unknown fields
+    are tolerated. When ``filename_stem`` is given, the record's ``id``
+    must equal it (ID = filename stem, always).
+    """
+    if not isinstance(record, dict):
+        return ["record: must be a JSON object"]
+    errors = validate_envelope(record)
+    errors.extend(validator_core.validate_required(record, REQUIRED_FIELDS))
+    if filename_stem is not None and record.get("id") != filename_stem:
+        errors.append(
+            f"id: {record.get('id')!r} does not equal the filename stem "
+            f"{filename_stem!r}"
+        )
+    _validate_symptom(record, errors)
+    _validate_vocabularies(record, errors)
+    _validate_placement(record, errors)
+    _validate_ticket(record, errors)
+    _validate_links_point_backward(record, errors)
+    return errors
+
+
+def validate_corpus(records: dict) -> list[str]:
+    """Cross-record checks: no link into a record outside the corpus.
+
+    ``records`` maps record ID -> record dict (normally the whole
+    ``records/`` directory).
+    """
+    return validator_core.validate_corpus(records, LINK_FIELDS, STORE_DIR)

--- a/evidence-memory/.github/guards/evidence_validator.py
+++ b/evidence-memory/.github/guards/evidence_validator.py
@@ -133,10 +133,42 @@ def _validate_placement(record: dict, errors: list[str]) -> None:
 def _validate_ticket(record: dict, errors: list[str]) -> None:
     """Every record names its forge ticket: the store is memory, the
     forge is the actionable backlog, and the link is what keeps them
-    from drifting into two trackers."""
-    ticket = record.get("ticket")
+    from drifting into two trackers.
+
+    A tier-2 record may carry ``null`` while its PR is under review.
+    Its ticket is filed only once a human has approved the capsule, so
+    the record necessarily exists before the ticket does. That state is
+    a valid record and NOT a mergeable one — the merge gate is
+    ``check_tickets_filed``, deliberately separate so the contract
+    describes what a record is and the guard decides what may land.
+
+    The key is required either way: ``null`` declares a pending ticket,
+    a missing key is an omission, and the two should not read alike.
+    """
+    if "ticket" not in record:
+        return  # the required-field check owns the missing-key case
+    ticket = record["ticket"]
+    if ticket is None and record.get("tier") == 2:
+        return
     if not isinstance(ticket, str) or not ticket.startswith("http"):
         errors.append("ticket: must be the forge ticket URL")
+
+
+def check_tickets_filed(records: dict) -> list[str]:
+    """Merge gate: no record lands without its forge ticket.
+
+    Separate from ``validate_record`` because it answers a different
+    question. The contract asks "is this a well-formed record?" — and a
+    tier-2 record awaiting approval is. This asks "may the store move
+    to this state?", and a store containing work with nowhere to track
+    it is the two-tracker drift the ticket link exists to prevent.
+    """
+    return [
+        f"{record_id}: ticket is still null — file the forge ticket and "
+        "amend it into this record before merging"
+        for record_id, record in sorted(records.items())
+        if isinstance(record, dict) and record.get("ticket") is None
+    ]
 
 
 def _validate_links_point_backward(record: dict, errors: list[str]) -> None:

--- a/evidence-memory/.github/guards/guards.py
+++ b/evidence-memory/.github/guards/guards.py
@@ -1,0 +1,115 @@
+"""CI guard for the evidence-memory store.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+the store repo; change it in the template and pull via `copier update`.
+
+Protects the store's two invariants: records are append-only, and
+every record satisfies the contract. Stdlib only — no dependencies to
+install, so the guard keeps working even if the template repo
+disappears.
+
+Deliberately smaller than the decision store's guard. That one also
+polices preferences.md discipline and per-commit edit rules, because a
+decision session is a human-reviewed batch. Evidence records
+auto-merge on green, so the guard IS the review: it checks what a
+machine can check and claims nothing more.
+
+Usage:
+
+    python .github/guards/guards.py --base «base-sha»
+    python .github/guards/guards.py            # corpus checks only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import evidence_validator  # noqa: E402  (path bootstrap above)
+
+RECORDS_DIR = evidence_validator.STORE_DIR
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+    return result.stdout
+
+
+def check_append_only(base: str) -> list[str]:
+    """No modify/delete/rename ever touches an existing record.
+
+    Moving a file breaks its stable ID and every inbound link, and a
+    link cannot be repaired after the fact because the pointing record
+    is itself immutable.
+    """
+    errors: list[str] = []
+    diff = _git("diff", "--name-status", "--find-renames", f"{base}...HEAD")
+    for line in diff.splitlines():
+        parts = line.split("\t")
+        status = parts[0]
+        paths = parts[1:]
+        if any(p.startswith(f"{RECORDS_DIR}/") for p in paths) and status != "A":
+            errors.append(
+                f"append-only: {RECORDS_DIR}/ change {status} {' '.join(paths)} "
+                "— existing records are never modified, deleted, or renamed"
+            )
+    return errors
+
+
+def check_corpus(root: str = ".") -> list[str]:
+    """Validate every record, then the links between them."""
+    errors: list[str] = []
+    records: dict[str, dict] = {}
+    records_dir = os.path.join(root, RECORDS_DIR)
+    if os.path.isdir(records_dir):
+        for name in sorted(os.listdir(records_dir)):
+            if name.startswith("."):
+                continue
+            path = os.path.join(records_dir, name)
+            if not name.endswith(".json"):
+                errors.append(f"{path}: non-JSON file in {RECORDS_DIR}/")
+                continue
+            stem = name[: -len(".json")]
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    record = json.load(handle)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"{path}: unreadable ({exc})")
+                continue
+            for error in evidence_validator.validate_record(record, filename_stem=stem):
+                errors.append(f"{path}: {error}")
+            if isinstance(record, dict):
+                records[stem] = record
+    errors.extend(evidence_validator.validate_corpus(records))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--base", help="base SHA to diff against for the append-only check"
+    )
+    parser.add_argument("--root", default=".", help="store root (default: .)")
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    if args.base:
+        errors.extend(check_append_only(args.base))
+    errors.extend(check_corpus(args.root))
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(f"\n{len(errors)} guard error(s)", file=sys.stderr)
+        return 1
+    print("guards: ok")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/evidence-memory/.github/guards/guards.py
+++ b/evidence-memory/.github/guards/guards.py
@@ -86,6 +86,7 @@ def check_corpus(root: str = ".") -> list[str]:
             if isinstance(record, dict):
                 records[stem] = record
     errors.extend(evidence_validator.validate_corpus(records))
+    errors.extend(evidence_validator.check_tickets_filed(records))
     return errors
 
 

--- a/evidence-memory/.github/guards/validator_core.py
+++ b/evidence-memory/.github/guards/validator_core.py
@@ -1,0 +1,97 @@
+"""Universal validation core — the checks every store's records share.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+a store repo; change it in the template and pull via `copier update`.
+
+The reading-side mirror of ``record_core.py``: one writer core and one
+validation core serve every store, and only lifecycle policy differs
+per store. What lives here is what cannot know which store it is
+checking — ID grammar, the envelope, required-field presence, and link
+integrity across a corpus. Which fields are required, which links
+exist, and what a record means are the store's own contract, and
+arrive as arguments.
+
+Stdlib only, so a guard runs with no install step.
+"""
+
+from __future__ import annotations
+
+import re
+
+SCHEMA_VERSION = 1
+MAX_SLUG_LENGTH = 40
+ID_RE = re.compile(r"^(\d{8}T\d{6}Z)-([a-z0-9]+(?:-[a-z0-9]+)*)$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def validate_id(record_id: object) -> list[str]:
+    """Check the ID grammar: <YYYYMMDDTHHMMSSZ>-<kebab-slug>, slug <= 40."""
+    if not isinstance(record_id, str):
+        return ["id: must be a string"]
+    match = ID_RE.match(record_id)
+    if not match:
+        return [
+            f"id: {record_id!r} does not match "
+            "<UTC-timestamp>Z-<kebab-slug> (lowercase kebab-case slug)"
+        ]
+    slug = match.group(2)
+    if len(slug) > MAX_SLUG_LENGTH:
+        return [f"id: slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})"]
+    return []
+
+
+def validate_envelope(record: dict, record_type: str) -> list[str]:
+    """Check the universal envelope: v, type, id.
+
+    ``record_type`` is the type this store's records must carry — the
+    envelope routes records in a mixed ledger, so which value is
+    correct is the store's policy rather than the core's.
+    """
+    errors: list[str] = []
+    v = record.get("v")
+    if not isinstance(v, int) or isinstance(v, bool) or v < 1:
+        errors.append("v: must be a positive integer schema version")
+    actual = record.get("type")
+    if actual != record_type:
+        errors.append(f"type: must be {record_type!r} in this repo, got {actual!r}")
+    errors.extend(validate_id(record.get("id")))
+    return errors
+
+
+def validate_required(record: dict, required_fields: tuple) -> list[str]:
+    """Report every required field the record does not carry."""
+    return [
+        f"{field}: required field missing"
+        for field in required_fields
+        if field not in record
+    ]
+
+
+def validate_corpus(records: dict, link_fields: tuple, store_dir: str) -> list[str]:
+    """Check that no link points outside the corpus.
+
+    ``records`` maps record ID -> record dict (normally a whole store
+    directory). ``link_fields`` is the store's own link vocabulary; a
+    field's value may be a single reference or a list of them, so both
+    are walked. ``store_dir`` only names the directory in the message.
+
+    A dangling reference is an error rather than a warning because a
+    record must not point at something that may never exist: records
+    are immutable, so a link that is wrong when written stays wrong.
+    """
+    errors: list[str] = []
+    for record_id, record in sorted(records.items()):
+        if not isinstance(record, dict):
+            continue
+        for field in link_fields:
+            value = record.get(field)
+            if value is None:
+                continue
+            refs = value if isinstance(value, list) else [value]
+            for ref in refs:
+                if ref not in records:
+                    errors.append(
+                        f"{record_id}: {field} points to {ref!r}, "
+                        f"which does not exist in {store_dir}/"
+                    )
+    return errors

--- a/evidence-memory/.github/workflows/guards.yml
+++ b/evidence-memory/.github/workflows/guards.yml
@@ -1,0 +1,24 @@
+name: Guards
+
+# Copier-vendored from the agentic-engineering-template evidence
+# subtemplate. Protects the evidence store: append-only records and
+# full contract validation. Stdlib Python only — no dependencies to
+# install.
+#
+# Evidence records auto-merge on green, so this workflow is the review.
+
+on:
+  pull_request:
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # Full history: the guard diffs against the PR base.
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+      - run: python .github/guards/guards.py --base "${{ github.event.pull_request.base.sha }}"

--- a/evidence-memory/.gitignore
+++ b/evidence-memory/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/evidence-memory/AGENTS.md
+++ b/evidence-memory/AGENTS.md
@@ -1,0 +1,63 @@
+# Evidence-Memory Store — Agent Guidelines
+
+> Copier-vendored from the agentic-engineering-template evidence
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+Private evidence store for one principal (a person or a team):
+detection records for bugs and features, the CI guard protecting them,
+and the writer that mints them.
+The data is this repo's; every line of code around it is vendored from
+the agentic-engineering-template evidence subtemplate,
+so N stores cannot drift from one schema.
+`tools/capture.py --help` is the writer's authoritative behavior doc.
+
+## Golden rules
+
+Compressed summary — [docs/conventions.md](docs/conventions.md) is the
+authoritative contract.
+
+- `records/` is append-only: NEVER modify, delete, or rename an
+  existing record. CI rejects it; do not try.
+- This store is **memory, not a tracker**. Every record names its forge
+  ticket, and progress is tracked there. Never add status to a record,
+  and never add a status file — a local mirror of forge state is stale
+  by the following week.
+- New evidence on a known symptom is a **new record** carrying
+  `same_symptom_as`, never an edit to the existing one.
+- Links point backward only. An older record cannot gain an edge to a
+  newer one, because it is immutable. Do not implement a back-edge.
+- A literal duplicate is **skipped**, not filed. If the case adds
+  nothing, there is nothing to record.
+- Never write this repo's URL into a public artifact.
+
+## Tiers, and the leak that matters
+
+- **Tier 1** — the capsule can be synthesized leak-free, so it goes in
+  the public ticket and is cold-reproducible by anyone.
+- **Tier 2** — the capsule cannot be sanitized (production data, org
+  internals, security). It lives here; the public ticket carries a
+  leak-free summary only.
+
+Sanitize by **synthesis, not redaction**: a synthetic fixture is both
+leak-free and runnable, a redacted one is neither. Tier 1 is preferred
+whenever synthesis is possible at all.
+
+Before filing anything public, re-read what you are about to write for
+paths, hostnames, tokens, and internal identifiers. A record here is
+private; the ticket it links is not.
+
+## Filing
+
+```bash
+python tools/capture.py --draft draft.json
+```
+
+The writer mints the ID, orders the fields, validates against this
+store's own vendored validator, and refuses to overwrite. Hand-written
+records are allowed; they get no help and face the same guard.
+
+Evidence PRs auto-merge on green, so the guard is the review. That is
+the reason the guard checks what a machine can check and claims nothing
+more — it never asserts that a record is *useful*, only that it is
+well-formed.

--- a/evidence-memory/AGENTS.md
+++ b/evidence-memory/AGENTS.md
@@ -43,9 +43,28 @@ Sanitize by **synthesis, not redaction**: a synthetic fixture is both
 leak-free and runnable, a redacted one is neither. Tier 1 is preferred
 whenever synthesis is possible at all.
 
+**Runnability is the boundary.** If a leak-free version still
+reproduces, it is tier 1 and belongs in the public ticket. A tier-2
+stub conveys only the *shape* of the failure, using invented
+specifics, and is not expected to run. Floor: a ticket titled `bug`.
+
+A thin stub is fine. Whoever picks the work up has store access and
+greps `records/` for the ticket URL. The ticket exists so the work is
+tracked, not so it is understood.
+
+**A tier-2 ticket is filed only after a human approves the PR.** Mint
+the record with `"ticket": null`, open the PR, wait. After approval,
+file the ticket and amend its URL into the record in the same PR. CI
+is red until you do — that is the guard working, not something to
+route around. Never file a tier-2 ticket before approval.
+
 Before filing anything public, re-read what you are about to write for
 paths, hostnames, tokens, and internal identifiers. A record here is
 private; the ticket it links is not.
+
+If you leak anything — even low-risk, even by accident — that is
+itself a detection. File it. Prevention here is built from observed
+weak spots, not imagined ones.
 
 ## Filing
 

--- a/evidence-memory/CLAUDE.md
+++ b/evidence-memory/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Specific Project Instructions
+
+**First:** Read `AGENTS.md`. Follow all instructions there.
+
+## Pull Requests
+
+Share PR URL in response to user.

--- a/evidence-memory/README.md
+++ b/evidence-memory/README.md
@@ -1,0 +1,53 @@
+# Evidence Memory
+
+> Copier-vendored from the agentic-engineering-template evidence
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+A private, data-only store of immutable **detection records**: bugs and
+features found while working, kept so the next person to hit the same
+thing finds it instead of filing it again.
+
+## What lives here, and what does not
+
+| Here | Not here |
+| --- | --- |
+| Detection facts — symptom, environment, expected vs observed | Status. Progress lives on the forge. |
+| Capsules that cannot be made public (tier 2) | Capsules that can (tier 1 — those go in the ticket) |
+| Links between records about one symptom | Rulings and their reasoning — those are decision records |
+
+The store is **memory, not a tracker**. Every record names its forge
+ticket; work happens there. Two backlogs would mean one stale backlog.
+
+Raw evidence lives in files rather than ticket bodies for two reasons:
+a tracker mangles the text (angle brackets vanish, formatting is
+rewritten), and a directory of records can be indexed and grepped
+offline, which is what makes "have we seen this?" answerable before
+touching a rate-limited API.
+
+## Filing
+
+Records are written by `tools/capture.py`, which mints the ID, applies
+the field order, validates against this store's own vendored validator,
+and refuses to overwrite an existing record:
+
+```bash
+python tools/capture.py --draft draft.json
+```
+
+The contract every record satisfies is
+[docs/conventions.md](docs/conventions.md). The guard in
+`.github/guards/` enforces it in CI, and evidence PRs auto-merge on
+green — so the guard *is* the review.
+
+## Privacy
+
+This repo is private and stays private: tier-2 capsules exist precisely
+because they could not be sanitized. Never write this repo's URL into a
+public artifact; consumers reach it through an environment variable, in
+the same way the decision store is reached.
+
+A public ticket linked from a tier-2 record carries a leak-free summary
+only. Sanitize by **synthesis, not redaction** wherever it is possible
+at all — a synthetic fixture is both leak-free and runnable, where a
+redacted one is neither.

--- a/evidence-memory/docs/conventions.md
+++ b/evidence-memory/docs/conventions.md
@@ -1,0 +1,101 @@
+# Evidence-Memory Store — Writing Conventions
+
+> Copier-vendored from the agentic-engineering-template evidence
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+The authoritative contract any writer — tool or hand — must satisfy.
+The CI guard (`.github/guards/`) enforces it mechanically; this file is
+the human-readable authority, `evidence_validator.py` the
+machine-readable one. Both live in the template repo's evidence
+subtemplate and change together there, in the same PR.
+
+## What this store is
+
+A store of immutable **detection records**: bugs and features found
+while working, kept as the substrate for dedup, lookup, and later kata
+promotion.
+
+It is **memory, not a tracker**. Progress lives on the forge — every
+record names its ticket, and work happens there. A store that also
+tracked status would be a second backlog, stale by the following week.
+
+## Storage layout
+
+- `records/<id>.json` — one immutable JSON **file** per detection, flat
+  directory. Append-only: existing files are NEVER modified, deleted,
+  or renamed.
+- ID = filename stem = `<timestamp>-<slug>`, e.g.
+  `20260728T161500Z-drift-baseline-ignored`. The slug is a
+  writer-chosen kebab-case title, ≤40 chars; the timestamp is minted
+  (UTC) by the writer tool.
+
+## Record schema
+
+```json
+{
+  "v": 1,
+  "type": "evidence",
+  "id": "20260728T161500Z-drift-baseline-ignored",
+  "date": "2026-07-28",
+
+  "symptom": "disambiguate --drift exits 0 with a stale baseline entry",
+  "triage": "code-bug",
+  "tier": 1,
+  "rung": "capsule",
+  "ticket": "https://github.com/«owner»/«repo»/issues/«n»",
+
+  "environment": "disambiguate 0.3.0, python 3.13, «repo»@«sha»",
+  "expected": "a baselined finding that no longer occurs is pruned",
+  "observed": "the entry survives and the run still exits 0",
+  "capsule": null,
+
+  "same_symptom_as": null,
+  "regression_of": null,
+  "session": "session_01ABC…",
+  "notes": null
+}
+```
+
+### Fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `symptom` | yes | **One line.** The grep-able fingerprint — dedup starts by grepping this across a local clone, so a multi-line value is invisible to that grep after its first line. Detail belongs in `expected`/`observed`. |
+| `triage` | yes | `code-bug` · `doc-bug` · `expectation-bug` · `feature` |
+| `tier` | yes | `1` capsule is public (in the ticket) · `2` capsule cannot be sanitized and lives here |
+| `rung` | yes | Filing ladder reached: `record` · `ticket` · `capsule` · `repro-branch` |
+| `ticket` | yes | Forge ticket URL. The store is memory; this is the link to where work happens. |
+| `environment` | yes | Tool versions, repo@SHA — what makes the observation reproducible |
+| `expected` / `observed` | yes | The contradiction, stated plainly |
+| `capsule` | tier 2 | The repro capsule. Required for a tier-2 record at the `capsule` rung or above — tier 2 exists *because* the capsule cannot be public, so it has to be here. |
+| `same_symptom_as` | no | An earlier record covering this symptom — whether it corroborates or suspects a different cause, which the body says |
+| `regression_of` | no | An earlier record whose capsule still reproduces *and* whose kata now fails |
+| `session` | no | Session pointer. The `Claude-Session:` commit trailer is the standing fallback; never build an uploader. |
+| `notes` | no | Anything else |
+
+Unknown fields are tolerated: a new optional field needs no migration.
+
+## Links point backward, always
+
+Records are immutable, so an earlier record can never gain an edge to a
+later one. Every link therefore points at an older record, and the
+guard enforces it from the IDs alone — they lead with a UTC timestamp.
+
+The consequence worth knowing: reconstructing every record about one
+symptom needs a **reverse index built at read time**, not a forward
+walk from the oldest. Do not implement a back-edge; it cannot exist.
+
+The forge is where two-way linking happens, because tickets are
+mutable. That asymmetry is deliberate, not an oversight.
+
+## Vocabulary this store does NOT use
+
+`related`, `supersedes`, `drill_down_of` belong to the decision store
+and mean something else there. A shared spelling with a different
+meaning is worse than two spellings.
+
+`duplicate_of` is absent by design: a literal duplicate is *skipped* at
+capture rather than filed, so the field would name the one case that
+never produces a record. Additional evidence on a known symptom is not
+duplication — it is a new record carrying `same_symptom_as`.

--- a/evidence-memory/docs/conventions.md
+++ b/evidence-memory/docs/conventions.md
@@ -65,7 +65,7 @@ tracked status would be a second backlog, stale by the following week.
 | `triage` | yes | `code-bug` · `doc-bug` · `expectation-bug` · `feature` |
 | `tier` | yes | `1` capsule is public (in the ticket) · `2` capsule cannot be sanitized and lives here |
 | `rung` | yes | Filing ladder reached: `record` · `ticket` · `capsule` · `repro-branch` |
-| `ticket` | yes | Forge ticket URL. The store is memory; this is the link to where work happens. |
+| `ticket` | yes | Forge ticket URL. The store is memory; this is the link to where work happens. May be `null` on a **tier-2** record whose ticket is not filed yet — see below. The key is always present: `null` declares a pending ticket, a missing key is an omission. |
 | `environment` | yes | Tool versions, repo@SHA — what makes the observation reproducible |
 | `expected` / `observed` | yes | The contradiction, stated plainly |
 | `capsule` | tier 2 | The repro capsule. Required for a tier-2 record at the `capsule` rung or above — tier 2 exists *because* the capsule cannot be public, so it has to be here. |
@@ -75,6 +75,60 @@ tracked status would be a second backlog, stale by the following week.
 | `notes` | no | Anything else |
 
 Unknown fields are tolerated: a new optional field needs no migration.
+
+## Tier 2: what the public ticket may say
+
+The capsule stays here. The forge ticket carries a summary, and the
+rule for deriving it is:
+
+> Anything that survives substituting **invented specifics for real
+> ones** may go in the ticket. Anything that identifies the real system
+> may not. The floor is a ticket titled `bug` and nothing else.
+
+Dummy values, not redaction — but note the distinction from tier 1. A
+tier-1 capsule is synthesized so that it **still reproduces**; a
+tier-2 stub only conveys the *shape* of the failure and is not
+expected to run. **Runnability is the tier boundary**: if a leak-free
+version reproduces, it is tier 1 and belongs in the ticket.
+
+A stub too thin to act on is not a failure of this design. Whoever
+picks the work up has store access and greps `records/` for the ticket
+URL to find the real detail. The public ticket exists so the work is
+*tracked*, not so it is *understood* — forge issues inherit repo
+visibility, so public tracking with private detail is the only shape
+available.
+
+## Tier 2: the filing order
+
+Filing a tier-2 ticket is the one step in this store that is not
+reversible, so it is the one step a human gates.
+
+1. Capture mints the record with `"ticket": null` and opens a PR.
+2. A human reviews the capsule — this is the gate, and it is
+   mechanical: a tier-2 record in the diff withholds auto-merge.
+3. On approval, the ticket is filed with whatever detail the
+   derivation rule above permits.
+4. The ticket URL is amended into the record **in the same PR**. This
+   is legal: `check_append_only` diffs `base...HEAD`, so a record
+   added and later amended inside one PR still reads as an addition.
+5. Merge.
+
+The record is *valid* at step 1 and *not mergeable* until step 4 —
+two different rules, deliberately in two different places.
+`validate_record` describes what a record is; `check_tickets_filed`
+decides what may land. Expect CI to be red between steps 1 and 4; that
+is the guard doing its job, not a problem to route around.
+
+Tier 1 has no such window. Its capsule is public, so its ticket is
+filed at detection and `ticket` is never null.
+
+## Leaks are evidence too
+
+No rule stops a determined mistake, and none is claimed to. A leak —
+including a low-risk or no-risk one — is itself a detection worth a
+record. Prevention gets built from observed weak spots rather than
+imagined ones, which is the same loop this store exists to serve,
+pointed at the store's own failure mode.
 
 ## Links point backward, always
 

--- a/evidence-memory/tools/capture.py
+++ b/evidence-memory/tools/capture.py
@@ -1,0 +1,166 @@
+"""Evidence recorder — mints one immutable record per detection.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+the store repo; change it in the template and pull via `copier update`.
+
+The sibling of the decision recorder, not a mode of it: both compose
+on ``record_core.py``, and neither carries a branch for the other's
+lifecycle. What differs is entirely policy — this store's record type,
+its field order, and the detection facts a record carries.
+
+Deliberately no git or forge mechanics. The decision recorder owns
+clone/branch/commit/PR because a decision session ends in one PR of
+many records; an evidence filing is a single record dropped mid-task,
+and the caller is already in a repo with a commit to make. Revisit
+when writing the record by hand is what hurts, not before.
+
+Stdlib only. Usage:
+
+    python tools/capture.py --draft draft.json
+    cat draft.json | python tools/capture.py --draft -
+    python tools/capture.py --draft draft.json --store «path»
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import record_core  # noqa: E402  (path bootstrap above)
+
+RECORD_TYPE = "evidence"
+RECORDS_DIR = "records"
+VALIDATOR_RELPATH = Path(".github") / "guards" / "evidence_validator.py"
+
+# Envelope, then the detection itself, then where it was filed, then
+# the links. A reader scanning a record top-to-bottom meets the
+# symptom before anything else, because that is the field every lookup
+# starts from.
+FIELD_ORDER = (
+    "v",
+    "type",
+    "id",
+    "date",
+    "symptom",
+    "triage",
+    "tier",
+    "rung",
+    "ticket",
+    "environment",
+    "expected",
+    "observed",
+    "capsule",
+    "same_symptom_as",
+    "regression_of",
+    "session",
+    "notes",
+)
+
+
+def draft_to_record(draft: dict, now: dt.datetime) -> dict:
+    """Turn a draft (the schema minus tool-minted fields, plus ``slug``)
+    into a full record.
+
+    Draft-supplied values always win over minted defaults; unknown
+    fields are preserved. Raises ValueError when ``slug`` is missing or
+    malformed.
+    """
+    payload = dict(draft)
+    slug = payload.pop("slug", None)
+    if not isinstance(slug, str) or not slug:
+        raise ValueError("draft is missing the writer-chosen 'slug' field")
+
+    merged = record_core.mint_envelope(slug, now, RECORD_TYPE)
+    merged["date"] = now.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
+    merged.update(payload)
+    return record_core.order_fields(merged, FIELD_ORDER)
+
+
+def load_validator(store_root: Path):
+    """Import the store's own vendored validator.
+
+    Writer-side and CI validation must be the same code: a record that
+    the writer accepts and CI rejects is a record that cannot be
+    filed, and one the writer rejects and CI would accept is lost
+    evidence.
+    """
+    path = store_root / VALIDATOR_RELPATH
+    if not path.exists():
+        raise SystemExit(f"no validator at {path} — is {store_root} an evidence store?")
+    spec = importlib.util.spec_from_file_location("evidence_validator", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise SystemExit(f"could not load the validator at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_record(record: dict, store_root: Path) -> Path:
+    """Write a record to its immutable ``records/<id>.json``.
+
+    Refuses to overwrite: the store is append-only, so an existing
+    path means the ID collided and the caller has to mint again.
+    """
+    directory = store_root / RECORDS_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{record['id']}.json"
+    if path.exists():
+        raise SystemExit(f"{path} already exists — records are immutable")
+    path.write_text(record_core.serialize_record(record), encoding="utf-8")
+    return path
+
+
+def read_draft(source: str) -> dict:
+    text = (
+        sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+    )
+    try:
+        draft = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"draft is not valid JSON: {exc}") from exc
+    if not isinstance(draft, dict):
+        raise SystemExit("draft must be a JSON object")
+    return draft
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--draft", required=True, help="path to the draft JSON, or - for stdin"
+    )
+    parser.add_argument(
+        "--store",
+        default=".",
+        help="the evidence store's root (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    store_root = Path(args.store).resolve()
+    draft = read_draft(args.draft)
+
+    try:
+        record = draft_to_record(draft, dt.datetime.now(dt.timezone.utc))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    validator = load_validator(store_root)
+    errors = validator.validate_record(record, filename_stem=record["id"])
+    if errors:
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        raise SystemExit(f"{len(errors)} contract error(s) — nothing written")
+
+    path = write_record(record, store_root)
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/evidence-memory/tools/record_core.py
+++ b/evidence-memory/tools/record_core.py
@@ -1,0 +1,124 @@
+"""Universal record contract core — the write format every store shares.
+
+Copier-vendored from the agentic-engineering-template — do NOT edit in
+a store repo; change it in the template and pull via `copier update`.
+
+Pure functions, no IO: this is the dojo lift-target, the part a future
+dojo package lifts verbatim. Everything here is common to every record
+kind. What a store calls its fields, and which of them it writes
+first, is that store's own policy and arrives as data.
+
+Validation is deliberately NOT defined here: each store's validator is
+vendored beside its own records, so writer-side and CI validation
+cannot drift.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+
+# Mint-side mirror of the envelope/ID grammar. The vendored validator
+# in a store checkout stays authoritative — minted records are
+# re-validated against it; these constants only make minting fail fast
+# with better messages.
+SCHEMA_VERSION = 1
+MAX_SLUG_LENGTH = 40
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def mint_id(slug: str, now: dt.datetime) -> str:
+    """Mint a record ID: <UTC timestamp>Z-<slug>."""
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"slug {slug!r} must be lowercase kebab-case ([a-z0-9-])")
+    if len(slug) > MAX_SLUG_LENGTH:
+        raise ValueError(f"slug {slug!r} is {len(slug)} chars (max {MAX_SLUG_LENGTH})")
+    timestamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{slug}"
+
+
+def mint_envelope(slug: str, now: dt.datetime, record_type: str) -> dict:
+    """Mint the universal envelope: v, type, id.
+
+    ``record_type`` is what routes a record in a mixed ledger, so it is
+    the calling store's to supply rather than a constant here.
+    """
+    return {
+        "v": SCHEMA_VERSION,
+        "type": record_type,
+        "id": mint_id(slug, now),
+    }
+
+
+def order_fields(merged: dict, field_order: tuple) -> dict:
+    """Order a record's fields by its store's declared order.
+
+    Fields the order does not name keep their incoming order after the
+    ones it does, so an unrecognized field is preserved rather than
+    silently dropped.
+    """
+    record = {key: merged[key] for key in field_order if key in merged}
+    for key, value in merged.items():
+        if key not in record:
+            record[key] = value
+    return record
+
+
+def serialize_record(record: dict) -> str:
+    """Serialize a record for its immutable ``<id>.json`` file."""
+    return json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+
+def resolve_batch_refs(drafts: list, now: dt.datetime) -> list:
+    """Resolve batch-local slug references to minted IDs.
+
+    Drafts written in one pass cannot know each other's final IDs, so
+    cross-draft links name their target by slug: ``supersedes_slug``
+    and ``drill_down_of_slug`` (single), ``related_slugs`` (list,
+    appended to any repo-ID ``related`` entries). This maps every
+    reference to the ID the batch will mint (order-independent).
+    Raises ValueError on unknown slugs or when a draft carries both a
+    slug reference and its resolved field.
+    """
+    minted = {}
+    for d in drafts:
+        slug = d.get("slug")
+        if isinstance(slug, str) and SLUG_RE.match(slug):
+            minted[slug] = mint_id(slug, now)
+
+    def resolve(draft_slug, ref):
+        if ref not in minted:
+            raise ValueError(
+                f"draft {draft_slug!r}: batch reference {ref!r} matches "
+                "no slug in this batch"
+            )
+        return minted[ref]
+
+    resolved = []
+    for d in drafts:
+        d = dict(d)
+        for slug_field, target in (
+            ("supersedes_slug", "supersedes"),
+            ("drill_down_of_slug", "drill_down_of"),
+        ):
+            ref = d.pop(slug_field, None)
+            if ref is not None:
+                if d.get(target):
+                    raise ValueError(
+                        f"draft {d.get('slug')!r}: both {target} and "
+                        f"{slug_field} given — use one"
+                    )
+                d[target] = resolve(d.get("slug"), ref)
+        refs = d.pop("related_slugs", None)
+        if refs is not None:
+            if not isinstance(refs, list):
+                raise ValueError(
+                    f"draft {d.get('slug')!r}: related_slugs must be a list"
+                )
+            existing = d.get("related") or []
+            d["related"] = existing + [resolve(d.get("slug"), r) for r in refs]
+        resolved.append(d)
+    return resolved

--- a/evidence-memory/{{ _copier_conf.answers_file }}.jinja
+++ b/evidence-memory/{{ _copier_conf.answers_file }}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ _copier_answers|to_nice_yaml -}}

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -264,7 +264,9 @@ def test_a_tier_two_record_may_mint_before_its_ticket_exists() -> None:
     """The tier-2 ticket is filed only after a human approves the
     capsule, so the record necessarily predates it. That intermediate
     state is a valid RECORD; the guard is what refuses to merge it."""
-    record = capture.draft_to_record({**draft(), "tier": 2, "ticket": None}, NOW)
+    record = capture.draft_to_record(
+        {**draft(), "tier": 2, "ticket": None, "capsule": "$ repro.sh"}, NOW
+    )
     assert validator.validate_record(record) == []
 
 
@@ -286,9 +288,11 @@ def test_the_ticket_must_still_be_a_url_when_present() -> None:
 def test_the_ticket_key_must_be_present_even_when_null() -> None:
     """Null is a declaration that the ticket is pending; a missing key
     is an omission. The contract distinguishes them."""
-    record = capture.draft_to_record({**draft(), "tier": 2}, NOW)
+    record = capture.draft_to_record(
+        {**draft(), "tier": 2, "capsule": "$ repro.sh"}, NOW
+    )
     del record["ticket"]
-    assert any(e.startswith("ticket:") for e in validator.validate_record(record))
+    assert validator.validate_record(record) == ["ticket: required field missing"]
 
 
 def test_a_null_ticket_blocks_the_merge_gate() -> None:

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -1,0 +1,257 @@
+"""Render and contract tests for the evidence-memory subtemplate.
+
+Selected by `agentic_subtemplate=evidence-memory`, it vendors what an
+evidence store needs — the capture writer, the CI guard, and the store
+docs — into a data repo, keyed by a minimal answers file.
+
+The store holds detection records for bugs and features. It is memory,
+not a tracker: every record names its forge ticket, and progress lives
+there.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import copier
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SUBTEMPLATE = PROJECT_ROOT / "evidence-memory"
+
+STORE_FILES = frozenset(
+    {
+        ".copier-answers.agentic.yml",
+        ".github/guards/evidence_validator.py",
+        ".github/guards/guards.py",
+        ".github/guards/validator_core.py",
+        ".github/workflows/guards.yml",
+        ".gitignore",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "docs/conventions.md",
+        "tools/capture.py",
+        "tools/record_core.py",
+    }
+)
+
+# The cores are copied into both store subtemplates because copier
+# renders one _subdirectory at a time. Managed duplication, per
+# AGENTS.md: declared here, and pinned identical by a test.
+SHARED_CORES = (
+    "tools/record_core.py",
+    ".github/guards/validator_core.py",
+)
+
+validator = load_module(
+    "evidence_validator", SUBTEMPLATE / ".github" / "guards" / "evidence_validator.py"
+)
+capture = load_module("capture", SUBTEMPLATE / "tools" / "capture.py")
+
+NOW = dt.datetime(2026, 7, 28, 16, 15, 0, tzinfo=dt.timezone.utc)
+
+
+def draft() -> dict:
+    """A draft record: the schema minus tool-minted fields, plus slug."""
+    return {
+        "slug": "drift-baseline-ignored",
+        "symptom": "disambiguate --drift exits 0 with a stale baseline entry",
+        "triage": "code-bug",
+        "tier": 1,
+        "rung": "capsule",
+        "ticket": "https://github.com/pandoscope/disambiguate/issues/1",
+        "environment": "disambiguate 0.3.0, python 3.13, repo@abc1234",
+        "expected": "a baselined finding that no longer occurs is pruned",
+        "observed": "the entry survives and the run still exits 0",
+    }
+
+
+def _render_store(tmp_path: Path) -> Path:
+    dst_path = tmp_path / "evidence-memory"
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data={"agentic_subtemplate": "evidence-memory"},
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        # Pin HEAD: with release tags present locally, copier would
+        # otherwise render the latest RELEASE instead of this branch.
+        vcs_ref="HEAD",
+    )
+    return dst_path
+
+
+def test_store_render_produces_exactly_the_store_files(tmp_path: Path) -> None:
+    dst_path = _render_store(tmp_path)
+    rendered = {
+        str(p.relative_to(dst_path)) for p in dst_path.rglob("*") if p.is_file()
+    }
+    assert rendered == STORE_FILES
+
+
+def test_default_render_contains_no_evidence_tooling(render_project) -> None:
+    """The writer is store tooling: it ships to evidence stores through
+    this subtemplate, never to consumer repos."""
+    dst_path = render_project()
+    assert not (dst_path / "tools" / "capture.py").exists()
+    assert not (dst_path / ".github" / "guards" / "evidence_validator.py").exists()
+
+
+@pytest.mark.parametrize("relpath", SHARED_CORES)
+def test_the_shared_cores_are_identical_across_subtemplates(relpath: str) -> None:
+    """Managed duplication, not drift.
+
+    Copier renders one _subdirectory at a time, so the evidence store
+    cannot import the decision store's copy. Two copies is the current
+    price; two DIFFERENT copies would be a defect, and the whole point
+    of one contract core is that N stores cannot fork the schema.
+    """
+    decision_copy = (PROJECT_ROOT / "decision-memory" / relpath).read_bytes()
+    evidence_copy = (SUBTEMPLATE / relpath).read_bytes()
+    assert decision_copy == evidence_copy, (
+        f"{relpath} has drifted between the store subtemplates — "
+        "change it once and copy, or the stores fork the contract"
+    )
+
+
+# --------------------------- the contract ---------------------------
+
+
+def test_a_valid_record_passes() -> None:
+    record = capture.draft_to_record(draft(), NOW)
+    assert validator.validate_record(record, filename_stem=record["id"]) == []
+
+
+def test_the_envelope_carries_the_evidence_type() -> None:
+    record = capture.draft_to_record(draft(), NOW)
+    assert record["type"] == "evidence"
+    assert record["id"] == "20260728T161500Z-drift-baseline-ignored"
+    assert validator.validate_envelope({**record, "type": "decision"}) != []
+
+
+@pytest.mark.parametrize("field", sorted(validator.REQUIRED_FIELDS))
+def test_a_missing_required_field_fails(field: str) -> None:
+    record = capture.draft_to_record(draft(), NOW)
+    record.pop(field, None)
+    assert any(e.startswith(f"{field}:") for e in validator.validate_record(record))
+
+
+def test_a_multi_line_symptom_is_rejected() -> None:
+    """The symptom is the grep-able fingerprint; dedup greps it across a
+    local clone, so everything after the first line would be invisible."""
+    record = capture.draft_to_record(
+        {**draft(), "symptom": "first line\nsecond line"}, NOW
+    )
+    assert any(e.startswith("symptom:") for e in validator.validate_record(record))
+
+
+@pytest.mark.parametrize(
+    "triage", ["code-bug", "doc-bug", "expectation-bug", "feature"]
+)
+def test_the_triage_taxonomy_includes_feature(triage: str) -> None:
+    """A feature-kata's capsule is a test failing because the capability
+    is absent — TDD red — so bug-vs-feature is a triage value here, not
+    a separate record kind."""
+    record = capture.draft_to_record({**draft(), "triage": triage}, NOW)
+    assert validator.validate_record(record) == []
+
+
+def test_an_unknown_triage_is_rejected() -> None:
+    record = capture.draft_to_record({**draft(), "triage": "wontfix"}, NOW)
+    assert any(e.startswith("triage:") for e in validator.validate_record(record))
+
+
+def test_a_tier_two_record_at_the_capsule_rung_must_carry_its_capsule() -> None:
+    """Tier 2 exists BECAUSE the capsule cannot be public. One that
+    reached the capsule rung with nothing stored means the capsule went
+    somewhere else, which is the leak this tier prevents."""
+    record = capture.draft_to_record({**draft(), "tier": 2, "rung": "capsule"}, NOW)
+    assert any(e.startswith("capsule:") for e in validator.validate_record(record))
+
+    with_capsule = capture.draft_to_record(
+        {**draft(), "tier": 2, "rung": "capsule", "capsule": "$ repro.sh"}, NOW
+    )
+    assert validator.validate_record(with_capsule) == []
+
+
+def test_a_tier_two_record_below_the_capsule_rung_needs_no_capsule() -> None:
+    record = capture.draft_to_record({**draft(), "tier": 2, "rung": "ticket"}, NOW)
+    assert validator.validate_record(record) == []
+
+
+def test_a_record_must_name_its_forge_ticket() -> None:
+    """The store is memory; the forge is the backlog. The link is what
+    stops them becoming two trackers."""
+    record = capture.draft_to_record({**draft(), "ticket": "see slack"}, NOW)
+    assert any(e.startswith("ticket:") for e in validator.validate_record(record))
+
+
+def test_links_may_not_point_forward() -> None:
+    """Records are immutable, so an older record can never gain an edge
+    to a newer one. IDs lead with a UTC timestamp, so a forward link is
+    catchable from the ID alone."""
+    newer = "20260729T000000Z-later-finding"
+    record = capture.draft_to_record({**draft(), "same_symptom_as": newer}, NOW)
+    errors = validator.validate_record(record)
+    assert any("backward-only" in e for e in errors)
+
+
+def test_a_backward_link_is_accepted() -> None:
+    older = "20260727T000000Z-earlier-finding"
+    record = capture.draft_to_record({**draft(), "regression_of": older}, NOW)
+    assert validator.validate_record(record) == []
+
+
+def test_the_store_does_not_borrow_decision_link_vocabulary() -> None:
+    """related/supersedes/drill_down_of mean something else in the
+    decision store; a shared spelling with a different meaning is worse
+    than two spellings."""
+    assert validator.LINK_FIELDS == ("same_symptom_as", "regression_of")
+    for borrowed in ("related", "supersedes", "drill_down_of", "duplicate_of"):
+        assert borrowed not in validator.LINK_FIELDS
+        assert borrowed not in capture.FIELD_ORDER
+
+
+def test_the_corpus_check_reports_a_link_outside_the_store() -> None:
+    records = {"20260728T161500Z-a": {"same_symptom_as": "20260101T000000Z-gone"}}
+    errors = validator.validate_corpus(records)
+    assert len(errors) == 1
+    assert "records/" in errors[0]
+
+
+# ---------------------------- the writer ----------------------------
+
+
+def test_the_writer_refuses_to_overwrite_a_record(tmp_path: Path) -> None:
+    """The store is append-only, so an existing path means the ID
+    collided and the caller has to mint again."""
+    record = capture.draft_to_record(draft(), NOW)
+    capture.write_record(record, tmp_path)
+    with pytest.raises(SystemExit):
+        capture.write_record(record, tmp_path)
+
+
+def test_the_writer_lays_the_record_out_symptom_first(tmp_path: Path) -> None:
+    record = capture.draft_to_record(draft(), NOW)
+    path = capture.write_record(record, tmp_path)
+    written = json.loads(path.read_text(encoding="utf-8"))
+    keys = list(written)
+    assert keys[:5] == ["v", "type", "id", "date", "symptom"]
+
+
+def test_the_writer_requires_a_slug() -> None:
+    payload = draft()
+    del payload["slug"]
+    with pytest.raises(ValueError):
+        capture.draft_to_record(payload, NOW)
+
+
+def test_the_writer_keeps_unknown_draft_fields(tmp_path: Path) -> None:
+    record = capture.draft_to_record({**draft(), "future_field": "kept"}, NOW)
+    assert record["future_field"] == "kept"

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -255,3 +255,49 @@ def test_the_writer_requires_a_slug() -> None:
 def test_the_writer_keeps_unknown_draft_fields(tmp_path: Path) -> None:
     record = capture.draft_to_record({**draft(), "future_field": "kept"}, NOW)
     assert record["future_field"] == "kept"
+
+
+# ------------------ the tier-2 ticket-filing window ------------------
+
+
+def test_a_tier_two_record_may_mint_before_its_ticket_exists() -> None:
+    """The tier-2 ticket is filed only after a human approves the
+    capsule, so the record necessarily predates it. That intermediate
+    state is a valid RECORD; the guard is what refuses to merge it."""
+    record = capture.draft_to_record({**draft(), "tier": 2, "ticket": None}, NOW)
+    assert validator.validate_record(record) == []
+
+
+def test_a_tier_one_record_may_not_mint_without_its_ticket() -> None:
+    """Tier 1 has no approval step to wait for — its capsule is public,
+    so the ticket is filed at detection."""
+    record = capture.draft_to_record({**draft(), "tier": 1, "ticket": None}, NOW)
+    assert any(e.startswith("ticket:") for e in validator.validate_record(record))
+
+
+def test_the_ticket_must_still_be_a_url_when_present() -> None:
+    for tier in (1, 2):
+        record = capture.draft_to_record(
+            {**draft(), "tier": tier, "ticket": "see slack"}, NOW
+        )
+        assert any(e.startswith("ticket:") for e in validator.validate_record(record))
+
+
+def test_the_ticket_key_must_be_present_even_when_null() -> None:
+    """Null is a declaration that the ticket is pending; a missing key
+    is an omission. The contract distinguishes them."""
+    record = capture.draft_to_record({**draft(), "tier": 2}, NOW)
+    del record["ticket"]
+    assert any(e.startswith("ticket:") for e in validator.validate_record(record))
+
+
+def test_a_null_ticket_blocks_the_merge_gate() -> None:
+    """Valid as a record, not mergeable as a corpus: every record in the
+    store names its forge ticket, or the store and the backlog drift."""
+    record = capture.draft_to_record({**draft(), "tier": 2, "ticket": None}, NOW)
+    errors = validator.check_tickets_filed({record["id"]: record})
+    assert len(errors) == 1
+    assert "ticket" in errors[0]
+
+    filed = {**record, "ticket": "https://github.com/pandoscope/ghx/issues/1"}
+    assert validator.check_tickets_filed({filed["id"]: filed}) == []


### PR DESCRIPTION
### Description of change

**Stacked on #97** — base is that branch, so this diff shows only the subtemplate. GitHub retargets to `main` when #97 merges.

Adds `evidence-memory` as a third `agentic_subtemplate` choice, so `pandoscope/evidence-memory` is stamped rather than hand-built. What ships into a store: `capture.py` (the sibling writer on `record_core`), `evidence_validator.py` (the contract, on `validator_core`), a guard runner and workflow, the store docs, and the two shared cores.

`_tasks` already no-ops for non-`template` subtemplates, so no wiring was needed there.

### The contract

Derived from the `kata-capture` protocol (pandoscope/skills#27) and the `kata-candidate` form (#75) rather than invented, so the skill, the form and the record do not fork. The rules that are more than presence checks, and why each exists:

- **`symptom` must be a single line.** It is the grep-able fingerprint, and dedup begins by grepping it across a local clone — a multi-line value is invisible to that grep after its first line, which defeats the only query the field exists for.
- **`triage` adds `feature`** to the meta-loop taxonomy. A feature-kata's capsule is a test failing because the capability is absent, which is TDD red — so bug-vs-feature is a triage value, not a separate record kind.
- **A tier-2 record at the `capsule` rung must carry its capsule.** Tier 2 exists *because* the capsule cannot be public; one that reached that rung with nothing stored means the capsule went somewhere else, and that is precisely the leak the tier prevents.
- **Every record names its forge ticket** — with one deliberate window, below.
- **Links are backward-only, checked from the IDs alone.** Records are immutable, so an older record can never gain an edge to a newer one. IDs lead with a UTC timestamp, so a forward link is catchable without consulting the corpus. Ties are tolerated — two records minted in the same second are not evidence of a forward link.

Absent by design: `related` / `supersedes` / `drill_down_of` (decision-store meanings), and `duplicate_of` (a literal duplicate is *skipped* at capture, so the field would name the one case that never produces a record). A test pins their absence.

### The tier-2 ticket window

Filing a tier-2 ticket is the one irreversible step in this store, so it is the one step a human gates (meta#13). The record therefore exists before its ticket does, and the contract has to allow that:

- `ticket` may be `null` on a **tier-2** record. The *key* stays required, so a pending ticket and an omitted one do not read alike.
- Tier 1 is unchanged — its capsule is public, so its ticket is filed at detection and `ticket` is never null.

**The merge gate is separate on purpose.** `validate_record` answers *"is this a well-formed record?"* — and a tier-2 record awaiting approval is one. `check_tickets_filed` answers *"may the store move to this state?"* — and a store holding work with nowhere to track it is exactly the two-tracker drift the ticket link prevents. Expect CI red between minting and filing; that is the guard working, not something to route around.

`docs/conventions.md` carries the stub derivation rule this implies: anything surviving substitution of invented specifics for real ones may go public, the floor is a ticket titled `bug`, and **runnability is the tier boundary** — a leak-free version that still reproduces is tier 1 by definition.

### DRY assessment for the copied cores

Requested once the code existed rather than in the abstract. The cores are currently **copied** into both store subtemplates, with `test_the_shared_cores_are_identical_across_subtemplates` pinning them byte-identical — managed duplication with a declared update mechanism per AGENTS.md § Avoid Duplication, not a fork.

1. **Keep copies + the identity test** (current). Zero new machinery; the failure mode is a contributor editing one copy, which the test catches immediately with a message saying what to do. Cost: two files to touch per core change.
2. **Single source at repo root + a copy step**, guarded by the same test. Removes the two-file edit, adds a generation step and the "did you run it?" failure mode the self-application flow already has.
3. **A `cores` subtemplate stamped separately into each store.** The genuinely single-source option, and the answers file is *already namespaced* (`.copier-answers.agentic.yml`) — multi-template stamping is an anticipated pattern here, not a hack. Cost: a second `copier update` per store, and a store that updates one but not the other drifts silently, which is strictly worse than the failure mode option 1 has.

**Recommendation: stay on 1 until a third store exists.** Two files is not yet a burden, the identity test makes drift loud, and option 3's failure mode is silent — the thing this whole design keeps trying to avoid. Option 3 becomes right at three stores, which is also the roadmap's extract-after-two-instances line.

### Verification

- `uv run pytest` → **180 passed, 3 skipped** (40 new)
- `uvx prek run --all-files` → clean
- Both new behaviors landed red-first; the render test pins the store's exact file manifest, and a separate test pins that a default `template` render still contains no store tooling

### Decisions requiring review

- **ARCH** `evidence-memory/tools/capture.py` — **no git or forge mechanics.** The decision recorder owns clone/branch/commit/PR because a decision session ends in one PR of many records; an evidence filing is a single record dropped mid-task by a caller already in a repo with a commit to make. This is the biggest deliberate omission in the PR and the most likely thing to want revisiting.
- **IFACE** `evidence_validator.check_tickets_filed` — a merge-gate check living outside `validate_record`, on the argument that "well-formed record" and "mergeable store state" are different questions.
- **SCOPE** conditional requirements: `capsule` for tier 2 at the capsule rung, `ticket` nullable for tier 2. Everything else unconditional. Worth checking against how filing actually feels.
- **IFACE** `records/` as the store directory, `symptom` first in the field order after the envelope.
- **SCOPE** The guard is deliberately smaller than the decision store's — no per-commit rules, no preference discipline. It checks what a machine can check and claims nothing more; it never asserts a record is *useful*.

### Follow-ups, deliberately not here

- #103 — the mechanical two-lane gate that makes the tier-2 human review enforceable rather than conventional
- #104 — secret scanning on public surfaces
- #105 — narrowing what a post-approval commit may change

Refs #100

---
_Recreated from #96, which was opened from the wrong account. Same branch, same commits; description copied verbatim (there were no comments)._

_Two sessions recreated the tracking ticket concurrently; #100 is kept and #102 closed as a duplicate._