### PR TITLE
fix(extraction): refuse to derive a watermark from a shallow clone

### DIFF
--- a/decision-memory/.github/store/extraction.py
+++ b/decision-memory/.github/store/extraction.py
@@ -278,13 +278,47 @@ def _git(*args: str) -> str:
     return result.stdout
 
 
+def _is_shallow(root: str) -> bool:
+    return _git("-C", root, "rev-parse", "--is-shallow-repository").strip() == "true"
+
+
+def _require_complete_history(root: str) -> None:
+    """Refuse to derive a watermark from a truncated history.
+
+    Deriving the watermark instead of storing it buys self-healing: a
+    session merged without a pass is not lost, because the next pass
+    reaches further back. That property depends entirely on the history
+    being complete. Under a shallow clone the walk stops at the boundary
+    and returns None — indistinguishable from "no pass has ever run",
+    and wrong by however much was cut off.
+
+    This is the normal state, not an exotic one: the grilling skill
+    tells sessions to shallow-clone the store.
+
+    Refusing rather than fetching: a `status` command that silently
+    reaches the network is a surprise, and the remedy is one command the
+    caller can run deliberately.
+    """
+    if _is_shallow(root):
+        raise SystemExit(
+            "refusing to derive the watermark: this is a shallow clone, so "
+            "`pref-extract:` commits older than the boundary are invisible and "
+            "the scope would be overstated by however much history is missing. "
+            "Run `git fetch --unshallow` and try again."
+        )
+
+
 def last_extraction_commit(rev_range: str = "HEAD", root: str = ".") -> str | None:
     """SHA of the newest `pref-extract:` commit in `rev_range`, or None.
 
     None means no pass has ever run over that range, which is not an
     error state: it is what the first pass on a fresh corpus sees, and
     it is why bootstrap needs no special mode.
+
+    That reading is only sound over a COMPLETE history, so a shallow
+    clone is refused rather than reported as a bootstrap.
     """
+    _require_complete_history(root)
     out = _git(
         "-C",
         root,

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -679,6 +679,48 @@ class ExtractionWatermarkTests(unittest.TestCase):
         self._commit(f"decision(f): case-{suffix} — a")
         return record["id"]
 
+    def test_a_shallow_clone_is_refused_rather_than_guessed_at(self):
+        """A truncated history cannot distinguish "no pass ever ran" from
+        "the pass is older than the boundary" — and the answers differ by
+        the whole corpus.
+
+        Observed on the live store: a shallow clone reported 106 records
+        and no watermark, when five passes had run and the real scope was
+        19. Committing that pass would have re-proposed promoted rules and
+        double-bumped counters, and the merge gate would have allowed it —
+        it checks that a pass commit EXISTS, never that its scope was real.
+
+        The grilling skill tells sessions to shallow-clone the store, so
+        this is the normal state, not an exotic one.
+        """
+        self._add_record("01")
+        self._commit(f"{extraction.EXTRACTION_PREFIX} 1 record", allow_empty=True)
+        later = self._add_record("02")
+
+        # Re-clone shallowly: the pass commit falls outside the boundary.
+        shallow = os.path.join(self.tmp.name, "shallow")
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{self.root}", shallow],
+            check=True,
+            capture_output=True,
+        )
+        self.assertEqual(
+            subprocess.run(
+                ["git", "-C", shallow, "rev-parse", "--is-shallow-repository"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+            "true",
+            "fixture must actually be shallow, or this test proves nothing",
+        )
+
+        with self.assertRaises(SystemExit) as caught:
+            extraction.scope_ids(shallow)
+        self.assertIn("shallow", str(caught.exception).lower())
+        self.assertIn("unshallow", str(caught.exception))
+        del later
+
     def test_no_pass_ever_means_the_whole_corpus(self):
         """Bootstrap is not a mode — it is what an empty history means."""
         first = self._add_record("01")


### PR DESCRIPTION
Closes #112.

## The measurement

Same command, same commit, before and after `git fetch --unshallow`:

```
106 record(s) since the beginning of the corpus, 0 already covered
 19 record(s) since dbf82bef0, 87 already covered
```

Five `pref-extract:` passes were invisible because `.git/shallow` pinned the
clone at an artificial root carrying 87 record files in one commit.

## Why refuse rather than report

`last_extraction_commit` returning `None` meant "no pass has ever run" — sound
over a complete history, and indistinguishable from "the pass is older than the
boundary" over a truncated one. The tool returned a confident number where it
had no basis for one.

The module docstring argues the derived watermark **self-heals**: a session
merged without a pass is picked up by the next. Shallow flips that into
over-reach, silently.

And the state is normal, not exotic — the grilling skill tells sessions to
shallow-clone the store, so the tool's precondition is contradicted by the
documented way of getting the repo.

**The merge gate would not have caught it.** It checks that a `pref-extract:`
commit exists, never that its scope was real. A pass claiming 106 records would
have re-proposed promoted rules and double-bumped counters, and merged green.

## The test asserts its own fixture

```python
self.assertEqual(..., "true",
    "fixture must actually be shallow, or this test proves nothing")
```

Directly applying pandoscope/skills#35: a test whose precondition is unmet
passes for the wrong reason. Cloning with `--depth 1` could stop producing a
shallow repo — over a `file://` remote it already behaves differently from
`--depth` over a path — so the test verifies the condition it depends on before
asserting the behaviour. Observed red first: `SystemExit not raised`.

## Verification

`186 passed, 3 skipped` (template) · `122 tests OK` (store suite, up from 120)
· `prek run --all-files` clean.

## Not in this PR

- **The grilling skill's shallow-clone instruction.** It is not simply wrong —
  shallow is fine for reading `preferences.md`, which is all a session start
  needs. It is wrong only at extraction time. Reconciling it belongs in
  `pandoscope/skills`, and this guard protects the store regardless of what the
  skill says.
- **Re-locking consumers** so the fix reaches both stores.

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_