### PR TITLE
feat(decision-memory): count self-credited and independent confirmations apart

### DIFF
--- a/decision-memory/.github/guards/decision_validator.py
+++ b/decision-memory/.github/guards/decision_validator.py
@@ -76,10 +76,100 @@ MAX_SLUG_LENGTH = validator_core.MAX_SLUG_LENGTH
 ID_RE = validator_core.ID_RE
 DATE_RE = validator_core.DATE_RE
 
-# Single source for the preferences counter-line grammar
-# ("[confirmed: N, last: YYYY-MM-DD]"): the guard's counter-math check
-# and the writer's pref-confirm bumps both consume this regex.
-COUNTER_RE = re.compile(r"\[confirmed: (\d+), last: (\d{4}-\d{2}-\d{2})\]")
+# Single source for the preferences metadata-suffix grammar (see
+# decision-memory/docs/conventions.md): one trailing bracket holding
+# comma-separated `key: value` pairs. The guard's counter-math check
+# and the writer's pref-confirm bumps both consume these.
+#
+# Parsed rather than pattern-matched so the key set is one tuple a
+# reader can check against the doc, not a shape encoded in a regex.
+METADATA_RE = re.compile(r"\[([^\]\[]*)\]\s*$")
+
+COUNTER_KEY = "confirmed"
+INDEPENDENT_KEY = "independent"
+DATE_KEY = "last"
+
+# Exactly these, on every rule, in this order. A closed set is what
+# keeps the suffix from gaining keys nothing reads: adding one is a
+# deliberate change here, with its consumer, rather than something a
+# writer can introduce in passing.
+SUFFIX_KEYS = (COUNTER_KEY, INDEPENDENT_KEY, DATE_KEY)
+
+
+def parse_metadata(line: str) -> dict[str, str] | None:
+    """Parse a rule line's trailing metadata bracket.
+
+    Returns the key/value pairs, or None when the line carries no
+    bracket or the bracket is not this grammar (a bare `[note]`, a
+    markdown link). Values are returned as written; callers coerce.
+    """
+    match = METADATA_RE.search(line)
+    if not match:
+        return None
+    pairs: dict[str, str] = {}
+    for chunk in match.group(1).split(","):
+        key, sep, value = chunk.partition(":")
+        if not sep:
+            return None
+        pairs[key.strip()] = value.strip()
+    return pairs or None
+
+
+def format_metadata(pairs: dict[str, str]) -> str:
+    """Render pairs back into a suffix, in SUFFIX_KEYS order."""
+    body = ", ".join(f"{k}: {pairs[k]}" for k in SUFFIX_KEYS if k in pairs)
+    return f"[{body}]"
+
+
+def strip_metadata(line: str) -> str:
+    """The rule text alone — what two rules are compared on."""
+    return METADATA_RE.sub("", line).rstrip()
+
+
+def counter_of(line: str) -> int | None:
+    """The `confirmed` value of a rule line, if it has a valid one."""
+    pairs = parse_metadata(line)
+    if not pairs or COUNTER_KEY not in pairs:
+        return None
+    try:
+        return int(pairs[COUNTER_KEY])
+    except ValueError:
+        return None
+
+
+def check_metadata_suffix(line: str) -> str | None:
+    """Return an error for a rule bullet whose suffix is malformed.
+
+    Applied to every `- ` bullet in preferences.md, so a rule that
+    silently lost its counters fails the guard instead of merging and
+    reading as a rule nobody has ever confirmed.
+    """
+    pairs = parse_metadata(line)
+    if pairs is None:
+        return f"rule has no metadata suffix: {line.strip()!r}"
+    if set(pairs) != set(SUFFIX_KEYS):
+        missing = [key for key in SUFFIX_KEYS if key not in pairs]
+        unknown = [key for key in pairs if key not in SUFFIX_KEYS]
+        return (
+            f"rule suffix must carry exactly {list(SUFFIX_KEYS)} "
+            f"(missing {missing}, unknown {unknown}): {line.strip()!r}"
+        )
+    for key in (COUNTER_KEY, INDEPENDENT_KEY):
+        if not pairs[key].isdigit():
+            return f"rule suffix {key}={pairs[key]!r} is not a count: {line.strip()!r}"
+    if not DATE_RE.fullmatch(pairs[DATE_KEY]):
+        return (
+            f"rule suffix {DATE_KEY}={pairs[DATE_KEY]!r} is not YYYY-MM-DD: "
+            f"{line.strip()!r}"
+        )
+    if int(pairs[INDEPENDENT_KEY]) > int(pairs[COUNTER_KEY]):
+        return (
+            f"rule suffix has {INDEPENDENT_KEY} > {COUNTER_KEY} "
+            f"({pairs[INDEPENDENT_KEY]} > {pairs[COUNTER_KEY]}): independent "
+            f"confirmations are a subset of all of them: {line.strip()!r}"
+        )
+    return None
+
 
 # ~1-2k-token hard budget on preferences.md (ticket §5); estimated at
 # the common ~4 chars/token heuristic — deliberately coarse, the budget

--- a/decision-memory/.github/guards/guards.py
+++ b/decision-memory/.github/guards/guards.py
@@ -52,7 +52,11 @@ COMMIT_SUBJECT_RES = (
     re.compile(r"^chore(\([\w-]+\))?: .+$"),
 )
 
-COUNTER_RE = decision_validator.COUNTER_RE
+parse_metadata = decision_validator.parse_metadata
+strip_metadata = decision_validator.strip_metadata
+counter_of = decision_validator.counter_of
+COUNTER_KEY = decision_validator.COUNTER_KEY
+INDEPENDENT_KEY = decision_validator.INDEPENDENT_KEY
 
 # The types permitted to REMOVE lines from preferences.md. Promotion and
 # compaction are different acts on the same file: promotion adds a rule a
@@ -103,22 +107,77 @@ def validate_pref_confirm_change(removed: list[str], added: list[str]) -> list[s
         )
         return errors
     for old, new in zip(removed, added):
-        old_match = COUNTER_RE.search(old)
-        new_match = COUNTER_RE.search(new)
-        if not old_match or not new_match:
+        old_count = counter_of(old)
+        new_count = counter_of(new)
+        if old_count is None or new_count is None:
             errors.append(
                 "pref-confirm: changed a line without a "
-                f"[confirmed: N, last: DATE] counter: {old!r} -> {new!r}"
+                f"[{COUNTER_KEY}: N, ...] suffix: {old!r} -> {new!r}"
             )
             continue
-        if COUNTER_RE.sub("", old) != COUNTER_RE.sub("", new):
+        if strip_metadata(old) != strip_metadata(new):
             errors.append(f"pref-confirm: rule text changed: {old!r} -> {new!r}")
-        if int(new_match.group(1)) != int(old_match.group(1)) + 1:
+        if new_count != old_count + 1:
             errors.append(
                 "pref-confirm: counter must increment by exactly 1: "
-                f"{old_match.group(1)} -> {new_match.group(1)}"
+                f"{old_count} -> {new_count}"
             )
+        errors.extend(_check_suffix_rest(old, new))
     return errors
+
+
+def _check_suffix_rest(old: str, new: str) -> list[str]:
+    """The part of the suffix that is not the counter or its date.
+
+    `independent` is a second count, earned differently: it rises only
+    when a confirmation was NOT the rule crediting itself. A bump may
+    move it by at most one and never downwards, since lowering it under
+    a mechanical subject would erase evidence as routine bookkeeping.
+    """
+    old_ind = _int_or_none((parse_metadata(old) or {}).get(INDEPENDENT_KEY))
+    new_ind = _int_or_none((parse_metadata(new) or {}).get(INDEPENDENT_KEY))
+    if old_ind is None or new_ind is None:
+        return [
+            f"pref-confirm: every rule carries {INDEPENDENT_KEY}; "
+            f"{old!r} -> {new!r} is missing it"
+        ]
+    if new_ind not in (old_ind, old_ind + 1):
+        return [
+            f"pref-confirm: {INDEPENDENT_KEY} moved {old_ind} -> {new_ind}; a bump "
+            "may hold it or raise it by exactly 1"
+        ]
+    return []
+
+
+def _rule_bullets(text: str) -> list[str]:
+    """Each `- ` rule in preferences.md, wrapped lines rejoined.
+
+    A rule may span several lines with its suffix on the last, so the
+    check has to see the whole entry rather than one line of it.
+    """
+    bullets: list[str] = []
+    current: list[str] | None = None
+    for line in text.splitlines():
+        if line.startswith("- "):
+            if current is not None:
+                bullets.append(" ".join(current))
+            current = [line.strip()]
+        elif current is not None:
+            if not line.strip() or line.startswith("#"):
+                bullets.append(" ".join(current))
+                current = None
+            else:
+                current.append(line.strip())
+    if current is not None:
+        bullets.append(" ".join(current))
+    return bullets
+
+
+def _int_or_none(value: str | None) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except ValueError:
+        return None
 
 
 def _git(*args: str) -> str:
@@ -211,11 +270,23 @@ def check_corpus(root: str = ".") -> list[str]:
     preferences_path = os.path.join(root, "preferences.md")
     if os.path.isfile(preferences_path):
         with open(preferences_path, encoding="utf-8") as handle:
-            errors.extend(
-                decision_validator.check_preferences_budget(
-                    handle.read(), int(config["budget_tokens"])
-                )
+            preferences_text = handle.read()
+        errors.extend(
+            decision_validator.check_preferences_budget(
+                preferences_text, int(config["budget_tokens"])
             )
+        )
+        # Every rule carries its counters. A rule that lost them reads
+        # as one nobody has ever confirmed, which is the same shape the
+        # counters exist to distinguish.
+        errors.extend(
+            f"preferences.md: {error}"
+            for error in map(
+                decision_validator.check_metadata_suffix,
+                _rule_bullets(preferences_text),
+            )
+            if error
+        )
     return errors
 
 

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -166,8 +166,8 @@ class CarveOutTests(unittest.TestCase):
         diff = (
             "--- a/preferences.md\n"
             "+++ b/preferences.md\n"
-            "-- rule text. [confirmed: 3, last: 2026-07-15]\n"
-            "+- rule text. [confirmed: 4, last: 2026-07-20]\n"
+            "-- rule text. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
+            "+- rule text. [confirmed: 4, independent: 0, last: 2026-07-20]\n"
         )
         required, notes = guard.classify_pref_commits(
             [self.commit("pref-confirm: rule text (n=4)", diff)]
@@ -177,8 +177,8 @@ class CarveOutTests(unittest.TestCase):
 
     def test_counter_bump_that_rewrites_the_rule_needs_the_label(self):
         diff = (
-            "-- old rule text. [confirmed: 3, last: 2026-07-15]\n"
-            "+- new rule text. [confirmed: 4, last: 2026-07-20]\n"
+            "-- old rule text. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
+            "+- new rule text. [confirmed: 4, independent: 0, last: 2026-07-20]\n"
         )
         required, _ = guard.classify_pref_commits(
             [self.commit("pref-confirm: rule text (n=4)", diff)]
@@ -1043,7 +1043,7 @@ class SimilarityGateTests(unittest.TestCase):
         preferences = (
             "# Active Preference Set\n\n"
             "- Rejects new infrastructure dependencies unless they remove an "
-            "entire class of maintenance. [confirmed: 3, last: 2026-07-15]\n"
+            "entire class of maintenance. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
         )
         record = self._draft(
             "20260715T143205Z-a",
@@ -1065,7 +1065,7 @@ class SimilarityGateTests(unittest.TestCase):
         """
         preferences = (
             "- Rejects new infrastructure dependencies unless they remove an "
-            "entire class of maintenance. [confirmed: 3, last: 2026-07-15]\n"
+            "entire class of maintenance. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
         )
         record = self._draft(
             "20260715T143205Z-a",
@@ -1168,7 +1168,9 @@ class MeasureInvariantTests(unittest.TestCase):
         Asserting one example would not have caught it. Asserting the
         property across the real length range does.
         """
-        preferences = f"- {self.RULE}. [confirmed: 3, last: 2026-07-15]\n"
+        preferences = (
+            f"- {self.RULE}. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
+        )
         for filler in (0, 10, 20, 30, 40):
             with self.subTest(filler=filler):
                 record = self._record_quoting_the_rule(filler)
@@ -1202,7 +1204,9 @@ class MeasureInvariantTests(unittest.TestCase):
         threshold: a threshold change must not be able to silently
         satisfy the test above while the measure regresses.
         """
-        preferences = f"- {self.RULE}. [confirmed: 3, last: 2026-07-15]\n"
+        preferences = (
+            f"- {self.RULE}. [confirmed: 3, independent: 0, last: 2026-07-15]\n"
+        )
         scores = set()
         for filler in (0, 20, 40):
             record = self._record_quoting_the_rule(filler)
@@ -1411,7 +1415,8 @@ class FixtureStoreTests(unittest.TestCase):
         for record in self.records:
             self._write_record(record)
         self._write(
-            "preferences.md", "- a short rule. [confirmed: 1, last: 2026-07-15]\n"
+            "preferences.md",
+            "- a short rule. [confirmed: 1, independent: 0, last: 2026-07-15]\n",
         )
         self._write("store.config.json", json.dumps({"budget_tokens": 2000}))
 

--- a/decision-memory/docs/conventions.md
+++ b/decision-memory/docs/conventions.md
@@ -197,7 +197,6 @@ One bracket at the end of a rule bullet, holding comma-separated
 `key: value` pairs:
 
 ```text
-- <rule text> [confirmed: <N>, last: <YYYY-MM-DD>]
 - <rule text> [confirmed: <N>, independent: <N>, last: <YYYY-MM-DD>]
 ```
 
@@ -205,9 +204,10 @@ Grammar, and it is deliberately this small:
 
 - **Flat only.** No nesting, no lists, no objects. A value is a bare
   scalar, so the whole suffix parses by splitting on `,` then `:`.
-- **Order is not significant**, but `last` reads better trailing.
-- **Unknown keys are tolerated**, so a key can be added without a
-  coordinated change to every reader.
+- **Exactly these three keys**, written in this order. A rule carrying
+  fewer, or any key outside the set, fails the guard. A closed set is
+  what keeps the suffix from gaining keys nothing reads; adding one is
+  a deliberate change to the validator, alongside its consumer.
 - **The whole bracket is stripped** before a rule's text is compared to
   anything, so bookkeeping never counts as rule vocabulary.
 
@@ -216,7 +216,7 @@ Keys currently defined:
 | Key | Meaning |
 | --- | --- |
 | `confirmed` | Times the rule predicted the chosen slot |
-| `independent` | Of those, how many were NOT the rule citing itself into the slot that was then chosen. Omitted means unmeasured, which is not the same as zero |
+| `independent` | Of those, how many were NOT the rule citing itself into the slot that was then chosen. Never greater than `confirmed` |
 | `last` | Date of the most recent confirmation |
 
 **Why not YAML or JSON.** Rule text is prose and contains colons
@@ -242,17 +242,22 @@ pairs are the whole affordance.
 
 - Counter-line updates are the ONE sanctioned edit in this repo,
   executed mechanically: `submit` auto-generates `pref-confirm`
-  commits from in-session preference-driven hits; CI validates the
-  counter math (increment by exactly 1, rule text unchanged).
-- A rule only ever confirmed by choices its own recommendation caused
-  has zero independent evidence — extraction flags such rules, never
-  strengthens them (provenance is in the records: `rules_cited` +
-  `chosen_slot`). `independent` is where that distinction becomes
-  visible in the active set rather than only in a pass report.
-- Editing a suffix for any reason OTHER than a mechanical bump — adding
-  `independent`, correcting a count — rewrites an existing line, so it
-  needs the carve-out label and a replay report like any other edit to
-  the active set.
+  commits; CI validates the counter math (increment by exactly 1, rule
+  text unchanged, other keys untouched).
+- `submit` counts two kinds of confirmation, and keeps them apart. A
+  `hit` credits the rules cited on the slot that won — the rule
+  agreeing with the option it authored, which raises `confirmed`
+  alone. The other kind is a rule cited on some option the rule did
+  NOT propose, which the decider chose anyway; that raises
+  `independent` as well. Only the second is evidence the rule tracks
+  the decider rather than steering them.
+- `independent` may rise by at most 1 per bump and never falls. A
+  mechanical bump that lowered it would be erasing evidence under a
+  subject that reads as routine.
+- Editing a suffix for any reason OTHER than a mechanical bump —
+  correcting a count, backfilling a key — rewrites an existing line,
+  so it needs the carve-out label and a replay report like any other
+  edit to the active set.
 - Promotion is separate and human-only: agents write candidate rules
   to `proposals/<YYYY-MM-DD>-<slug>.md` (one rule per file); only a
   human `pref-promote` commit moves content into `preferences.md`.

--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -584,12 +584,26 @@ def _normalize(text: str) -> str:
 
 
 def bump_preference_counter(
-    preferences_text: str, rule: str, today: str, counter_re: re.Pattern
+    preferences_text: str,
+    rule: str,
+    today: str,
+    validator,
+    *,
+    independent: bool = False,
 ) -> tuple[str, int] | None:
     """Bump the confirmation counter of the bullet matching ``rule``.
 
-    ``counter_re`` is the vendored validator's COUNTER_RE — the single
-    source of the counter-line grammar, shared with the CI guard.
+    ``validator`` is the data repo's vendored decision_validator — the
+    single source of the metadata-suffix grammar, shared with the CI
+    guard, so writer and guard cannot disagree about the format.
+
+    ``independent`` also raises the `independent` count. It is true only
+    when the confirmation was NOT the rule crediting itself: the rule
+    was cited on an option, and the decider chose that option, but it
+    was not the slot the rule was written into. The two are counted
+    apart because `confirmed` alone also rises when a rule predicts the
+    slot it authored, which reads as evidence without being any.
+
     Returns (new_text, new_count), or None when no bullet matches.
     Handles wrapped bullets: an entry runs from its `- ` line to the
     next bullet/heading/blank line; the counter sits on its last line.
@@ -614,13 +628,19 @@ def bump_preference_counter(
         if wanted not in entry_text:
             continue
         for i in range(end - 1, begin - 1, -1):
-            match = counter_re.search(lines[i])
-            if match:
-                count = int(match.group(1)) + 1
-                lines[i] = counter_re.sub(
-                    f"[confirmed: {count}, last: {today}]", lines[i]
-                )
-                return "".join(lines), count
+            pairs = validator.parse_metadata(lines[i])
+            if not pairs or validator.COUNTER_KEY not in pairs:
+                continue
+            count = int(pairs[validator.COUNTER_KEY]) + 1
+            pairs[validator.COUNTER_KEY] = str(count)
+            pairs[validator.DATE_KEY] = today
+            if independent:
+                prior = int(pairs.get(validator.INDEPENDENT_KEY, "0"))
+                pairs[validator.INDEPENDENT_KEY] = str(prior + 1)
+            suffix = validator.format_metadata(pairs)
+            trailing = "\n" if lines[i].endswith("\n") else ""
+            lines[i] = validator.strip_metadata(lines[i]) + " " + suffix + trailing
+            return "".join(lines), count
     return None
 
 
@@ -645,6 +665,31 @@ def prediction_rules(record: dict) -> list[str]:
         ):
             rules = option.get("rules_cited")
             return [r for r in rules if isinstance(r, str)] if rules else []
+    return []
+
+
+def independent_rules(record: dict) -> list[str]:
+    """Rules confirmed by the decider WITHOUT the rule picking the slot.
+
+    `prediction_rules` returns the rules cited on the prediction slot,
+    and a `hit` means that slot was chosen — so every confirmation it
+    yields is the rule agreeing with the option it authored. That is
+    worth counting, but it is not evidence the rule tracks the decider.
+
+    This is the other case: a rule cited on some non-prediction option
+    that the decider chose anyway. The rule did not put the option in
+    front of them, and they took it regardless.
+    """
+    chosen_slot = record.get("chosen_slot")
+    if chosen_slot is None:
+        return []
+    for option in record.get("options", []):
+        if not isinstance(option, dict) or option.get("slot") != chosen_slot:
+            continue
+        if option.get("role") in ("prediction", "prediction+recommendation"):
+            return []
+        rules = option.get("rules_cited") or []
+        return [rule for rule in rules if isinstance(rule, str)]
     return []
 
 
@@ -720,12 +765,18 @@ def cmd_submit(args: argparse.Namespace) -> int:
 
     preferences_path = repo_dir / "preferences.md"
     for record in records:
-        if (
-            record.get("prediction_stream") != "preference-driven"
-            or record.get("outcome") != "hit"
-        ):
+        if record.get("prediction_stream") != "preference-driven":
             continue
-        for rule in prediction_rules(record):
+        # Two ways a rule earns a confirmation, and they are counted
+        # apart. A `hit` credits the rules cited on the slot that won —
+        # the rule agreeing with itself. Anything else can still confirm
+        # a rule, if the decider chose an option that cited it without
+        # that rule having proposed it; that one is independent.
+        if record.get("outcome") == "hit":
+            confirmations = [(rule, False) for rule in prediction_rules(record)]
+        else:
+            confirmations = [(rule, True) for rule in independent_rules(record)]
+        for rule, independent in confirmations:
             if not preferences_path.exists():
                 print(f"WARN: no preferences.md — cannot bump {rule!r}")
                 continue
@@ -733,7 +784,8 @@ def cmd_submit(args: argparse.Namespace) -> int:
                 preferences_path.read_text(encoding="utf-8"),
                 rule,
                 today,
-                validator.COUNTER_RE,
+                validator,
+                independent=independent,
             )
             if bumped is None:
                 print(

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -36,27 +36,27 @@ def test_foreign_commit_subjects_fail() -> None:
 
 
 def test_pref_confirm_counter_math_accepts_single_bump() -> None:
-    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
-    added = ["- Rejects new deps. [confirmed: 4, last: 2026-07-21]"]
+    removed = ["- Rejects new deps. [confirmed: 3, independent: 0, last: 2026-07-15]"]
+    added = ["- Rejects new deps. [confirmed: 4, independent: 0, last: 2026-07-21]"]
     assert guards.validate_pref_confirm_change(removed, added) == []
 
 
 def test_pref_confirm_counter_math_rejects_bad_increment() -> None:
-    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
-    added = ["- Rejects new deps. [confirmed: 5, last: 2026-07-21]"]
+    removed = ["- Rejects new deps. [confirmed: 3, independent: 0, last: 2026-07-15]"]
+    added = ["- Rejects new deps. [confirmed: 5, independent: 0, last: 2026-07-21]"]
     errors = guards.validate_pref_confirm_change(removed, added)
     assert any("increment" in e for e in errors)
 
 
 def test_pref_confirm_counter_math_rejects_text_change() -> None:
-    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
-    added = ["- Accepts new deps. [confirmed: 4, last: 2026-07-21]"]
+    removed = ["- Rejects new deps. [confirmed: 3, independent: 0, last: 2026-07-15]"]
+    added = ["- Accepts new deps. [confirmed: 4, independent: 0, last: 2026-07-21]"]
     errors = guards.validate_pref_confirm_change(removed, added)
     assert any("rule text" in e for e in errors)
 
 
 def test_pref_confirm_counter_math_rejects_line_removal() -> None:
-    removed = ["- Rejects new deps. [confirmed: 3, last: 2026-07-15]"]
+    removed = ["- Rejects new deps. [confirmed: 3, independent: 0, last: 2026-07-15]"]
     errors = guards.validate_pref_confirm_change(removed, [])
     assert errors
 
@@ -67,9 +67,95 @@ def test_parse_unified_diff_pairs_changed_lines() -> None:
         "--- a/preferences.md\n"
         "+++ b/preferences.md\n"
         "@@ -5 +5 @@\n"
-        "-- Old rule. [confirmed: 1, last: 2026-07-15]\n"
-        "+- Old rule. [confirmed: 2, last: 2026-07-21]\n"
+        "-- Old rule. [confirmed: 1, independent: 0, last: 2026-07-15]\n"
+        "+- Old rule. [confirmed: 2, independent: 0, last: 2026-07-21]\n"
     )
     removed, added = guards.parse_unified_diff(diff)
-    assert removed == ["- Old rule. [confirmed: 1, last: 2026-07-15]"]
-    assert added == ["- Old rule. [confirmed: 2, last: 2026-07-21]"]
+    assert removed == ["- Old rule. [confirmed: 1, independent: 0, last: 2026-07-15]"]
+    assert added == ["- Old rule. [confirmed: 2, independent: 0, last: 2026-07-21]"]
+
+
+# --- metadata suffix grammar -----------------------------------------
+
+
+def test_suffix_keys_may_appear_in_any_order() -> None:
+    removed = ["- A rule. [last: 2026-07-15, independent: 0, confirmed: 3]"]
+    added = ["- A rule. [independent: 0, last: 2026-07-21, confirmed: 4]"]
+    assert guards.validate_pref_confirm_change(removed, added) == []
+
+
+def test_an_unknown_suffix_key_is_rejected() -> None:
+    error = guards.decision_validator.check_metadata_suffix(
+        "- A rule. [confirmed: 3, independent: 0, last: 2026-07-15, src: x]"
+    )
+    assert error and "src" in error
+
+
+# --- the independent counter -----------------------------------------
+
+
+def test_a_bump_may_raise_independent_by_one() -> None:
+    removed = ["- A rule. [confirmed: 3, independent: 1, last: 2026-07-15]"]
+    added = ["- A rule. [confirmed: 4, independent: 2, last: 2026-07-21]"]
+    assert guards.validate_pref_confirm_change(removed, added) == []
+
+
+def test_a_bump_may_not_lower_independent() -> None:
+    removed = ["- A rule. [confirmed: 3, independent: 2, last: 2026-07-15]"]
+    added = ["- A rule. [confirmed: 4, independent: 1, last: 2026-07-21]"]
+    errors = guards.validate_pref_confirm_change(removed, added)
+    assert errors and "independent" in errors[0]
+
+
+def test_a_rule_without_independent_is_rejected() -> None:
+    removed = ["- A rule. [confirmed: 3, last: 2026-07-15]"]
+    added = ["- A rule. [confirmed: 4, last: 2026-07-21]"]
+    errors = guards.validate_pref_confirm_change(removed, added)
+    assert errors and "independent" in errors[0]
+
+
+def test_independent_may_not_exceed_confirmed() -> None:
+    # Independent confirmations are a subset of all of them, so a
+    # suffix claiming more of the subset than the whole is incoherent
+    # regardless of how it got there.
+    error = guards.decision_validator.check_metadata_suffix(
+        "- A rule. [confirmed: 2, independent: 3, last: 2026-07-15]"
+    )
+    assert error and "independent" in error
+
+
+def test_a_rule_set_missing_counters_fails_the_corpus_check() -> None:
+    # Deliberately NOT run against this repo's own preferences.md: the
+    # template ships the seed, which has no rules, so the same assertion
+    # there would pass for as long as the file stays empty and prove
+    # nothing. The live store runs this guard over its real file.
+    text = (
+        "## Process\n\n"
+        "- A counted rule. [confirmed: 1, independent: 0, last: 2026-07-15]\n"
+        "- A rule someone hand-added without counters.\n"
+    )
+    errors = [
+        error
+        for error in map(
+            guards.decision_validator.check_metadata_suffix, guards._rule_bullets(text)
+        )
+        if error
+    ]
+    assert len(errors) == 1
+    assert "hand-added" in errors[0]
+
+
+def test_a_wrapped_rule_is_checked_as_one_bullet() -> None:
+    # The suffix sits on the entry's last line, so a check that looked
+    # at lines rather than entries would report every continuation line
+    # as a rule missing its counters.
+    text = (
+        "## Heading\n\n"
+        "- A rule that runs onto\n"
+        "  a second line. [confirmed: 1, independent: 0, last: 2026-07-15]\n"
+    )
+    assert len(guards._rule_bullets(text)) == 1
+    assert (
+        guards.decision_validator.check_metadata_suffix(guards._rule_bullets(text)[0])
+        is None
+    )


### PR DESCRIPTION
Closes the writer half of #115.

## The defect

`confirmed` could only ever count a rule agreeing with itself. The
writer bumps on a preference-driven `hit`, and a `hit` means the slot
the rule was cited into is the slot the decider chose. So the counter
credited a rule for predicting its own recommendation.

Every bump in the store's history took that path. That is why five
extraction passes in a row reported `0 confirmed` against rules the
active set displayed at `n=4` — the pass excludes rule-driven
acceptances, and the writer never has. The two numbers were measuring
different things and neither said so.

## The fix

`submit` now records both kinds and keeps them apart:

- a `hit` raises `confirmed` alone — the rule agreeing with the option
  it authored
- a rule cited on an option the rule did **not** propose, which the
  decider chose anyway, raises `independent` as well

Only the second is evidence a rule tracks the decider rather than
steering them.

## Why the grammar had to change first

`conventions.md` declared the suffix as flat, order-insensitive and
tolerant of unknown keys. The code was `\[confirmed: (\d+), last:
(\d{4}-\d{2}-\d{2})\]` — one regex pinning both the key set and their
order. The documented format was not implemented, and adding a key is
what surfaced it. Replaced by a `parse_metadata`/`format_metadata` pair
in the validator, which is the single source the guard and the writer
both consume.

## `independent` is required

The first draft made it optional, omitted meaning "unmeasured, which is
not the same as zero." A real distinction — with no instance behind it.
The only bump path could not produce anything but zero, so there was
never an unmeasured rule for the optional form to describe. It cost a
branch in every reader to represent a state that cannot arise. The key
is required; rules predating it are backfilled with the zero they had
measured all along.

## Guard changes

- counter math goes through the parser, not a regex
- a bump may move `confirmed`, `last` and `independent` only;
  `independent` rises by at most 1 and never falls
- every other key is frozen, so a rewrite hiding behind a bump's commit
  subject fails instead of merging as routine
- the corpus check now verifies every rule bullet carries its counters,
  so a rule that loses them fails rather than reading as one nobody has
  ever confirmed

## Tests

201 passed, 4 skipped. The grammar tests go red against the old regex.

One test was written and then removed: asserting the template's own
`preferences.md` has valid suffixes passes vacuously, because the
template ships the seed and the seed has no rules. It would stay green
for as long as the file stayed empty. Replaced with a fixture that
actually contains a broken rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_