### PR TITLE
docs(agents): a commit named in tracker content must be clickable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,22 @@ Line wrapping:
   the rendered text at random places, because each single newline
   becomes a hard break.
 
-Repairing violations (applies to both rules):
+Linking commits and other references:
+
+- **A commit named in tracker-posted content must be clickable.**
+  Write `[«short-sha»](«repo-url»/commit/«full-sha»)`,
+  or `«owner»/«repo»@«sha»` for a repo other than the one being posted to.
+- Backticks suppress it:
+  the tracker autolinks a *bare* SHA in the same repo,
+  but `` `«sha»` `` renders as inert code —
+  so the habit of code-formatting an identifier is exactly what breaks the link.
+  A cross-repo SHA never autolinks at all, bare or not.
+- The same applies to anything the reader will want to open:
+  files (link to the blob at a ref), workflow runs, and PRs or issues in another repo
+  (`«owner»/«repo»#«n»`, which does autolink).
+  A reference the reader has to copy-paste into a search box is a reference that will not be followed.
+
+Repairing violations (applies to all rules above):
 
 - If an EXISTING ticket violates them, ask the user whether it should
   be fixed — don't rewrite it unprompted.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -172,7 +172,22 @@ Line wrapping:
   the rendered text at random places, because each single newline
   becomes a hard break.
 
-Repairing violations (applies to both rules):
+Linking commits and other references:
+
+- **A commit named in tracker-posted content must be clickable.**
+  Write `[«short-sha»](«repo-url»/commit/«full-sha»)`,
+  or `«owner»/«repo»@«sha»` for a repo other than the one being posted to.
+- Backticks suppress it:
+  the tracker autolinks a *bare* SHA in the same repo,
+  but `` `«sha»` `` renders as inert code —
+  so the habit of code-formatting an identifier is exactly what breaks the link.
+  A cross-repo SHA never autolinks at all, bare or not.
+- The same applies to anything the reader will want to open:
+  files (link to the blob at a ref), workflow runs, and PRs or issues in another repo
+  (`«owner»/«repo»#«n»`, which does autolink).
+  A reference the reader has to copy-paste into a search box is a reference that will not be followed.
+
+Repairing violations (applies to all rules above):
 
 - If an EXISTING ticket violates them, ask the user whether it should
   be fixed — don't rewrite it unprompted.


### PR DESCRIPTION
Closes #129. Reported on pandoscope/meta#45: two review replies cited the commits that fixed the review, and neither could be clicked.

## The trap

The tracker autolinks a **bare** SHA in the same repo. Backticks suppress it — and code-formatting an identifier is the reflex for every other identifier in a comment, so the habit is exactly what breaks the link, while looking *more* correct for doing it. A cross-repo SHA never autolinks at all, bare or not.

Same class as the two rules already in `### Tracker Content Formatting`: content that renders correctly in a committed `.md` and silently degrades when posted to a tracker. It goes in the template rather than a repo-local convention because **Failures Become Rules** names the template as the preferred home — every generated repo inherits it.

The rule also covers the general case: anything the reader will want to open (a blob at a ref, a workflow run, a cross-repo PR) gets a link, because a reference that has to be copy-pasted into a search box will not be followed.

## Two commits, per `docs/conventions.md`

| | |
| --- | --- |
| [`6af1cd0`](https://github.com/pandoscope/agentic-engineering-template/commit/6af1cd0) | template source only — `template/AGENTS.md.jinja` |
| [`eaf9b84`](https://github.com/pandoscope/agentic-engineering-template/commit/eaf9b84) | `chore: reapply template to self` — the root `AGENTS.md` adopted verbatim from the render |

The first version of this PR hand-edited both files in one commit. That happens to satisfy `test_self_application.py`, because the two edits were identical by hand — which is the whole problem: it proves the gate passes without proving the render produces it. Rebuilt on the documented route, with the root file taken verbatim from `copier copy --vcs-ref HEAD`.

## Tests

205 passed, 4 skipped. `test_self_application.py` green.

## Not in scope

Sweeping existing tickets — that section's own repair rule says a violation in an existing ticket is raised with the user rather than rewritten unprompted. The two replies on pandoscope/meta#45 were fixed in place because the principal asked for exactly that.