### PR TITLE
feat: make template updates actually propagate — stores get an updater, releases announce themselves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,68 @@ jobs:
           # semantic-release needs full history and tags to find the
           # previous release and analyze the commits since.
           fetch-depth: 0
+      - name: Record the tag before releasing
+        id: before
+        run: echo "tag=$(git tag --list --sort=-v:refname | head -1)" >> "$GITHUB_OUTPUT"
+
       - run: npx --yes semantic-release@24
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect whether a release was actually cut
+        id: released
+        run: |
+          set -euo pipefail
+          after="$(git tag --list --sort=-v:refname | head -1)"
+          if [ "$after" != "${{ steps.before.outputs.tag }}" ]; then
+            echo "tag=$after" >> "$GITHUB_OUTPUT"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new tag — nothing to announce."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The release above is published with GITHUB_TOKEN, and GitHub does
+      # not let a GITHUB_TOKEN-created event trigger further workflows. So
+      # an `on: release` workflow would never fire, and the fan-out has to
+      # happen here, with an app token.
+      - name: Mint release-bot token for the fan-out
+        if: steps.released.outputs.released == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Tell every stamped repo a release is out
+        if: steps.released.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          SELF: ${{ github.repository }}
+          TAG: ${{ steps.released.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Consumers are DISCOVERED, never listed: a hardcoded array is a
+          # per-repo checklist, which is the thing this factory replaces
+          # with mechanism. A repo is a consumer iff it carries an answers
+          # file naming this template.
+          failed=0
+          for repo in $(gh repo list "$OWNER" --limit 200 --json nameWithOwner --jq '.[].nameWithOwner'); do
+            [ "$repo" = "$SELF" ] && continue
+            gh api "repos/$repo/contents/.copier-answers.agentic.yml" \
+              --jq .name >/dev/null 2>&1 || continue
+            if gh api --method POST "repos/$repo/dispatches" \
+                 -f "event_type=template-released" \
+                 -f "client_payload[tag]=$TAG"; then
+              echo "dispatched $TAG -> $repo"
+            else
+              # Never swallowed: a consumer that silently stops receiving
+              # updates is indistinguishable from one that is up to date.
+              echo "::error::dispatch failed for $repo"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/decision-memory/.github/workflows/template-update.yml
+++ b/decision-memory/.github/workflows/template-update.yml
@@ -1,0 +1,127 @@
+name: Template Update
+
+on:
+  schedule:
+    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+# The workflow only acts through the release-bot app token minted below —
+# the default GITHUB_TOKEN would open PRs that trigger no CI, silently
+# skipping the checks that flag copier conflict markers for resolution.
+permissions: {}
+
+concurrency:
+  group: template-update
+
+jobs:
+  update:
+    name: "copier update (agentic template)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Skip if an update PR is already open
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          open_prs="$(gh pr list --state open --json headRefName \
+            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
+          if [ "$open_prs" -gt 0 ]; then
+            echo "An update PR is already open ($open_prs) — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.dedupe.outputs.skip == 'false'
+        with:
+          # Push the update branch as the app so the resulting PR runs CI.
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.dedupe.outputs.skip == 'false'
+
+      - name: Run copier update against the latest template tag
+        if: steps.dedupe.outputs.skip == 'false'
+        id: update
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          old_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          # --skip-tasks: post-tasks (doctor.sh, skills install, prek) need
+          # host tools absent on runners; the consuming repo already ran them.
+          # copier-template-extensions is required to load the template's
+          # Jinja extensions.
+          uvx --with copier-template-extensions copier update \
+            --answers-file "$answers_file" \
+            --defaults --trust --skip-tasks
+
+          new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+          {
+            echo "old_ref=$old_ref"
+            echo "new_ref=$new_ref"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Already up to date ($old_ref) — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open update PR
+        if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_REF: ${{ steps.update.outputs.old_ref }}
+          NEW_REF: ${{ steps.update.outputs.new_ref }}
+        run: |
+          set -euo pipefail
+          branch="chore/template-update-$NEW_REF"
+
+          git config user.name "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # Conflicts are committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution on
+          # the branch, so updates never silently stall.
+          git add -A
+          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
+          git push -u origin "$branch"
+
+          # Changelog excerpt from the template's GitHub Release for the new
+          # tag. Best-effort: a missing release only degrades the PR body.
+          src_path="$(awk '$1 == "_src_path:" {print $2}' .copier-answers.agentic.yml)"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+          changelog="$(gh release view "$NEW_REF" --repo "$template_repo" \
+            --json body --jq .body \
+            || echo "_No release notes found for $NEW_REF in $template_repo._")"
+
+          {
+            echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
+            echo
+            echo "If CI is red, the update hit merge conflicts — resolve copier's inline conflict markers on this branch."
+            echo
+            echo "## Template changelog ($NEW_REF)"
+            echo
+            echo "$changelog"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "chore: update agentic template to $NEW_REF" \
+            --body-file /tmp/pr-body.md \
+            --head "$branch"

--- a/decision-memory/.github/workflows/template-update.yml
+++ b/decision-memory/.github/workflows/template-update.yml
@@ -1,8 +1,15 @@
 name: Template Update
 
 on:
+  # Fired by the template's own release job the moment a release is cut,
+  # so an update arrives because something happened rather than because a
+  # timer caught up.
+  repository_dispatch:
+    types: [template-released]
   schedule:
-    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    # Backstop, not the delivery path: a repo stamped after the dispatch
+    # ran, or one the dispatch failed to reach, still converges within a
+    # week. Off the top of the hour to dodge GitHub's cron stampede.
     - cron: "17 5 * * 1"
   workflow_dispatch:
 

--- a/decision-memory/.github/workflows/template-update.yml
+++ b/decision-memory/.github/workflows/template-update.yml
@@ -40,13 +40,56 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          open_prs="$(gh pr list --state open --json headRefName \
-            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
-          if [ "$open_prs" -gt 0 ]; then
-            echo "An update PR is already open ($open_prs) — skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          open_pr="$(gh pr list --state open --json headRefName,number,url,createdAt \
+            --jq 'map(select(.headRefName | startswith("chore/template-update-"))) | first')"
+          if [ -n "$open_pr" ] && [ "$open_pr" != "null" ]; then
+            echo "An update PR is already open — skipping the update run."
+            {
+              echo "skip=true"
+              echo "pr_url=$(echo "$open_pr" | jq -r .url)"
+              echo "pr_opened=$(echo "$open_pr" | jq -r .createdAt)"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The cron is the auditor, so it is the run that has to be loud. A
+      # repo can be behind for exactly two reasons, and both are failures
+      # of something rather than states to live with:
+      #
+      #   - an update PR is open and nobody merged it
+      #   - no PR at all, which means the release fan-out never arrived
+      #
+      # Neither is visible from a green weekly run, and "quietly behind"
+      # is the state this whole mechanism exists to prevent.
+      - name: Audit — is this repo actually on the latest template?
+        if: github.event_name == 'schedule'
+        id: audit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.dedupe.outputs.pr_url }}
+          PR_OPENED: ${{ steps.dedupe.outputs.pr_opened }}
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          src_path="$(awk '$1 == "_src_path:" {print $2}' "$answers_file")"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+
+          latest="$(gh release view --repo "$template_repo" --json tagName --jq .tagName)"
+
+          if [ "$stamped" = "$latest" ]; then
+            echo "On the latest template ($latest)."
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${PR_URL:-}" ]; then
+            echo "::error::Out of date: stamped $stamped, latest is $latest. An update PR has been open since $PR_OPENED and has not been merged: $PR_URL"
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Out of date: stamped $stamped, latest is $latest, and no update PR exists. The release fan-out did not reach this repo — check the dispatch step of the template's release job."
+            echo "drift=true" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -132,3 +175,12 @@ jobs:
             --title "chore: update agentic template to $NEW_REF" \
             --body-file /tmp/pr-body.md \
             --head "$branch"
+
+      # Last, not at the audit: a drifted repo with no PR still needs the
+      # update run above to open one. Failing early would report the
+      # problem and then decline to fix it.
+      - name: Fail the audit if this repo is behind
+        if: github.event_name == 'schedule' && steps.audit.outputs.drift == 'true'
+        run: |
+          echo "Weekly audit found this repo behind the template — see the annotation above."
+          exit 1

--- a/evidence-memory/.github/workflows/template-update.yml
+++ b/evidence-memory/.github/workflows/template-update.yml
@@ -1,0 +1,127 @@
+name: Template Update
+
+on:
+  schedule:
+    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+# The workflow only acts through the release-bot app token minted below —
+# the default GITHUB_TOKEN would open PRs that trigger no CI, silently
+# skipping the checks that flag copier conflict markers for resolution.
+permissions: {}
+
+concurrency:
+  group: template-update
+
+jobs:
+  update:
+    name: "copier update (agentic template)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Skip if an update PR is already open
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          open_prs="$(gh pr list --state open --json headRefName \
+            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
+          if [ "$open_prs" -gt 0 ]; then
+            echo "An update PR is already open ($open_prs) — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.dedupe.outputs.skip == 'false'
+        with:
+          # Push the update branch as the app so the resulting PR runs CI.
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.dedupe.outputs.skip == 'false'
+
+      - name: Run copier update against the latest template tag
+        if: steps.dedupe.outputs.skip == 'false'
+        id: update
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          old_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          # --skip-tasks: post-tasks (doctor.sh, skills install, prek) need
+          # host tools absent on runners; the consuming repo already ran them.
+          # copier-template-extensions is required to load the template's
+          # Jinja extensions.
+          uvx --with copier-template-extensions copier update \
+            --answers-file "$answers_file" \
+            --defaults --trust --skip-tasks
+
+          new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+          {
+            echo "old_ref=$old_ref"
+            echo "new_ref=$new_ref"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Already up to date ($old_ref) — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open update PR
+        if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_REF: ${{ steps.update.outputs.old_ref }}
+          NEW_REF: ${{ steps.update.outputs.new_ref }}
+        run: |
+          set -euo pipefail
+          branch="chore/template-update-$NEW_REF"
+
+          git config user.name "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # Conflicts are committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution on
+          # the branch, so updates never silently stall.
+          git add -A
+          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
+          git push -u origin "$branch"
+
+          # Changelog excerpt from the template's GitHub Release for the new
+          # tag. Best-effort: a missing release only degrades the PR body.
+          src_path="$(awk '$1 == "_src_path:" {print $2}' .copier-answers.agentic.yml)"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+          changelog="$(gh release view "$NEW_REF" --repo "$template_repo" \
+            --json body --jq .body \
+            || echo "_No release notes found for $NEW_REF in $template_repo._")"
+
+          {
+            echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
+            echo
+            echo "If CI is red, the update hit merge conflicts — resolve copier's inline conflict markers on this branch."
+            echo
+            echo "## Template changelog ($NEW_REF)"
+            echo
+            echo "$changelog"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "chore: update agentic template to $NEW_REF" \
+            --body-file /tmp/pr-body.md \
+            --head "$branch"

--- a/evidence-memory/.github/workflows/template-update.yml
+++ b/evidence-memory/.github/workflows/template-update.yml
@@ -1,8 +1,15 @@
 name: Template Update
 
 on:
+  # Fired by the template's own release job the moment a release is cut,
+  # so an update arrives because something happened rather than because a
+  # timer caught up.
+  repository_dispatch:
+    types: [template-released]
   schedule:
-    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    # Backstop, not the delivery path: a repo stamped after the dispatch
+    # ran, or one the dispatch failed to reach, still converges within a
+    # week. Off the top of the hour to dodge GitHub's cron stampede.
     - cron: "17 5 * * 1"
   workflow_dispatch:
 

--- a/evidence-memory/.github/workflows/template-update.yml
+++ b/evidence-memory/.github/workflows/template-update.yml
@@ -40,13 +40,56 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          open_prs="$(gh pr list --state open --json headRefName \
-            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
-          if [ "$open_prs" -gt 0 ]; then
-            echo "An update PR is already open ($open_prs) — skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          open_pr="$(gh pr list --state open --json headRefName,number,url,createdAt \
+            --jq 'map(select(.headRefName | startswith("chore/template-update-"))) | first')"
+          if [ -n "$open_pr" ] && [ "$open_pr" != "null" ]; then
+            echo "An update PR is already open — skipping the update run."
+            {
+              echo "skip=true"
+              echo "pr_url=$(echo "$open_pr" | jq -r .url)"
+              echo "pr_opened=$(echo "$open_pr" | jq -r .createdAt)"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The cron is the auditor, so it is the run that has to be loud. A
+      # repo can be behind for exactly two reasons, and both are failures
+      # of something rather than states to live with:
+      #
+      #   - an update PR is open and nobody merged it
+      #   - no PR at all, which means the release fan-out never arrived
+      #
+      # Neither is visible from a green weekly run, and "quietly behind"
+      # is the state this whole mechanism exists to prevent.
+      - name: Audit — is this repo actually on the latest template?
+        if: github.event_name == 'schedule'
+        id: audit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.dedupe.outputs.pr_url }}
+          PR_OPENED: ${{ steps.dedupe.outputs.pr_opened }}
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          src_path="$(awk '$1 == "_src_path:" {print $2}' "$answers_file")"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+
+          latest="$(gh release view --repo "$template_repo" --json tagName --jq .tagName)"
+
+          if [ "$stamped" = "$latest" ]; then
+            echo "On the latest template ($latest)."
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${PR_URL:-}" ]; then
+            echo "::error::Out of date: stamped $stamped, latest is $latest. An update PR has been open since $PR_OPENED and has not been merged: $PR_URL"
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Out of date: stamped $stamped, latest is $latest, and no update PR exists. The release fan-out did not reach this repo — check the dispatch step of the template's release job."
+            echo "drift=true" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -132,3 +175,12 @@ jobs:
             --title "chore: update agentic template to $NEW_REF" \
             --body-file /tmp/pr-body.md \
             --head "$branch"
+
+      # Last, not at the audit: a drifted repo with no PR still needs the
+      # update run above to open one. Failing early would report the
+      # problem and then decline to fix it.
+      - name: Fail the audit if this repo is behind
+        if: github.event_name == 'schedule' && steps.audit.outputs.drift == 'true'
+        run: |
+          echo "Weekly audit found this repo behind the template — see the annotation above."
+          exit 1

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
@@ -1,8 +1,15 @@
 name: Template Update
 
 on:
+  # Fired by the template's own release job the moment a release is cut,
+  # so an update arrives because something happened rather than because a
+  # timer caught up.
+  repository_dispatch:
+    types: [template-released]
   schedule:
-    # Weekly, off the top of the hour to dodge GitHub's cron stampede.
+    # Backstop, not the delivery path: a repo stamped after the dispatch
+    # ran, or one the dispatch failed to reach, still converges within a
+    # week. Off the top of the hour to dodge GitHub's cron stampede.
     - cron: "17 5 * * 1"
   workflow_dispatch:
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
@@ -40,13 +40,56 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          open_prs="$(gh pr list --state open --json headRefName \
-            --jq '[.[].headRefName | select(startswith("chore/template-update-"))] | length')"
-          if [ "$open_prs" -gt 0 ]; then
-            echo "An update PR is already open ($open_prs) — skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          open_pr="$(gh pr list --state open --json headRefName,number,url,createdAt \
+            --jq 'map(select(.headRefName | startswith("chore/template-update-"))) | first')"
+          if [ -n "$open_pr" ] && [ "$open_pr" != "null" ]; then
+            echo "An update PR is already open — skipping the update run."
+            {
+              echo "skip=true"
+              echo "pr_url=$(echo "$open_pr" | jq -r .url)"
+              echo "pr_opened=$(echo "$open_pr" | jq -r .createdAt)"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The cron is the auditor, so it is the run that has to be loud. A
+      # repo can be behind for exactly two reasons, and both are failures
+      # of something rather than states to live with:
+      #
+      #   - an update PR is open and nobody merged it
+      #   - no PR at all, which means the release fan-out never arrived
+      #
+      # Neither is visible from a green weekly run, and "quietly behind"
+      # is the state this whole mechanism exists to prevent.
+      - name: Audit — is this repo actually on the latest template?
+        if: github.event_name == 'schedule'
+        id: audit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.dedupe.outputs.pr_url }}
+          PR_OPENED: ${{ steps.dedupe.outputs.pr_opened }}
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          src_path="$(awk '$1 == "_src_path:" {print $2}' "$answers_file")"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+
+          latest="$(gh release view --repo "$template_repo" --json tagName --jq .tagName)"
+
+          if [ "$stamped" = "$latest" ]; then
+            echo "On the latest template ($latest)."
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${PR_URL:-}" ]; then
+            echo "::error::Out of date: stamped $stamped, latest is $latest. An update PR has been open since $PR_OPENED and has not been merged: $PR_URL"
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Out of date: stamped $stamped, latest is $latest, and no update PR exists. The release fan-out did not reach this repo — check the dispatch step of the template's release job."
+            echo "drift=true" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -132,3 +175,12 @@ jobs:
             --title "chore: update agentic template to $NEW_REF" \
             --body-file /tmp/pr-body.md \
             --head "$branch"
+
+      # Last, not at the audit: a drifted repo with no PR still needs the
+      # update run above to open one. Failing early would report the
+      # problem and then decline to fix it.
+      - name: Fail the audit if this repo is behind
+        if: github.event_name == 'schedule' && steps.audit.outputs.drift == 'true'
+        run: |
+          echo "Weekly audit found this repo behind the template — see the annotation above."
+          exit 1

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -35,6 +35,7 @@ STORE_FILES = frozenset(
         ".github/workflows/preferences-budget.yml",
         ".github/workflows/preferences-guard.yml",
         ".github/workflows/guards.yml",
+        ".github/workflows/template-update.yml",
         ".gitignore",
         "AGENTS.md",
         "CLAUDE.md",

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -32,6 +32,7 @@ STORE_FILES = frozenset(
         ".github/guards/validator_core.py",
         ".github/labels.toml",
         ".github/workflows/guards.yml",
+        ".github/workflows/template-update.yml",
         ".github/workflows/labels.yml",
         ".gitignore",
         "AGENTS.md",
@@ -49,6 +50,7 @@ STORE_FILES = frozenset(
 SHARED_CORES = (
     "tools/record_core.py",
     ".github/guards/validator_core.py",
+    ".github/workflows/template-update.yml",
 )
 
 validator = load_module(
@@ -346,3 +348,23 @@ def test_the_store_takes_no_triage_or_phase_labels(tmp_path: Path) -> None:
     defined = tomllib.loads((dst_path / ".github" / "labels.toml").read_text())
 
     assert set(defined) == {"needs-human-review", "tier-2"}
+
+
+def test_the_store_updater_matches_the_one_consumers_get() -> None:
+    """A store vendors record_core and validator_core, so a fix to
+    either reaches it only through `copier update`. Without an updater
+    the store silently runs a stale validator — the gap meta#30 names.
+
+    Byte-identical to the consumer workflow on purpose: three copies
+    that DIFFER would mean the stores update by different rules than
+    everything else, which is the drift the pinning exists to stop.
+    """
+    consumer = (
+        PROJECT_ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "template-update.yml"
+    ).read_bytes()
+    store = (SUBTEMPLATE / ".github" / "workflows" / "template-update.yml").read_bytes()
+    assert store == consumer

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -668,3 +668,25 @@ def test_consumers_are_told_about_a_release_rather_than_polling_for_it(
             "workflow_dispatch:",
         ],
     )
+
+
+def test_the_weekly_run_fails_loudly_when_the_repo_is_behind(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """A green weekly run must mean "on the latest template", not "the
+    workflow executed". Being quietly behind is the state the whole
+    updater exists to prevent, and it is invisible otherwise.
+
+    Only on `schedule`: the cron is the auditor. A dispatch that fails
+    is already visible to whoever triggered it.
+    """
+    dst_path = _render(tmp_path, base_answers, "update-audit")
+    workflow = (dst_path / ".github" / "workflows" / "template-update.yml").read_text()
+
+    assert "github.event_name == 'schedule'" in workflow
+    # Both drift causes are named, because the remedy differs: merge the
+    # PR, versus go and look at why the fan-out never arrived.
+    assert "has not been merged" in workflow
+    assert "did not reach this repo" in workflow
+    assert "::error::" in workflow

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -646,3 +646,25 @@ def test_forgejo_forge_ships_no_github_org_plumbing(
     dst_path = _render(tmp_path, answers, "no-plumbing-forgejo")
 
     assert not (dst_path / ".github").exists()
+
+
+def test_consumers_are_told_about_a_release_rather_than_polling_for_it(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """A weekly poll means a template release reaches a consumer up to
+    seven days later — a timer catching up, not a mechanism. The cron
+    stays as the backstop: it is what makes a FAILED dispatch survivable,
+    and it covers repos stamped after the fan-out already ran.
+    """
+    dst_path = _render(tmp_path, base_answers, "dispatch-trigger")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "template-update.yml",
+        [
+            "repository_dispatch:",
+            "types: [template-released]",
+            'cron: "17 5 * * 1"',
+            "workflow_dispatch:",
+        ],
+    )


### PR DESCRIPTION
Refs pandoscope/meta#30, which names the store gap as *"the gap worth more
attention than the app"*.

Two halves of one problem: a template change reaching the repos that need it.

## Half 1 — the stores had no updater at all

Split out of #107: that commit was pushed after the branch was ready to merge and
the merge captured the earlier head, so v3.5.0 shipped the label work without it.

Both stores are copier-stamped, and since #99 both vendor `record_core.py` and
`validator_core.py`. The vendoring contract says *"change it in the template and
pull via `copier update`"* — and for the stores there was no pull. A fix to
either core reached them only when a human remembered.

`template-update.yml` now ships to both store subtemplates, **byte-identical to
the consumer copy and pinned by a test**. Identical rather than adapted, because
three copies that *differ* would mean the stores update by different rules than
everything else — the drift the pinning exists to stop.

**Trigger ruled: weekly cron, not `workflow_dispatch`-only.** meta#30 argues both
sides; the deciding point is that the PR still needs review before merging, so
the schedule buys visibility, not unattended change. The human gate does not
move — only the discovery of drift becomes mechanical.

## Half 2 — nobody told consumers a release existed

Consumers polled weekly, so a release reached them up to seven days later. That
is a timer catching up, not a mechanism.

**The fan-out lives inside the release job, not in an `on: release` workflow.**
`semantic-release` publishes with `GITHUB_TOKEN`, and GitHub does not let a
`GITHUB_TOKEN`-created event trigger further workflows — so an `on: release`
workflow would simply never fire. Same class as this repo's existing note that a
PR opened with `GITHUB_TOKEN` runs no CI. Worth knowing before anyone "tidies"
it into its own file.

**Consumers are discovered, never listed.** A repo is a consumer iff it carries
`.copier-answers.agentic.yml`. A hardcoded array would be a per-repo checklist,
which is the thing this template exists to replace with mechanism. There is no
org-level dispatch event in GitHub — `repository_dispatch` targets a repository —
so "dispatch to the org" is implemented as org-scoped *discovery* plus per-repo
dispatch.

**A failed dispatch fails the job.** A consumer that silently stops receiving
updates is indistinguishable from one that is up to date, so the loop collects
failures and exits non-zero rather than swallowing them.

**The cron stays, and is not redundant.** It is what makes a failed dispatch
survivable, and it covers repos stamped after a fan-out already ran. Delivery
path and backstop, not two delivery paths.

## Requires

`RELEASE_BOT_CLIENT_ID` / `RELEASE_BOT_PRIVATE_KEY` configured on the org, and
the app needing **contents: write** on consumers — that is the permission the
dispatch endpoint checks. Also **workflows: write**, since `copier update`
renders workflow files and #107 just added two more. pandoscope/meta#30 has the
full setup; its permission list was corrected in a comment there.

Until that app exists, the fan-out step fails and the weekly cron carries
everything — degraded, but visibly so.

## Deliberately not decided here

Whether dispatch should fire on **every** release or only minor/major. Today's
cadence — four releases in two days — would have produced six PRs per release.
Currently every release fans out; narrowing it is a one-line condition once
there is evidence about the real churn.

## Verification

`189 passed, 3 skipped`; `prek run --all-files` clean, including
actionlint and yamllint over both changed workflows.

Four tests, written first and observed failing: both stores' render manifests
gain the workflow, the two store copies are pinned identical to each other, the
store copy is pinned identical to the consumer source, and the rendered consumer
workflow carries all three triggers.

The fan-out itself is not covered by a test — it is a shell loop against live
GitHub APIs, and a mock proving `gh` was called with the arguments I wrote would
assert nothing about whether the dispatch lands. The honest verification is the
first real release, which is the acceptance criterion in meta#30: a PR opens in
a consumer **and CI runs on it**.