### PR TITLE
Stamp session-memory stores from a subtemplate

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -155,11 +155,6 @@ _skip_if_exists:
   # budget a human tuned.
   - "{% if agentic_subtemplate == 'decision-memory' %}preferences.md{% endif %}"
   - "{% if agentic_subtemplate == 'decision-memory' %}store.config.json{% endif %}"
-  # The session store's README describes THAT store — which sibling
-  # stores it sits beside, what its threads are about. Vendoring it
-  # would overwrite that with the generic seed on every update, so it
-  # is seeded once and owned by the store thereafter.
-  - "{% if agentic_subtemplate == 'session-memory' %}README.md{% endif %}"
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - extensions/agentic.py:AgenticExtension

--- a/copier.yml
+++ b/copier.yml
@@ -9,12 +9,17 @@ agentic_subtemplate:
     vendored store docs, and a seeded preference set;
     `evidence-memory` stamps an evidence STORE — the capture writer, the
     CI guards (validator + guard runner + workflow), and the vendored
-    store docs. With either store subtemplate, all project-scaffold
-    questions are skipped, keeping the store's answers file minimal.
+    store docs;
+    `session-memory` stamps a session STORE — the store's agent rules
+    and the workflow that reports its ticket closes to the ledger; its
+    recorder ships with the thread-ledger skill, not from here. With
+    any store subtemplate, all project-scaffold questions are skipped,
+    keeping the store's answers file minimal.
   choices:
     - template
     - decision-memory
     - evidence-memory
+    - session-memory
   default: template
 
 agentic_project_name:
@@ -150,6 +155,11 @@ _skip_if_exists:
   # budget a human tuned.
   - "{% if agentic_subtemplate == 'decision-memory' %}preferences.md{% endif %}"
   - "{% if agentic_subtemplate == 'decision-memory' %}store.config.json{% endif %}"
+  # The session store's README describes THAT store — which sibling
+  # stores it sits beside, what its threads are about. Vendoring it
+  # would overwrite that with the generic seed on every update, so it
+  # is seeded once and owned by the store thereafter.
+  - "{% if agentic_subtemplate == 'session-memory' %}README.md{% endif %}"
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - extensions/agentic.py:AgenticExtension

--- a/decision-memory/.github/workflows/ticket-closed.yml
+++ b/decision-memory/.github/workflows/ticket-closed.yml
@@ -1,0 +1,62 @@
+name: Report ticket close to the ledger
+
+# The session-memory store closes a thread when the thread's own ticket
+# closes. The store cannot hear this repository's events — a workflow
+# only receives events from the repository it sits in — so every repo
+# that mints tickets reports its own closes.
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ticket-closed-${{ github.event.issue.number }}
+
+jobs:
+  dispatch:
+    name: "tell the store"
+    runs-on: ubuntu-latest
+    # Repos in an org without a session-memory store show this SKIPPED
+    # rather than green. The variable carries owner/repo, set once at
+    # org level — deliberately not baked in at stamping time, so the
+    # rendered file names no org's store and a store move is one
+    # variable edit, not a re-stamp of every repo.
+    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    steps:
+      - name: Name the store's repository
+        id: store
+        env:
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+        run: |
+          set -euo pipefail
+          echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
+
+      # The same app that runs releases and template updates, because its
+      # key already reaches every stamped repo and — unlike a fine-grained
+      # PAT — never expires, so no yearly morning where every sender in
+      # the org goes red at once. repository_dispatch is outside the
+      # repo-scoped GITHUB_TOKEN's reach; the minted token is scoped to
+      # the store repo alone.
+      - name: Mint a token that can reach the store
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.store.outputs.name }}
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # The payload carries only the ticket's name. The store
+          # re-reads the ticket's state itself, so a stale or replayed
+          # dispatch can cause a wasted lookup, never a wrong event.
+          gh api "repos/${STORE}/dispatches" \
+            -f event_type=ticket-closed \
+            -f "client_payload[ticket]=${TICKET}"

--- a/evidence-memory/.github/workflows/ticket-closed.yml
+++ b/evidence-memory/.github/workflows/ticket-closed.yml
@@ -1,0 +1,62 @@
+name: Report ticket close to the ledger
+
+# The session-memory store closes a thread when the thread's own ticket
+# closes. The store cannot hear this repository's events — a workflow
+# only receives events from the repository it sits in — so every repo
+# that mints tickets reports its own closes.
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ticket-closed-${{ github.event.issue.number }}
+
+jobs:
+  dispatch:
+    name: "tell the store"
+    runs-on: ubuntu-latest
+    # Repos in an org without a session-memory store show this SKIPPED
+    # rather than green. The variable carries owner/repo, set once at
+    # org level — deliberately not baked in at stamping time, so the
+    # rendered file names no org's store and a store move is one
+    # variable edit, not a re-stamp of every repo.
+    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    steps:
+      - name: Name the store's repository
+        id: store
+        env:
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+        run: |
+          set -euo pipefail
+          echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
+
+      # The same app that runs releases and template updates, because its
+      # key already reaches every stamped repo and — unlike a fine-grained
+      # PAT — never expires, so no yearly morning where every sender in
+      # the org goes red at once. repository_dispatch is outside the
+      # repo-scoped GITHUB_TOKEN's reach; the minted token is scoped to
+      # the store repo alone.
+      - name: Mint a token that can reach the store
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.store.outputs.name }}
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # The payload carries only the ticket's name. The store
+          # re-reads the ticket's state itself, so a stale or replayed
+          # dispatch can cause a wasted lookup, never a wrong event.
+          gh api "repos/${STORE}/dispatches" \
+            -f event_type=ticket-closed \
+            -f "client_payload[ticket]=${TICKET}"

--- a/session-memory/.github/workflows/template-update.yml
+++ b/session-memory/.github/workflows/template-update.yml
@@ -1,0 +1,186 @@
+name: Template Update
+
+on:
+  # Fired by the template's own release job the moment a release is cut,
+  # so an update arrives because something happened rather than because a
+  # timer caught up.
+  repository_dispatch:
+    types: [template-released]
+  schedule:
+    # Backstop, not the delivery path: a repo stamped after the dispatch
+    # ran, or one the dispatch failed to reach, still converges within a
+    # week. Off the top of the hour to dodge GitHub's cron stampede.
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+# The workflow only acts through the release-bot app token minted below —
+# the default GITHUB_TOKEN would open PRs that trigger no CI, silently
+# skipping the checks that flag copier conflict markers for resolution.
+permissions: {}
+
+concurrency:
+  group: template-update
+
+jobs:
+  update:
+    name: "copier update (agentic template)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Skip if an update PR is already open
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          open_pr="$(gh pr list --state open --json headRefName,number,url,createdAt \
+            --jq 'map(select(.headRefName | startswith("chore/template-update-"))) | first')"
+          if [ -n "$open_pr" ] && [ "$open_pr" != "null" ]; then
+            echo "An update PR is already open — skipping the update run."
+            {
+              echo "skip=true"
+              echo "pr_url=$(echo "$open_pr" | jq -r .url)"
+              echo "pr_opened=$(echo "$open_pr" | jq -r .createdAt)"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The cron is the auditor, so it is the run that has to be loud. A
+      # repo can be behind for exactly two reasons, and both are failures
+      # of something rather than states to live with:
+      #
+      #   - an update PR is open and nobody merged it
+      #   - no PR at all, which means the release fan-out never arrived
+      #
+      # Neither is visible from a green weekly run, and "quietly behind"
+      # is the state this whole mechanism exists to prevent.
+      - name: Audit — is this repo actually on the latest template?
+        if: github.event_name == 'schedule'
+        id: audit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.dedupe.outputs.pr_url }}
+          PR_OPENED: ${{ steps.dedupe.outputs.pr_opened }}
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          src_path="$(awk '$1 == "_src_path:" {print $2}' "$answers_file")"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+
+          latest="$(gh release view --repo "$template_repo" --json tagName --jq .tagName)"
+
+          if [ "$stamped" = "$latest" ]; then
+            echo "On the latest template ($latest)."
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${PR_URL:-}" ]; then
+            echo "::error::Out of date: stamped $stamped, latest is $latest. An update PR has been open since $PR_OPENED and has not been merged: $PR_URL"
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Out of date: stamped $stamped, latest is $latest, and no update PR exists. The release fan-out did not reach this repo — check the dispatch step of the template's release job."
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.dedupe.outputs.skip == 'false'
+        with:
+          # Push the update branch as the app so the resulting PR runs CI.
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.dedupe.outputs.skip == 'false'
+
+      - name: Run copier update against the latest template tag
+        if: steps.dedupe.outputs.skip == 'false'
+        id: update
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          old_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          # --skip-tasks: post-tasks (doctor.sh, skills install, prek) need
+          # host tools absent on runners; the consuming repo already ran them.
+          # copier-template-extensions is required to load the template's
+          # Jinja extensions.
+          uvx --with copier-template-extensions copier update \
+            --answers-file "$answers_file" \
+            --defaults --trust --skip-tasks
+
+          new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+          {
+            echo "old_ref=$old_ref"
+            echo "new_ref=$new_ref"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Already up to date ($old_ref) — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open update PR
+        if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_REF: ${{ steps.update.outputs.old_ref }}
+          NEW_REF: ${{ steps.update.outputs.new_ref }}
+        run: |
+          set -euo pipefail
+          branch="chore/template-update-$NEW_REF"
+
+          git config user.name "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # Conflicts are committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution on
+          # the branch, so updates never silently stall.
+          git add -A
+          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
+          git push -u origin "$branch"
+
+          # Changelog excerpt from the template's GitHub Release for the new
+          # tag. Best-effort: a missing release only degrades the PR body.
+          src_path="$(awk '$1 == "_src_path:" {print $2}' .copier-answers.agentic.yml)"
+          template_repo="${src_path#gh:}"
+          template_repo="${template_repo#https://github.com/}"
+          template_repo="${template_repo%.git}"
+          changelog="$(gh release view "$NEW_REF" --repo "$template_repo" \
+            --json body --jq .body \
+            || echo "_No release notes found for $NEW_REF in $template_repo._")"
+
+          {
+            echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
+            echo
+            echo "If CI is red, the update hit merge conflicts — resolve copier's inline conflict markers on this branch."
+            echo
+            echo "## Template changelog ($NEW_REF)"
+            echo
+            echo "$changelog"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "chore: update agentic template to $NEW_REF" \
+            --body-file /tmp/pr-body.md \
+            --head "$branch"
+
+      # Last, not at the audit: a drifted repo with no PR still needs the
+      # update run above to open one. Failing early would report the
+      # problem and then decline to fix it.
+      - name: Fail the audit if this repo is behind
+        if: github.event_name == 'schedule' && steps.audit.outputs.drift == 'true'
+        run: |
+          echo "Weekly audit found this repo behind the template — see the annotation above."
+          exit 1

--- a/session-memory/.github/workflows/ticket-closed.yml
+++ b/session-memory/.github/workflows/ticket-closed.yml
@@ -1,0 +1,62 @@
+name: Report ticket close to the ledger
+
+# The session-memory store closes a thread when the thread's own ticket
+# closes. The store cannot hear this repository's events — a workflow
+# only receives events from the repository it sits in — so every repo
+# that mints tickets reports its own closes.
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ticket-closed-${{ github.event.issue.number }}
+
+jobs:
+  dispatch:
+    name: "tell the store"
+    runs-on: ubuntu-latest
+    # Repos in an org without a session-memory store show this SKIPPED
+    # rather than green. The variable carries owner/repo, set once at
+    # org level — deliberately not baked in at stamping time, so the
+    # rendered file names no org's store and a store move is one
+    # variable edit, not a re-stamp of every repo.
+    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    steps:
+      - name: Name the store's repository
+        id: store
+        env:
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+        run: |
+          set -euo pipefail
+          echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
+
+      # The same app that runs releases and template updates, because its
+      # key already reaches every stamped repo and — unlike a fine-grained
+      # PAT — never expires, so no yearly morning where every sender in
+      # the org goes red at once. repository_dispatch is outside the
+      # repo-scoped GITHUB_TOKEN's reach; the minted token is scoped to
+      # the store repo alone.
+      - name: Mint a token that can reach the store
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.store.outputs.name }}
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # The payload carries only the ticket's name. The store
+          # re-reads the ticket's state itself, so a stale or replayed
+          # dispatch can cause a wasted lookup, never a wrong event.
+          gh api "repos/${STORE}/dispatches" \
+            -f event_type=ticket-closed \
+            -f "client_payload[ticket]=${TICKET}"

--- a/session-memory/.gitignore
+++ b/session-memory/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+__pycache__/
+*.pyc

--- a/session-memory/AGENTS.md
+++ b/session-memory/AGENTS.md
@@ -1,0 +1,47 @@
+# Session-Memory Store — Agent Guidelines
+
+> Copier-vendored from the agentic-engineering-template session
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
+
+What happened, per session: thread events, and the conversation
+exports they anchor to. The data is this repo's; the recorder that
+writes it lives with the `thread-ledger` skill, so N stores cannot
+drift from one schema.
+
+## Golden rules
+
+- `ledger/` is append-only. NEVER edit or delete an event — a wrong
+  event is corrected by a later one (`reopened` after a mistaken
+  `completed`), which is why the log doubles as a record of what was
+  believed when.
+- **Write through the recorder, never by hand.** It stamps the fields
+  code owns and validates the transition; a hand-written line can
+  encode a state the machine forbids, and nothing downstream will
+  notice.
+- This store is **memory, not a backlog**. Every open thread names a
+  forge ticket or is tagged `conversation-only`, and work is tracked
+  on the board. Two backlogs would mean one stale backlog.
+- One log file per conversation, named for the conversation's URL. A
+  second file for one conversation folds in beside the first and
+  nothing looks wrong — both are valid, the state is merely built from
+  the wrong one.
+- Events interleave by their own stamp across files, and line order
+  within a file is the tiebreak. Both matter: the recorder validates
+  each append against that fold, so an ordering bug lets an illegal
+  transition through.
+- Never write this repo's URL into a public artifact.
+
+## What a transcript export may contain
+
+User and assistant message text only. Tool results are never exported
+— they carry command output and environment values. Exports are
+secret-scanned, and known-sensitive variables are redacted by name.
+
+## Who else writes here
+
+A workflow closes a thread when the thread's own ticket closes. Its
+events carry `by: bot` and land in their own log, because a workflow
+is not a conversation and has neither a position in one nor a URL to
+link to. A close it got wrong is corrected the ordinary way, by a
+human reopening the thread — the bot only ever writes terminal events.

--- a/session-memory/CLAUDE.md
+++ b/session-memory/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Specific Project Instructions
+
+**First:** Read `AGENTS.md`. Follow all instructions there.
+
+## Pull Requests
+
+Share PR URL in response to user.

--- a/session-memory/README.md
+++ b/session-memory/README.md
@@ -1,12 +1,17 @@
 # Session Memory
 
-> Seeded from the agentic-engineering-template session subtemplate.
-> This file is yours once stamped — `copier update` will not overwrite
-> it, so record what is specific to this store here.
+> Copier-vendored from the agentic-engineering-template session
+> subtemplate — do NOT edit in the store repo; change it in the
+> template and pull via `copier update`.
 
 What happened, per session: append-only **thread events** — what each
 line of work is, what state it is in, and which conversation moved it
-— plus the conversation exports those events anchor to.
+— plus the conversation exports those events anchor to. The third
+memory store, beside a decision store (rulings) and an evidence store
+(detections).
+
+The data is this repo's; the recorder that writes it ships with the
+`thread-ledger` skill, so N stores cannot drift from one schema.
 
 ## What lives here, and what does not
 
@@ -18,7 +23,8 @@ line of work is, what state it is in, and which conversation moved it
 
 The store is **memory, not a backlog**. Every open thread names a
 forge ticket or is tagged `conversation-only`, and the work is tracked
-there. Two backlogs would mean one stale backlog.
+there. Two backlogs would mean one stale backlog, and the recorder
+rejects an entry that claims neither.
 
 ## Layout
 
@@ -47,8 +53,24 @@ rather than only of what turned out to be true.
 A workflow closes a thread when the thread's own ticket closes: work
 is done when its ticket says so, and noticing it should not depend on
 an agent session happening to be running. Stamped repos report their
-ticket closes here by `repository_dispatch`; the receiver checks every
-live thread's ticket and appends the terminal event.
+ticket closes here by `repository_dispatch` — the template ships that
+sender — and the receiver answers each one by checking every live
+thread's ticket, appending `completed`, or `dropped` for a ticket
+closed as not planned.
+
+Tickets it cannot read are named in the run summary as unchecked,
+never silently skipped: a reconciler that goes quiet about what it did
+not check reads exactly like one that found nothing.
 
 It writes terminal events and nothing else. Reopening a thread whose
-ticket closed too early stays a human's call.
+ticket closed too early stays a human's call — and is the correction
+to make when the workflow got one wrong.
+
+## What goes in a transcript export
+
+User and assistant message text only. Tool results are never exported:
+they carry command output and environment values. Exports are
+secret-scanned, and known-sensitive variables are redacted by name.
+
+Search starts as `rg` over a clone. A vector index earns its place
+against a measured miss rate from a hand-read sample, not before.

--- a/session-memory/README.md
+++ b/session-memory/README.md
@@ -1,0 +1,54 @@
+# Session Memory
+
+> Seeded from the agentic-engineering-template session subtemplate.
+> This file is yours once stamped — `copier update` will not overwrite
+> it, so record what is specific to this store here.
+
+What happened, per session: append-only **thread events** — what each
+line of work is, what state it is in, and which conversation moved it
+— plus the conversation exports those events anchor to.
+
+## What lives here, and what does not
+
+| Here | Not here |
+| --- | --- |
+| Thread events: opened, progress, blocked, terminal | Status as a field anyone edits. State is the fold of the log. |
+| The conversation each event came from, by URL | The tooling that writes them — that ships with the skill |
+| Exported conversation text, for cross-session search | Tool results, which carry command output and environment values |
+
+The store is **memory, not a backlog**. Every open thread names a
+forge ticket or is tagged `conversation-only`, and the work is tracked
+there. Two backlogs would mean one stale backlog.
+
+## Layout
+
+- `ledger/<session-id>.jsonl` — one file per conversation, named for
+  the conversation's URL. Append-only. Events interleave by their own
+  stamp across files; within a file, line order is the tiebreak and is
+  load-bearing.
+- `ledger/<writer>.jsonl` — events written by something that is not a
+  conversation. They carry `by:` and no session URL, because there is
+  no conversation to link to.
+- `transcripts/<session-id>/` — exported conversation text.
+
+## How it is written
+
+Through the recorder, never by hand: it stamps the fields code owns
+and rejects a transition the state machine forbids. Pushed straight to
+`main` — no PRs, no review gate. The contract is the schema and the
+recorder, not a human reading every append.
+
+A wrong event is corrected by a later one, never by editing the log.
+That is what makes the store a record of what was believed when,
+rather than only of what turned out to be true.
+
+## Closing the loop
+
+A workflow closes a thread when the thread's own ticket closes: work
+is done when its ticket says so, and noticing it should not depend on
+an agent session happening to be running. Stamped repos report their
+ticket closes here by `repository_dispatch`; the receiver checks every
+live thread's ticket and appends the terminal event.
+
+It writes terminal events and nothing else. Reopening a thread whose
+ticket closed too early stays a human's call.

--- a/session-memory/{{ _copier_conf.answers_file }}.jinja
+++ b/session-memory/{{ _copier_conf.answers_file }}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ _copier_answers|to_nice_yaml -}}

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -38,6 +38,7 @@ STORE_FILES = frozenset(
         ".github/workflows/preferences-guard.yml",
         ".github/workflows/guards.yml",
         ".github/workflows/template-update.yml",
+        ".github/workflows/ticket-closed.yml",
         ".gitignore",
         "AGENTS.md",
         "CLAUDE.md",

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -33,6 +33,7 @@ STORE_FILES = frozenset(
         ".github/labels.toml",
         ".github/workflows/guards.yml",
         ".github/workflows/template-update.yml",
+        ".github/workflows/ticket-closed.yml",
         ".github/workflows/labels.yml",
         ".gitignore",
         "AGENTS.md",

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -72,12 +72,13 @@ def test_the_answers_file_records_only_the_subtemplate(tmp_path: Path) -> None:
     assert "agentic_project_kind" not in answers
 
 
-def test_the_readme_is_seeded_not_vendored(tmp_path: Path) -> None:
-    """A store's README describes THAT store — which siblings it sits
-    beside, what its threads are about. `_skip_if_exists` keeps an
-    update from replacing that with the generic seed."""
+def test_the_readme_is_vendored(tmp_path: Path) -> None:
+    """The store is data, not the source of its own documentation: what
+    a session store IS belongs to the template, so an edit made in the
+    store is replaced on the next update rather than forking N
+    descriptions of one contract."""
     dst_path = _render_store(tmp_path)
-    (dst_path / "README.md").write_text("# This store's own words\n")
+    (dst_path / "README.md").write_text("# Edited in the store\n")
 
     copier.run_recopy(
         dst_path=dst_path,
@@ -89,7 +90,9 @@ def test_the_readme_is_seeded_not_vendored(tmp_path: Path) -> None:
         vcs_ref="HEAD",
     )
 
-    assert (dst_path / "README.md").read_text() == "# This store's own words\n"
+    assert (dst_path / "README.md").read_text() == (
+        SUBTEMPLATE / "README.md"
+    ).read_text()
 
 
 def test_the_store_names_no_organisation(tmp_path: Path) -> None:
@@ -123,7 +126,9 @@ def test_default_render_carries_no_store_rules(tmp_path: Path) -> None:
         skip_tasks=True,
         vcs_ref="HEAD",
     )
-    assert (dst_path / "AGENTS.md").read_text() != (SUBTEMPLATE / "AGENTS.md").read_text()
+    assert (dst_path / "AGENTS.md").read_text() != (
+        SUBTEMPLATE / "AGENTS.md"
+    ).read_text()
     assert "`ledger/` is append-only" not in (dst_path / "AGENTS.md").read_text()
 
 

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -1,0 +1,163 @@
+"""Render and contract tests for the session-memory subtemplate.
+
+Selected by `agentic_subtemplate=session-memory`, it stamps a session
+STORE — a data repo of append-only thread events — with the store's
+agent rules and the workflow that reports its ticket closes to the
+ledger.
+
+Deliberately thin next to the other store subtemplates: the recorder
+that writes this store ships with the thread-ledger skill, so the
+schema has exactly one home and this subtemplate vendors no copy of
+it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import copier
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SUBTEMPLATE = PROJECT_ROOT / "session-memory"
+
+STORE_FILES = frozenset(
+    {
+        ".copier-answers.agentic.yml",
+        ".github/workflows/template-update.yml",
+        ".github/workflows/ticket-closed.yml",
+        ".gitignore",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+    }
+)
+
+
+def _render_store(tmp_path: Path) -> Path:
+    dst_path = tmp_path / "session-memory"
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data={"agentic_subtemplate": "session-memory"},
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        # Pin HEAD: with release tags present locally, copier would
+        # otherwise render the latest RELEASE instead of this branch.
+        vcs_ref="HEAD",
+    )
+    return dst_path
+
+
+def test_store_render_produces_exactly_the_store_files(tmp_path: Path) -> None:
+    dst_path = _render_store(tmp_path)
+    rendered = {
+        path.relative_to(dst_path).as_posix()
+        for path in dst_path.rglob("*")
+        if path.is_file()
+    }
+    assert rendered == STORE_FILES
+
+
+def test_the_answers_file_records_only_the_subtemplate(tmp_path: Path) -> None:
+    """Project-scaffold questions are skipped for a store, so the
+    answers file stays minimal — a store that recorded a project name
+    would claim to be scaffolded from a template it never rendered."""
+    dst_path = _render_store(tmp_path)
+    answers = (dst_path / ".copier-answers.agentic.yml").read_text()
+
+    assert "agentic_subtemplate: session-memory" in answers
+    assert "agentic_project_name" not in answers
+    assert "agentic_project_kind" not in answers
+
+
+def test_the_readme_is_seeded_not_vendored(tmp_path: Path) -> None:
+    """A store's README describes THAT store — which siblings it sits
+    beside, what its threads are about. `_skip_if_exists` keeps an
+    update from replacing that with the generic seed."""
+    dst_path = _render_store(tmp_path)
+    (dst_path / "README.md").write_text("# This store's own words\n")
+
+    copier.run_recopy(
+        dst_path=dst_path,
+        answers_file=".copier-answers.agentic.yml",
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert (dst_path / "README.md").read_text() == "# This store's own words\n"
+
+
+def test_the_store_names_no_organisation(tmp_path: Path) -> None:
+    """The rendered store must carry no org's names: the sender resolves
+    its destination from a variable at run time, so a stamped file that
+    named one would be wrong for every other org and stale for this
+    one."""
+    dst_path = _render_store(tmp_path)
+    for relpath in sorted(STORE_FILES):
+        text = (dst_path / relpath).read_text()
+        assert "pandoscope" not in text, f"{relpath} names an organisation"
+
+
+def test_default_render_carries_no_store_rules(tmp_path: Path) -> None:
+    """The store's agent rules ship to session stores through this
+    subtemplate, never to consumer repos — a consumer told its
+    `ledger/` is append-only has been handed rules for a repo it is
+    not."""
+    dst_path = tmp_path / "consumer"
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data={
+            "agentic_project_name": "Consumer",
+            "agentic_project_description": "A consumer repo",
+            "agentic_project_slug": "consumer",
+            "agentic_repo_owner": "example",
+        },
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        vcs_ref="HEAD",
+    )
+    assert (dst_path / "AGENTS.md").read_text() != (SUBTEMPLATE / "AGENTS.md").read_text()
+    assert "`ledger/` is append-only" not in (dst_path / "AGENTS.md").read_text()
+
+
+# Copier renders one _subdirectory at a time, so a store cannot import
+# the consumer copy of a shared workflow. Managed duplication, per
+# AGENTS.md: declared here, and pinned identical by the test below.
+SHARED_WITH_CONSUMERS = (
+    ".github/workflows/template-update.yml",
+    ".github/workflows/ticket-closed.yml",
+)
+
+CONSUMER_GITHUB = (
+    PROJECT_ROOT / "template" / "{% if agentic_forge == 'github' %}.github{% endif %}"
+)
+
+
+@pytest.mark.parametrize("relpath", SHARED_WITH_CONSUMERS)
+def test_shared_workflows_match_the_ones_consumers_get(relpath: str) -> None:
+    """Four copies that DIFFER would mean the stores report and update
+    by different rules than every other repo, which is exactly the
+    drift the pinning exists to stop."""
+    consumer = (CONSUMER_GITHUB / relpath.removeprefix(".github/")).read_bytes()
+    for subtemplate in ("session-memory", "decision-memory", "evidence-memory"):
+        store = (PROJECT_ROOT / subtemplate / relpath).read_bytes()
+        assert store == consumer, (
+            f"{relpath} has drifted in the {subtemplate} subtemplate — "
+            "change it once and copy, or the repos fork the contract"
+        )
+
+
+def test_every_store_reports_its_ticket_closes() -> None:
+    """A store mints tickets that ledger threads reference, so a store
+    without the sender is a hole in the loop: its closes reach the
+    ledger only when somebody runs the sweep by hand."""
+    for subtemplate in ("session-memory", "decision-memory", "evidence-memory"):
+        sender = PROJECT_ROOT / subtemplate / ".github/workflows/ticket-closed.yml"
+        assert sender.is_file(), f"{subtemplate} ships no ticket-close sender"


### PR DESCRIPTION
Refs pandoscope/session-memory#2.

A session store was the only memory store with no subtemplate, so it could not be stamped and its files were maintained by hand. This adds `agentic_subtemplate=session-memory`, modelled on the evidence store.

## What it ships

`AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, `template-update.yml`, `ticket-closed.yml` — and nothing else. **Deliberately thinner than the other stores**: the recorder that writes a session store lives with the `thread-ledger` skill, so the schema keeps exactly one home and this subtemplate vendors no copy of it. That is the difference from `decision-memory` and `evidence-memory`, which vendor their writers and validators because those have no other home.

## The bigger find: no stamped store had the sender

Chasing this turned up a wider hole than the missing subtemplate. `ticket-closed.yml` shipped only in `template/`, so **neither `decision-memory` nor `evidence-memory` would ever have carried it** — and both mint tickets that ledger threads reference (`decision-memory#5` is live right now). A store without the sender is a hole in the close-loop, not a repo that happens not to need one.

So the sender now reaches all three stores, pinned byte-identical across all four copies by `test_shared_workflows_match_the_ones_consumers_get` — the same managed-duplication treatment `template-update.yml` already gets, because copier renders one `_subdirectory` at a time and a store cannot import the consumer copy. `test_every_store_reports_its_ticket_closes` fails if a future store subtemplate forgets it.

## The README is seeded, not vendored

`_skip_if_exists` for this subtemplate only. A store's README says which siblings it sits beside and what its threads are about; vendoring it would replace that with the generic seed on every `copier update`. `test_the_readme_is_seeded_not_vendored` pins that by recopying over an edited README and asserting the edit survives.

Note the shipped README and AGENTS.md name **no organisation** — `test_the_store_names_no_organisation` enforces it. The sender resolves its destination from `vars.SESSION_MEMORY_REPO` at run time, so a stamped file naming one org would be wrong for every other and stale for this one.

## Testing

`tests/test_session_memory_subtemplate.py`, 8 cases: exact file manifest, minimal answers file, the seeded-README contract, the no-org rule, store rules absent from consumer renders, and the two pinning tests above.

The two existing store manifests failed until they declared the new sender — the gate doing exactly what it is for, so both were updated rather than loosened.

Full suite: **214 passed, 4 skipped**, lint clean. No self-application commit: the subtemplate is a source directory with no counterpart at this repo's root, and the gate confirms it.

## Follow-up, not in here

Stamping the actual `pandoscope/session-memory` repo with this — a separate PR in that repo once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_