### PR TITLE
feat(github): label taxonomy and board auto-add for every stamped repo

### DIFF
--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -1,0 +1,77 @@
+# Label taxonomy, synced by .github/workflows/labels.yml.
+#
+# Deliberately small. A label earns its place by having a CONSUMER —
+# something or someone that filters on it. Labels nothing reads drift
+# out of sync with the behaviour they appear to describe, and then
+# mislead the next reader.
+#
+# WARNING: `labels sync` DELETES any label not listed here, removing it
+# from every issue that carries it. Run `labels fetch` first in a repo
+# with existing labels.
+
+# --- triage taxonomy -------------------------------------------------
+# The same four values the evidence store's `triage` field takes, so a
+# record and the ticket it links classify identically.
+
+[code-bug]
+color = "d73a4a"
+name = "code-bug"
+description = "Behaviour contradicts the code's own contract"
+
+[doc-bug]
+color = "1bc4a5"
+name = "doc-bug"
+description = "Behaviour is right, the documentation is wrong"
+
+[expectation-bug]
+color = "e99695"
+name = "expectation-bug"
+description = "Code and docs agree; the expectation they set is wrong"
+
+[feature]
+color = "a2eeef"
+name = "feature"
+description = "A capability that is absent rather than broken"
+
+# --- agent lanes -----------------------------------------------------
+
+[needs-human-review]
+color = "b60205"
+name = "needs-human-review"
+description = "Never auto-merges: a human gate stands between this and main"
+
+# --- programme phase -------------------------------------------------
+# TEMPORARY, for the org consolidation. Encodes dependency order, not
+# urgency. Delete all four when the programme ends.
+
+[phase-0]
+color = "5319e7"
+name = "phase-0"
+description = "Instruments: the board, the stores, the labels themselves"
+
+[phase-1]
+color = "7057ff"
+name = "phase-1"
+description = "Drain in-flight work, in dependency order"
+
+[phase-2]
+color = "9d7bea"
+name = "phase-2"
+description = "Org-wide refactors, gated behind phase-1"
+
+[phase-3]
+color = "c5b3f2"
+name = "phase-3"
+description = "Observation layer — runs throughout, not after"
+
+# --- kept, because a bot applies them --------------------------------
+
+[dependencies]
+color = "0366d6"
+name = "dependencies"
+description = "Pull requests that update a dependency file"
+
+[github_actions]
+color = "000000"
+name = "github_actions"
+description = "Update of github actions"

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,35 @@
+name: Add to project board
+
+on:
+  issues:
+    types: [opened, reopened]
+  # `pull_request` from a fork carries no secrets, so the token would be
+  # empty exactly when a contributor opens a PR. The base-context event
+  # has it. Safe here only because this workflow never checks out — let
+  # alone runs — the PR's code.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+concurrency:
+  group: add-to-project-${{ github.event.number || github.event.issue.number }}
+
+jobs:
+  add:
+    name: "add to board"
+    runs-on: ubuntu-latest
+    # GitHub's built-in auto-add workflow is plan-limited to a single
+    # repository, so the board is populated from here instead. Repos that
+    # set no board URL show this job as SKIPPED rather than green.
+    if: ${{ vars.PROJECT_BOARD_URL != '' }}
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: ${{ vars.PROJECT_BOARD_URL }}
+          # An ORG-level project is outside the repo-scoped GITHUB_TOKEN's
+          # reach, so this needs a PAT with organization Projects: write.
+          # It expires; when it does, items stop reaching the board and the
+          # only visible signal is this job going red. Do not soften that
+          # into a warning.
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,48 @@
+name: Sync labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only when the taxonomy itself changes — this workflow DELETES
+      # labels absent from the config, so it must not fire incidentally.
+      - ".github/labels.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: labels-${{ github.ref }}
+
+jobs:
+  sync:
+    name: "labels sync"
+    runs-on: ubuntu-latest
+    # Opt-in per repo. A repo that never sets the variable shows this job
+    # as SKIPPED, which is visibly different from a green run — an absent
+    # sync must never be indistinguishable from a successful one.
+    if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-python@e9d6f990972a57673cdb72ec29e19d42ba28880f # v6
+        with:
+          python-version: "3.x"
+
+      - name: Sync .github/labels.toml with the forge
+        env:
+          # Needs a PAT with `repo` scope: the default GITHUB_TOKEN cannot
+          # manage labels across an org from a shared config.
+          LABELS_TOKEN: ${{ secrets.LABELS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LABELS_TOKEN:-}" ]; then
+            echo "::error::LABELS_SYNC_ENABLED is true but LABELS_TOKEN is unset."
+            exit 1
+          fi
+          pip install labels
+          labels -u "${{ github.repository_owner }}" -t "$LABELS_TOKEN" \
+            sync -o "${{ github.repository_owner }}" \
+                 -r "${{ github.event.repository.name }}" \
+                 -f .github/labels.toml

--- a/evidence-memory/.github/labels.toml
+++ b/evidence-memory/.github/labels.toml
@@ -1,0 +1,23 @@
+# Label taxonomy for an evidence store, synced by
+# .github/workflows/labels.yml.
+#
+# Copier-vendored from the agentic-engineering-template evidence
+# subtemplate — change it in the template, not here.
+#
+# Deliberately tiny, and deliberately NOT the project taxonomy. Triage
+# (code-bug / doc-bug / expectation-bug / feature) belongs on the forge
+# TICKET a record links, never on the record's own PR: this store is
+# memory, not a tracker, and classifying in two places is how the two
+# classifications diverge.
+#
+# WARNING: `labels sync` DELETES any label not listed here.
+
+[needs-human-review]
+color = "b60205"
+name = "needs-human-review"
+description = "Never auto-merges: a human approves the capsule before its ticket is filed"
+
+[tier-2]
+color = "5319e7"
+name = "tier-2"
+description = "Capsule cannot be sanitized, so it stays in the store and the ticket carries a summary"

--- a/evidence-memory/.github/workflows/labels.yml
+++ b/evidence-memory/.github/workflows/labels.yml
@@ -1,0 +1,53 @@
+name: Sync labels
+
+# Copier-vendored from the agentic-engineering-template evidence
+# subtemplate. The tier-2 gate (agentic-engineering-template#103) selects
+# on these labels, so they have to exist before that gate is mechanical
+# rather than conventional.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only when the taxonomy itself changes — this workflow DELETES
+      # labels absent from the config, so it must not fire incidentally.
+      - ".github/labels.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: labels-${{ github.ref }}
+
+jobs:
+  sync:
+    name: "labels sync"
+    runs-on: ubuntu-latest
+    # Opt-in per repo. A repo that never sets the variable shows this job
+    # as SKIPPED, which is visibly different from a green run — an absent
+    # sync must never be indistinguishable from a successful one.
+    if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-python@e9d6f990972a57673cdb72ec29e19d42ba28880f # v6
+        with:
+          python-version: "3.x"
+
+      - name: Sync .github/labels.toml with the forge
+        env:
+          # Needs a PAT with `repo` scope: the default GITHUB_TOKEN cannot
+          # manage labels across an org from a shared config.
+          LABELS_TOKEN: ${{ secrets.LABELS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LABELS_TOKEN:-}" ]; then
+            echo "::error::LABELS_SYNC_ENABLED is true but LABELS_TOKEN is unset."
+            exit 1
+          fi
+          pip install labels
+          labels -u "${{ github.repository_owner }}" -t "$LABELS_TOKEN" \
+            sync -o "${{ github.repository_owner }}" \
+                 -r "${{ github.event.repository.name }}" \
+                 -f .github/labels.toml

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/labels.toml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/labels.toml
@@ -1,0 +1,77 @@
+# Label taxonomy, synced by .github/workflows/labels.yml.
+#
+# Deliberately small. A label earns its place by having a CONSUMER —
+# something or someone that filters on it. Labels nothing reads drift
+# out of sync with the behaviour they appear to describe, and then
+# mislead the next reader.
+#
+# WARNING: `labels sync` DELETES any label not listed here, removing it
+# from every issue that carries it. Run `labels fetch` first in a repo
+# with existing labels.
+
+# --- triage taxonomy -------------------------------------------------
+# The same four values the evidence store's `triage` field takes, so a
+# record and the ticket it links classify identically.
+
+[code-bug]
+color = "d73a4a"
+name = "code-bug"
+description = "Behaviour contradicts the code's own contract"
+
+[doc-bug]
+color = "1bc4a5"
+name = "doc-bug"
+description = "Behaviour is right, the documentation is wrong"
+
+[expectation-bug]
+color = "e99695"
+name = "expectation-bug"
+description = "Code and docs agree; the expectation they set is wrong"
+
+[feature]
+color = "a2eeef"
+name = "feature"
+description = "A capability that is absent rather than broken"
+
+# --- agent lanes -----------------------------------------------------
+
+[needs-human-review]
+color = "b60205"
+name = "needs-human-review"
+description = "Never auto-merges: a human gate stands between this and main"
+
+# --- programme phase -------------------------------------------------
+# TEMPORARY, for the org consolidation. Encodes dependency order, not
+# urgency. Delete all four when the programme ends.
+
+[phase-0]
+color = "5319e7"
+name = "phase-0"
+description = "Instruments: the board, the stores, the labels themselves"
+
+[phase-1]
+color = "7057ff"
+name = "phase-1"
+description = "Drain in-flight work, in dependency order"
+
+[phase-2]
+color = "9d7bea"
+name = "phase-2"
+description = "Org-wide refactors, gated behind phase-1"
+
+[phase-3]
+color = "c5b3f2"
+name = "phase-3"
+description = "Observation layer — runs throughout, not after"
+
+# --- kept, because a bot applies them --------------------------------
+
+[dependencies]
+color = "0366d6"
+name = "dependencies"
+description = "Pull requests that update a dependency file"
+
+[github_actions]
+color = "000000"
+name = "github_actions"
+description = "Update of github actions"

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/add-to-project.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/add-to-project.yml
@@ -1,0 +1,35 @@
+name: Add to project board
+
+on:
+  issues:
+    types: [opened, reopened]
+  # `pull_request` from a fork carries no secrets, so the token would be
+  # empty exactly when a contributor opens a PR. The base-context event
+  # has it. Safe here only because this workflow never checks out — let
+  # alone runs — the PR's code.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+concurrency:
+  group: add-to-project-${{ github.event.number || github.event.issue.number }}
+
+jobs:
+  add:
+    name: "add to board"
+    runs-on: ubuntu-latest
+    # GitHub's built-in auto-add workflow is plan-limited to a single
+    # repository, so the board is populated from here instead. Repos that
+    # set no board URL show this job as SKIPPED rather than green.
+    if: ${{ vars.PROJECT_BOARD_URL != '' }}
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: ${{ vars.PROJECT_BOARD_URL }}
+          # An ORG-level project is outside the repo-scoped GITHUB_TOKEN's
+          # reach, so this needs a PAT with organization Projects: write.
+          # It expires; when it does, items stop reaching the board and the
+          # only visible signal is this job going red. Do not soften that
+          # into a warning.
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml
@@ -1,0 +1,48 @@
+name: Sync labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only when the taxonomy itself changes — this workflow DELETES
+      # labels absent from the config, so it must not fire incidentally.
+      - ".github/labels.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: labels-${{ github.ref }}
+
+jobs:
+  sync:
+    name: "labels sync"
+    runs-on: ubuntu-latest
+    # Opt-in per repo. A repo that never sets the variable shows this job
+    # as SKIPPED, which is visibly different from a green run — an absent
+    # sync must never be indistinguishable from a successful one.
+    if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-python@e9d6f990972a57673cdb72ec29e19d42ba28880f # v6
+        with:
+          python-version: "3.x"
+
+      - name: Sync .github/labels.toml with the forge
+        env:
+          # Needs a PAT with `repo` scope: the default GITHUB_TOKEN cannot
+          # manage labels across an org from a shared config.
+          LABELS_TOKEN: ${{ secrets.LABELS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LABELS_TOKEN:-}" ]; then
+            echo "::error::LABELS_SYNC_ENABLED is true but LABELS_TOKEN is unset."
+            exit 1
+          fi
+          pip install labels
+          labels -u "${{ github.repository_owner }}" -t "$LABELS_TOKEN" \
+            sync -o "${{ github.repository_owner }}" \
+                 -r "${{ github.event.repository.name }}" \
+                 -f .github/labels.toml

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -51,6 +51,9 @@ COMMON_FILES = frozenset(
 GITHUB_ONLY_FILES = frozenset(
     {
         ".github/workflows/template-update.yml",
+        ".github/labels.toml",
+        ".github/workflows/add-to-project.yml",
+        ".github/workflows/labels.yml",
         ".github/workflows/lint.yml",
     }
 )

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import tomllib
 from pathlib import Path
 
 import copier
@@ -29,7 +30,9 @@ STORE_FILES = frozenset(
         ".github/guards/evidence_validator.py",
         ".github/guards/guards.py",
         ".github/guards/validator_core.py",
+        ".github/labels.toml",
         ".github/workflows/guards.yml",
+        ".github/workflows/labels.yml",
         ".gitignore",
         "AGENTS.md",
         "CLAUDE.md",
@@ -305,3 +308,41 @@ def test_a_null_ticket_blocks_the_merge_gate() -> None:
 
     filed = {**record, "ticket": "https://github.com/pandoscope/ghx/issues/1"}
     assert validator.check_tickets_filed({filed["id"]: filed}) == []
+
+
+# ------------------------ the tier-2 gate's labels ------------------------
+
+
+def test_the_store_ships_the_labels_its_tier_two_gate_needs(
+    tmp_path: Path,
+) -> None:
+    """#103's two-lane gate is label-based, so the labels have to exist
+    in the store before the gate can be mechanical rather than
+    conventional. The project template's taxonomy does not reach here:
+    a store renders its own file set and stays consumer-ignorant.
+    """
+    dst_path = _render_store(tmp_path)
+
+    config = (dst_path / ".github" / "labels.toml").read_text()
+    # The lane marker: a tier-2 record waits for a human, and this is how
+    # that wait is visible without opening every PR.
+    assert "needs-human-review" in config
+    # The tier itself, so the gate can select on it.
+    assert "tier-2" in config
+
+    workflow = (dst_path / ".github" / "workflows" / "labels.yml").read_text()
+    assert ".github/labels.toml" in workflow
+    assert "LABELS_TOKEN" in workflow
+
+
+def test_the_store_takes_no_triage_or_phase_labels(tmp_path: Path) -> None:
+    """Triage lives on the forge TICKET, not on the record's PR — the
+    store is memory, not a tracker. Shipping the ticket taxonomy here
+    would invite classifying in two places, which is how they diverge.
+    """
+    dst_path = _render_store(tmp_path)
+    # Parse rather than substring-match: the file explains in prose which
+    # labels it deliberately omits, and naming them there is the point.
+    defined = tomllib.loads((dst_path / ".github" / "labels.toml").read_text())
+
+    assert set(defined) == {"needs-human-review", "tier-2"}

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -553,3 +553,96 @@ def test_precommit_none_omits_prek_bootstrap(
         for hook in group["hooks"]
     ]
     assert not any("ensure-prek.sh" in command for command in commands)
+
+
+# ------------------ org plumbing: labels + board auto-add ------------------
+
+
+def test_github_forge_ships_label_config_and_sync_workflow(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Labels are config-as-code so the taxonomy is one file, not seven
+    clicked-in sets that drift."""
+    dst_path = _render(tmp_path, base_answers, "labels-github")
+
+    _check_file_contents(
+        dst_path / ".github" / "labels.toml",
+        [
+            # Triage taxonomy — the evidence store's `triage` values, so a
+            # record and its ticket classify the same way.
+            "code-bug",
+            "doc-bug",
+            "expectation-bug",
+            "feature",
+            # The quarantine lane's marker (agentic-engineering-template#62).
+            "needs-human-review",
+            # Kept deliberately: these are what Dependabot applies.
+            "dependencies",
+            "github_actions",
+        ],
+    )
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "labels.yml",
+        [
+            # Only fires when the taxonomy itself changes.
+            ".github/labels.toml",
+            "workflow_dispatch",
+            "LABELS_TOKEN",
+        ],
+    )
+
+
+def test_label_sync_is_skipped_rather_than_failed_without_its_token(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """A repo that never sets the org secret must not show a permanently
+    red workflow — but the job has to be visibly SKIPPED, never a silent
+    green, or the absence of the sync reads as a successful sync."""
+    dst_path = _render(tmp_path, base_answers, "labels-guard")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "labels.yml",
+        ["if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}"],
+    )
+
+
+def test_github_forge_ships_board_auto_add_workflow(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """GitHub's built-in auto-add is plan-limited to one repository, so
+    the board is populated by an action instead."""
+    dst_path = _render(tmp_path, base_answers, "board-github")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "add-to-project.yml",
+        [
+            "actions/add-to-project",
+            # The default GITHUB_TOKEN is repo-scoped and cannot write to
+            # an ORG-level project.
+            "PROJECT_BOARD_TOKEN",
+            "vars.PROJECT_BOARD_URL",
+            # Fork PRs carry no secrets under `pull_request`; the base-context
+            # event is what makes the token reachable. Safe here only because
+            # nothing checks out PR code.
+            "pull_request_target",
+        ],
+    )
+
+
+def test_forgejo_forge_ships_no_github_org_plumbing(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Both workflows are GitHub-specific: `labels` targets the GitHub
+    API and Projects V2 has no Forgejo counterpart."""
+    answers = {
+        **base_answers,
+        "agentic_forge": "forgejo",
+        "agentic_forgejo_host": "codeberg.org",
+    }
+    dst_path = _render(tmp_path, answers, "no-plumbing-forgejo")
+
+    assert not (dst_path / ".github").exists()


### PR DESCRIPTION
Closes #106.

Ships `.github/labels.toml` (11 labels), `.github/workflows/labels.yml`, and
`.github/workflows/add-to-project.yml` under the existing
`agentic_forge == 'github'` conditional, plus self-application to this repo.

#106 carries the full rationale. The four points most worth a reviewer's
attention:

**Both jobs skip rather than pass when unconfigured**, gated on org variables.
A repo that never sets one shows the job as *skipped* — visibly different from
green. Fourth instance this session of the failure class where a mechanism's
absence and its success look identical (ghx#7, skills#32, meta#33). Inside the
jobs the rule inverts: enabled-but-tokenless **fails loudly** rather than
no-oping.

**`pull_request_target`, not `pull_request`** — a fork PR under `pull_request`
carries no secrets, so the board token would be empty exactly when an outside
contributor opens a PR. Safe only because nothing here checks out PR code; the
constraint is commented at the call site.

**⚠️ The first `labels sync` is destructive** — it deletes any label absent from
the config, removing it from every issue carrying it. `disambiguate`'s 21
labels are unused template seed so this is expected, but it should be a
decision rather than a surprise. Warning lives in the config file itself.

**`phase-*` labels supersede `board-priority-encodes-phase`**, recorded this
morning. The board's Priority field turns out to be unwritable through the
Projects connector (`option_not_found` for options it demonstrably has, while
`Status` and `Size` accept the identical call). Labels are writable, travel
with the issue, and make the ruling's own sunset clause cheaper.

## Verification

`184 passed, 3 skipped`; `prek run --all-files` clean.

Five render tests added: label config contents, the skip-not-fail guard, the
board workflow's token/event/URL wiring, and a Forgejo negative case asserting
no `.github` at all. Tests were written first and observed failing (3 red, 1
green — the Forgejo case correctly passed before any implementation existed);
they are committed together with the implementation rather than as a separate
`test(red)` commit, since render tests have no meaningful xfail form and a
red commit would have left CI red.

`test_e2e`'s pinned render tree and `test_self_application` both had to be
updated — the latter forced the adopt-or-declare-divergence decision, and
adopting was the honest answer for a repo with 30 open issues that belong on
the board.

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_