### PR TITLE
feat(decision-memory): the predictions corpus

### DIFF
--- a/decision-memory/.github/guards/decision_validator.py
+++ b/decision-memory/.github/guards/decision_validator.py
@@ -40,6 +40,14 @@ RECORD_TYPE = "decision"
 LINK_FIELDS = ("related", "supersedes", "drill_down_of")
 STORE_DIR = "decisions"
 
+# Autonomous agent records: same schema, same append-only guarantee,
+# outside the preference pipeline entirely. A run with no decider
+# present is a prediction under the active set, not a ruling — so
+# extraction never walks this directory and no record in it can bump a
+# counter. Naming it for what it holds keeps `decisions/` meaning
+# a-human-ruled.
+PREDICTIONS_DIR = "predictions"
+
 REQUIRED_FIELDS = (
     "v",
     "type",

--- a/decision-memory/.github/guards/guards.py
+++ b/decision-memory/.github/guards/guards.py
@@ -7,17 +7,19 @@ the guard must keep working even if the template repo disappears.
 
 Checks, per PR (run with --base <base-sha> from a full checkout):
 
-1. Append-only: no modify/delete/rename under decisions/**; line
+1. Append-only: no modify/delete/rename under decisions/** or
+   predictions/**; line
    removals in preferences.md only from pref-confirm/pref-promote/
    pref-compact commits, with pref-confirm counter math validated
    mechanically.
-2. Full-corpus schema check: EVERY decisions/*.json validates (not
-   just added files), so guard updates re-validate the entire corpus.
+2. Full-corpus schema check: EVERY decisions/*.json and
+   predictions/*.json validates (not just added files), so guard
+   updates re-validate the entire corpus.
 3. Dangling-reference check across the corpus.
 4. Token budget on preferences.md, against the repo-local budget.
 5. Commit lint: every PR commit subject uses one of the repo's own
-   types (decision/pref-proposal/pref-promote/pref-confirm/
-   pref-compact/pref-drift/pref-extract/chore).
+   types (decision/prediction/pref-proposal/pref-promote/
+   pref-confirm/pref-compact/pref-drift/pref-extract/chore).
 """
 
 from __future__ import annotations
@@ -43,6 +45,7 @@ import decision_validator  # noqa: E402  (path bootstrap above)
 # writer composes these subjects in record.py.
 COMMIT_SUBJECT_RES = (
     re.compile(r"^decision\([a-z0-9][a-z0-9-]*\): .+ — .+$"),
+    re.compile(r"^prediction\([a-z0-9][a-z0-9-]*\): .+ — .+$"),
     re.compile(r"^pref-proposal: .+$"),
     re.compile(r"^pref-promote: .+$"),
     re.compile(r"^pref-confirm: .+ \(n=\d+\)$"),
@@ -74,7 +77,8 @@ def check_commit_subject(subject: str) -> str | None:
         return None
     return (
         f"commit subject {subject!r} matches none of the repo's types: "
-        "decision(<project>): <slug> — <chosen> | pref-proposal: | "
+        "decision(<project>): <slug> — <chosen> | "
+        "prediction(<project>): <slug> — <chosen> | pref-proposal: | "
         "pref-promote: | pref-confirm: ... (n=N) | pref-compact: | "
         "pref-drift: | pref-extract: | chore:"
     )
@@ -185,17 +189,30 @@ def _git(*args: str) -> str:
     return result.stdout
 
 
+APPEND_ONLY_DIRS = (
+    f"{decision_validator.STORE_DIR}/",
+    f"{decision_validator.PREDICTIONS_DIR}/",
+)
+
+
 def check_append_only(base: str) -> list[str]:
-    """No modify/delete/rename ever touches existing decision records."""
+    """No modify/delete/rename ever touches a recorded ruling.
+
+    Predictions are covered too: an agent's recorded choice is the
+    input a counterfactual replay reads, and a corpus that can be
+    quietly rewritten cannot support one.
+    """
     errors: list[str] = []
     diff = _git("diff", "--name-status", "--find-renames", f"{base}...HEAD")
     for line in diff.splitlines():
         parts = line.split("\t")
         status = parts[0]
         paths = parts[1:]
-        if any(p.startswith("decisions/") for p in paths) and not (status == "A"):
+        touched = [p for p in paths if p.startswith(APPEND_ONLY_DIRS)]
+        if touched and status != "A":
+            directory = touched[0].split("/", 1)[0]
             errors.append(
-                f"append-only: decisions/ change {status} {' '.join(paths)} "
+                f"append-only: {directory}/ change {status} {' '.join(paths)} "
                 "— existing records are never modified, deleted, or renamed"
             )
     return errors
@@ -229,8 +246,43 @@ def check_commits(base: str) -> list[str]:
     return errors
 
 
+def _check_records_in(root: str, directory: str, records: dict[str, dict]) -> list[str]:
+    """Validate every record in one corpus directory.
+
+    Records from both directories share the ID namespace and the link
+    graph, so they accumulate into one ``records`` map: a prediction
+    may reference a decision, and a dangling link is dangling either
+    way.
+    """
+    errors: list[str] = []
+    path_dir = os.path.join(root, directory)
+    if not os.path.isdir(path_dir):
+        return errors
+    for name in sorted(os.listdir(path_dir)):
+        if name.startswith("."):
+            continue
+        path = os.path.join(path_dir, name)
+        if not name.endswith(".json"):
+            errors.append(f"{path}: non-JSON file in {directory}/")
+            continue
+        stem = name[: -len(".json")]
+        try:
+            with open(path, encoding="utf-8") as handle:
+                record = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{path}: unreadable or invalid JSON: {exc}")
+            continue
+        errors.extend(
+            f"{path}: {e}"
+            for e in decision_validator.validate_record(record, filename_stem=stem)
+        )
+        if isinstance(record, dict) and isinstance(record.get("id"), str):
+            records[record["id"]] = record
+    return errors
+
+
 def check_corpus(root: str = ".") -> list[str]:
-    """Validate the ENTIRE decisions/ corpus + refs + token budget.
+    """Validate BOTH record corpora + refs + token budget.
 
     The token budget comes from the repo-local `store.config.json`
     (`budget_tokens`), not from a constant in this file: the budget is
@@ -244,29 +296,9 @@ def check_corpus(root: str = ".") -> list[str]:
         config = store_config.load_config(root)
     except store_config.ConfigError as exc:
         return [str(exc)]
-    decisions_dir = os.path.join(root, "decisions")
-    if os.path.isdir(decisions_dir):
-        for name in sorted(os.listdir(decisions_dir)):
-            if name.startswith("."):
-                continue
-            path = os.path.join(decisions_dir, name)
-            if not name.endswith(".json"):
-                errors.append(f"{path}: non-JSON file in decisions/")
-                continue
-            stem = name[: -len(".json")]
-            try:
-                with open(path, encoding="utf-8") as handle:
-                    record = json.load(handle)
-            except (OSError, json.JSONDecodeError) as exc:
-                errors.append(f"{path}: unreadable or invalid JSON: {exc}")
-                continue
-            errors.extend(
-                f"{path}: {e}"
-                for e in decision_validator.validate_record(record, filename_stem=stem)
-            )
-            if isinstance(record, dict) and isinstance(record.get("id"), str):
-                records[record["id"]] = record
-        errors.extend(decision_validator.validate_corpus(records))
+    for directory in (decision_validator.STORE_DIR, decision_validator.PREDICTIONS_DIR):
+        errors.extend(_check_records_in(root, directory, records))
+    errors.extend(decision_validator.validate_corpus(records))
     preferences_path = os.path.join(root, "preferences.md")
     if os.path.isfile(preferences_path):
         with open(preferences_path, encoding="utf-8") as handle:

--- a/decision-memory/docs/conventions.md
+++ b/decision-memory/docs/conventions.md
@@ -15,6 +15,19 @@ subtemplate and change together there, in the same PR.
 - `decisions/<id>.json` — one immutable JSON **file** per decision,
   flat directory. Append-only: existing files are NEVER modified,
   deleted, or renamed.
+- `predictions/<id>.json` — the same schema and the same append-only
+  guarantee, for what an AUTONOMOUS run chose under the active
+  preference set with no decider present. Written by
+  `record.py record --predict`, committed as
+  `prediction(<project>): …`.
+
+  A prediction is not a ruling, so it stays outside the preference
+  pipeline entirely: extraction never walks the directory, no
+  prediction can bump a counter, and a PR adding only predictions needs
+  no extraction pass. It is replay material — the records carry
+  `preference_set.commit`, so a candidate rule set can be run against
+  them to see what an agent WOULD have chosen. Keeping the corpora
+  apart is what lets `decisions/` keep meaning a-human-ruled.
 - ID = filename stem = `<timestamp>-<slug>`, e.g.
   `20260715T143205Z-agent-access`. The slug is a writer-chosen
   kebab-case title, ≤40 chars; the timestamp is minted (UTC) by the

--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -19,8 +19,11 @@ Verbs:
            one commit per record, each pushed as it lands so the
            clone holds nothing the remote does not; batch-local slug
            references (supersedes_slug, drill_down_of_slug,
-           related_slugs) resolve to the minted IDs
-  check    validate the entire decisions/ corpus + dangling refs +
+           related_slugs) resolve to the minted IDs. `--predict`
+           writes to predictions/ instead: an autonomous run's own
+           choices under the active preference set, with no decider
+           present — replay material, never preference input
+  check    validate both record corpora + dangling refs +
            preferences.md token budget
   submit   compute two-stream hit rates (refined and near-tie
            bucketed separately), auto-bump pref-confirm counters for
@@ -452,9 +455,9 @@ def cmd_open(args: argparse.Namespace) -> int:
     return 0
 
 
-def commit_record(repo_dir: Path, record: dict) -> None:
+def commit_record(repo_dir: Path, record: dict, directory: str = "decisions") -> None:
     record_id = record["id"]
-    path = repo_dir / "decisions" / f"{record_id}.json"
+    path = repo_dir / directory / f"{record_id}.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         raise fail(f"{path} already exists — records are immutable")
@@ -465,7 +468,8 @@ def commit_record(repo_dir: Path, record: dict) -> None:
         chosen = chosen[:99] + "…"
     # Subject grammar authority: the store's docs/conventions.md
     # (§ Commit types); the vendored guard lints what this composes.
-    subject = f"decision({record['project']}): {slug} — {chosen}"
+    kind = "decision" if directory == "decisions" else "prediction"
+    subject = f"{kind}({record['project']}): {slug} — {chosen}"
     run_git(repo_dir, "add", str(path))
     run_git(repo_dir, "commit", "--quiet", "-m", subject)
     push_session(repo_dir)
@@ -498,6 +502,14 @@ def push_session(repo_dir: Path) -> None:
 
 
 def cmd_record(args: argparse.Namespace) -> int:
+    """Write decision records, or predictions with ``--predict``.
+
+    Predictions land in a separate corpus with the same schema and the
+    same append-only guarantee. They are what an autonomous run chose
+    under the active preference set with no decider present — replay
+    material, never preference input, so nothing downstream may read
+    them as rulings.
+    """
     repo_dir = store_root()
     state = load_state(repo_dir)
     validator = load_validator(repo_dir)
@@ -534,8 +546,9 @@ def cmd_record(args: argparse.Namespace) -> int:
         )
         return 1
 
+    directory = "predictions" if getattr(args, "predict", False) else "decisions"
     for record in records:
-        commit_record(repo_dir, record)
+        commit_record(repo_dir, record, directory)
     return 0
 
 
@@ -544,14 +557,19 @@ def cmd_check(args: argparse.Namespace) -> int:
     validator = load_validator(repo_dir)
 
     errors: list[str] = []
-    decisions_dir = repo_dir / "decisions"
     records: dict[str, dict] = {}
-    if decisions_dir.is_dir():
-        for path in sorted(decisions_dir.iterdir()):
+    # Both corpora share the ID namespace and the link graph, so they
+    # validate together: a prediction may reference a decision, and a
+    # dangling link is dangling either way.
+    for directory in ("decisions", "predictions"):
+        corpus = repo_dir / directory
+        if not corpus.is_dir():
+            continue
+        for path in sorted(corpus.iterdir()):
             if path.name.startswith("."):
                 continue
             if path.suffix != ".json":
-                errors.append(f"{path.name}: non-JSON file in decisions/")
+                errors.append(f"{path.name}: non-JSON file in {path.parent.name}/")
                 continue
             try:
                 record = json.loads(path.read_text(encoding="utf-8"))
@@ -754,6 +772,9 @@ def cmd_submit(args: argparse.Namespace) -> int:
         "--",
         "decisions/",
     ).split()
+    # Scoped to decisions/ deliberately: a prediction is an agent's own
+    # choice, and letting one reach the counters would be the rule
+    # confirming itself through a second door.
     records = []
     for name in added:
         path = repo_dir / name
@@ -896,6 +917,12 @@ def main(argv: list[str] | None = None) -> int:
         dest="from_file",
         help="JSON file with a draft record or an array of drafts "
         "(default: read stdin)",
+    )
+    p_record.add_argument(
+        "--predict",
+        action="store_true",
+        help="write to predictions/ instead of decisions/: an autonomous "
+        "run's own choices, replay material only, never preference input",
     )
     p_record.set_defaults(func=cmd_record)
 

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import copier
 
+from tests.conftest import load_module
+
 PROJECT_ROOT = Path(__file__).parent.parent
 
 STORE_FILES = frozenset(
@@ -183,3 +185,20 @@ def test_default_render_contains_no_recorder(
     stores through the decision-memory subtemplate, never to consumer repos."""
     dst_path = render_project()
     assert not (dst_path / "tools" / "record.py").exists()
+
+
+def test_a_predictions_only_pr_needs_no_extraction_pass(tmp_path) -> None:
+    """The extraction gate keys on decisions/, so an autonomous run's
+    records never demand a pass they have no business in."""
+    extraction = load_module(
+        "extraction",
+        PROJECT_ROOT / "decision-memory" / ".github" / "store" / "extraction.py",
+    )
+    assert extraction.DECISIONS_DIR == "decisions"
+    source = (
+        PROJECT_ROOT / "decision-memory" / ".github" / "store" / "extraction.py"
+    ).read_text()
+    assert "predictions" not in source, (
+        "extraction must not know about predictions/ at all — the "
+        "exclusion is structural, not a filter someone must remember"
+    )

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -159,3 +159,53 @@ def test_a_wrapped_rule_is_checked_as_one_bullet() -> None:
         guards.decision_validator.check_metadata_suffix(guards._rule_bullets(text)[0])
         is None
     )
+
+
+# --- the predictions corpus ------------------------------------------
+# An autonomous run's own choices: same schema, same append-only
+# guarantee, outside the preference pipeline entirely.
+
+
+def test_predictions_are_append_only_too() -> None:
+    assert guards.APPEND_ONLY_DIRS == ("decisions/", "predictions/")
+
+
+def test_the_prediction_commit_type_is_accepted() -> None:
+    assert guards.check_commit_subject("prediction(factory): a-slug — chosen") is None
+
+
+def test_a_prediction_subject_still_needs_its_scope_and_chosen() -> None:
+    assert guards.check_commit_subject("prediction: no scope") is not None
+    assert guards.check_commit_subject("prediction(factory): no separator") is not None
+
+
+def test_both_corpora_validate_and_share_the_link_graph(tmp_path) -> None:
+    import json as _json
+
+    record = {
+        "v": 1,
+        "type": "decision",
+        "id": "20260730T000000Z-a",
+        "date": "2026-07-30",
+        "project": "factory",
+        "question": "q",
+        "options": [
+            {"slot": 1, "label": "x", "role": "prediction", "rules_cited": []},
+        ],
+        "prediction_stream": "cold",
+        "artifact_ref": None,
+        "chosen_slot": 1,
+        "chosen": "x",
+        "rejections": [],
+        "outcome": "hit",
+    }
+    (tmp_path / "predictions").mkdir()
+    # A prediction whose `related` points nowhere must be caught, which
+    # only happens if predictions enter the same link graph.
+    dangling = dict(record, id="20260730T000001Z-b", related=["20260730T000009Z-ghost"])
+    (tmp_path / "predictions" / f"{dangling['id']}.json").write_text(
+        _json.dumps(dangling)
+    )
+    (tmp_path / "store.config.json").write_text('{"budget_tokens": 2000}')
+    errors = guards.check_corpus(str(tmp_path))
+    assert any("ghost" in error for error in errors), errors


### PR DESCRIPTION
Closes #121. Store-side prerequisite for the `ready-for-agent` pilot;
ruled in decision-memory record
`20260730T115655Z-agent-records-live-in-predictions-dir`.

## What lands

`predictions/<id>.json` — same schema, same append-only guarantee,
same link graph and ID namespace as `decisions/`. A prediction may
reference a decision, and a dangling link is dangling either way, so
both corpora validate together.

What differs is everything downstream:

| | `decisions/` | `predictions/` |
| --- | --- | --- |
| Written by | a human ruling | an autonomous run |
| Extraction walks it | yes | **never** |
| Can bump a counter | yes | **never** |
| Needs a `pref-extract` pass | yes | **no** |
| Append-only | yes | yes |

## The exclusion is structural

`extraction.py` scopes to `decisions/` and does not know
`predictions/` exists — so the exclusion cannot be forgotten by a
future consumer. A test asserts the string never appears in that
module:

```python
assert "predictions" not in source, (
    "extraction must not know about predictions/ at all — the "
    "exclusion is structural, not a filter someone must remember"
)
```

That is deliberate after this week: a filter every reader must
remember is the shape that produced the self-crediting counter (#115).

## Writer

`record.py record --predict` writes to `predictions/` and commits as
`prediction(<project>): <slug> — <chosen>`, a new accepted commit
type. `submit` still reads `decisions/` alone, so a prediction cannot
reach the counters through a second door.

## Why the corpus is worth keeping at all

The records carry `preference_set.commit`. That makes them replayable:
a candidate rule set can be run against them to see what an agent
*would* have chosen — counterfactual simulation, which was the
decider's stated reason for wanting a corpus rather than PR-only
prose.

## Tests

205 passed, 4 skipped. New coverage: append-only extends to
`predictions/`, the commit type is accepted (and still requires scope
and separator), both corpora share the link graph, and extraction
stays ignorant of the directory.

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_