### PR TITLE
Every repo reports its ticket closes to the session-memory store

### DIFF
--- a/.github/workflows/ticket-closed.yml
+++ b/.github/workflows/ticket-closed.yml
@@ -1,0 +1,62 @@
+name: Report ticket close to the ledger
+
+# The session-memory store closes a thread when the thread's own ticket
+# closes. The store cannot hear this repository's events — a workflow
+# only receives events from the repository it sits in — so every repo
+# that mints tickets reports its own closes.
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ticket-closed-${{ github.event.issue.number }}
+
+jobs:
+  dispatch:
+    name: "tell the store"
+    runs-on: ubuntu-latest
+    # Repos in an org without a session-memory store show this SKIPPED
+    # rather than green. The variable carries owner/repo, set once at
+    # org level — deliberately not baked in at stamping time, so the
+    # rendered file names no org's store and a store move is one
+    # variable edit, not a re-stamp of every repo.
+    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    steps:
+      - name: Name the store's repository
+        id: store
+        env:
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+        run: |
+          set -euo pipefail
+          echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
+
+      # The same app that runs releases and template updates, because its
+      # key already reaches every stamped repo and — unlike a fine-grained
+      # PAT — never expires, so no yearly morning where every sender in
+      # the org goes red at once. repository_dispatch is outside the
+      # repo-scoped GITHUB_TOKEN's reach; the minted token is scoped to
+      # the store repo alone.
+      - name: Mint a token that can reach the store
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.store.outputs.name }}
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # The payload carries only the ticket's name. The store
+          # re-reads the ticket's state itself, so a stale or replayed
+          # dispatch can cause a wasted lookup, never a wrong event.
+          gh api "repos/${STORE}/dispatches" \
+            -f event_type=ticket-closed \
+            -f "client_payload[ticket]=${TICKET}"

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ticket-closed.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ticket-closed.yml
@@ -1,0 +1,62 @@
+name: Report ticket close to the ledger
+
+# The session-memory store closes a thread when the thread's own ticket
+# closes. The store cannot hear this repository's events — a workflow
+# only receives events from the repository it sits in — so every repo
+# that mints tickets reports its own closes.
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ticket-closed-${{ github.event.issue.number }}
+
+jobs:
+  dispatch:
+    name: "tell the store"
+    runs-on: ubuntu-latest
+    # Repos in an org without a session-memory store show this SKIPPED
+    # rather than green. The variable carries owner/repo, set once at
+    # org level — deliberately not baked in at stamping time, so the
+    # rendered file names no org's store and a store move is one
+    # variable edit, not a re-stamp of every repo.
+    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    steps:
+      - name: Name the store's repository
+        id: store
+        env:
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+        run: |
+          set -euo pipefail
+          echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
+
+      # The same app that runs releases and template updates, because its
+      # key already reaches every stamped repo and — unlike a fine-grained
+      # PAT — never expires, so no yearly morning where every sender in
+      # the org goes red at once. repository_dispatch is outside the
+      # repo-scoped GITHUB_TOKEN's reach; the minted token is scoped to
+      # the store repo alone.
+      - name: Mint a token that can reach the store
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.store.outputs.name }}
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # The payload carries only the ticket's name. The store
+          # re-reads the ticket's state itself, so a stale or replayed
+          # dispatch can cause a wasted lookup, never a wrong event.
+          gh api "repos/${STORE}/dispatches" \
+            -f event_type=ticket-closed \
+            -f "client_payload[ticket]=${TICKET}"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -55,6 +55,7 @@ GITHUB_ONLY_FILES = frozenset(
         ".github/workflows/add-to-project.yml",
         ".github/workflows/labels.yml",
         ".github/workflows/lint.yml",
+        ".github/workflows/ticket-closed.yml",
     }
 )
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -637,6 +637,38 @@ def test_github_forge_ships_board_auto_add_workflow(
     )
 
 
+def test_github_forge_ships_ticket_close_dispatch(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """The session-memory store closes a thread when its ticket closes,
+    and it cannot hear another repository's events — so every stamped
+    repo reports its own closes. The store's location is an org-level
+    variable, never baked in at stamping time: the rendered file must
+    name no org's store."""
+    dst_path = _render(tmp_path, base_answers, "ticket-closed")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "ticket-closed.yml",
+        [
+            "repos/${STORE}/dispatches",
+            "event_type=ticket-closed",
+            # The dispatch crosses repositories, which the repo-scoped
+            # GITHUB_TOKEN cannot do. The release-bot app signs instead
+            # of a PAT: its key already reaches every stamped repo and
+            # never expires.
+            "actions/create-github-app-token",
+            "RELEASE_BOT_PRIVATE_KEY",
+            # The minted token reaches the store repo alone.
+            "repositories: ${{ steps.store.outputs.name }}",
+            # Unset store variable -> visibly SKIPPED, never silent green.
+            "if: ${{ vars.SESSION_MEMORY_REPO != '' }}",
+        ],
+    )
+    content = (dst_path / ".github" / "workflows" / "ticket-closed.yml").read_text()
+    assert "session-memory" not in content.replace("session-memory store", "")
+
+
 def test_forgejo_forge_ships_no_github_org_plumbing(
     tmp_path: Path,
     base_answers: dict[str, str],


### PR DESCRIPTION
Refs pandoscope/session-memory#2, pandoscope/session-memory#3.

The store closes a thread when the thread's own ticket closes. Its first design polled every live ticket on a six-hour clock; the principal ruled that unacceptable (decision-memory: `close-loop-trigger-poll-overruled`), and the correction is this: the template ships an `issues: closed` workflow to every stamped repo, which fires `repository_dispatch` at the store the moment a ticket closes. Event-driven end to end, on the same channel that already ships the labels and board workflows.

## Shape

- **`ticket-closed.yml`**, GitHub-forge only, beside `labels.yml` and `add-to-project.yml`. Adopted at root too — this repo mints tickets that ledger threads reference, and the self-application gate requires it anyway.
- **The store's location is `vars.SESSION_MEMORY_REPO`**, an org-level variable, deliberately not baked in at stamping time: the rendered file names no org's store, and a store move is one variable edit rather than a re-stamp of every repo. Unset → the job shows SKIPPED, never a silent green (same rule as the labels guard).
- **The sender signs as the release-bot app** (`RELEASE_BOT_CLIENT_ID` + `RELEASE_BOT_PRIVATE_KEY`, the exact pattern of `template-update.yml`), at the principal's direction: a fine-grained PAT's mandatory one-year expiry means a yearly morning where every sender in the org goes red at once, and the app's key never expires. Reuse over a second app because the key already circulates to every stamped repo — this PR introduces **no new secret**. The minted installation token is scoped to the store repository alone, so the sender never runs with more reach than the one call it makes.
- **The payload carries only the ticket's name, and the receiver ignores even that.** The store re-reads ticket state itself, so a stale or replayed dispatch is a wasted lookup, never a wrong event — there is no parser at the trust boundary at all (the concern AET#111 documents).

## Setup this needs, once

1. `SESSION_MEMORY_REPO` org variable = the store's `owner/repo`.
2. Release-bot app: no permission change for the sender (Contents write suffices for `repository_dispatch`). The **receiver** side wants Issues: Read-only added — detailed in pandoscope/session-memory#3.

## Testing

`test_github_forge_ships_ticket_close_dispatch` pins the dispatch call, the app-token mint, the store-only token scope, the SKIPPED guard, and — separately — that the rendered file names no org's store. The e2e expected-tree manifests gained the file. Full suite: 206 passed, 4 skipped.

## Rollout

Stamped repos pick the sender up on their next template update. Until a repo carries it, its closes reach the ledger via the store's manual sweep (`workflow_dispatch` on close-loop), which reconciles every live ticket — the receiver side is pandoscope/session-memory#3.