### PR TITLE
feat: bot commits are created through the API, so they arrive Verified

### DIFF
--- a/decision-memory/.github/workflows/template-update.yml
+++ b/decision-memory/.github/workflows/template-update.yml
@@ -140,16 +140,50 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/template-update-$NEW_REF"
+          head="$(git rev-parse HEAD)"
 
-          git config user.name "release-bot[bot]"
-          git config user.email "release-bot[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          # Conflicts are committed as copier's inline markers on purpose:
-          # the PR opens either way and red CI flags them for resolution on
-          # the branch, so updates never silently stall.
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub on behalf
+          # of the app and show as Verified, so repos can require
+          # verified signatures without exempting this bot. Conflicts
+          # are still committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution
+          # on the branch, so updates never silently stall.
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$branch" -f sha="$head" --silent
+
           git add -A
-          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
-          git push -u origin "$branch"
+          printf '[]' > /tmp/additions.json
+          printf '[]' > /tmp/deletions.json
+          while IFS=$'\t' read -r status path; do
+            [ -z "$status" ] && continue
+            if [ "$status" = "D" ]; then
+              jq --arg p "$path" '. + [{path: $p}]' /tmp/deletions.json \
+                > /tmp/d.json && mv /tmp/d.json /tmp/deletions.json
+            else
+              jq --arg p "$path" --arg c "$(base64 -w0 "$path")" \
+                '. + [{path: $p, contents: $c}]' /tmp/additions.json \
+                > /tmp/a.json && mv /tmp/a.json /tmp/additions.json
+            fi
+          done < <(git -c core.quotePath=false -c diff.renames=false \
+            diff --cached --name-status)
+
+          jq -n \
+            --slurpfile adds /tmp/additions.json \
+            --slurpfile dels /tmp/deletions.json \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$branch" \
+            --arg head "$head" \
+            --arg headline "chore: update agentic template $OLD_REF -> $NEW_REF" \
+            '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                expectedHeadOid: $head,
+                message: {headline: $headline},
+                fileChanges: {additions: $adds[0], deletions: $dels[0]}}}}' \
+            > /tmp/graphql.json
+          gh api graphql --input /tmp/graphql.json \
+            --jq '.data.createCommitOnBranch.commit.oid'
 
           # Changelog excerpt from the template's GitHub Release for the new
           # tag. Best-effort: a missing release only degrades the PR body.

--- a/evidence-memory/.github/workflows/template-update.yml
+++ b/evidence-memory/.github/workflows/template-update.yml
@@ -140,16 +140,50 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/template-update-$NEW_REF"
+          head="$(git rev-parse HEAD)"
 
-          git config user.name "release-bot[bot]"
-          git config user.email "release-bot[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          # Conflicts are committed as copier's inline markers on purpose:
-          # the PR opens either way and red CI flags them for resolution on
-          # the branch, so updates never silently stall.
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub on behalf
+          # of the app and show as Verified, so repos can require
+          # verified signatures without exempting this bot. Conflicts
+          # are still committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution
+          # on the branch, so updates never silently stall.
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$branch" -f sha="$head" --silent
+
           git add -A
-          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
-          git push -u origin "$branch"
+          printf '[]' > /tmp/additions.json
+          printf '[]' > /tmp/deletions.json
+          while IFS=$'\t' read -r status path; do
+            [ -z "$status" ] && continue
+            if [ "$status" = "D" ]; then
+              jq --arg p "$path" '. + [{path: $p}]' /tmp/deletions.json \
+                > /tmp/d.json && mv /tmp/d.json /tmp/deletions.json
+            else
+              jq --arg p "$path" --arg c "$(base64 -w0 "$path")" \
+                '. + [{path: $p, contents: $c}]' /tmp/additions.json \
+                > /tmp/a.json && mv /tmp/a.json /tmp/additions.json
+            fi
+          done < <(git -c core.quotePath=false -c diff.renames=false \
+            diff --cached --name-status)
+
+          jq -n \
+            --slurpfile adds /tmp/additions.json \
+            --slurpfile dels /tmp/deletions.json \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$branch" \
+            --arg head "$head" \
+            --arg headline "chore: update agentic template $OLD_REF -> $NEW_REF" \
+            '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                expectedHeadOid: $head,
+                message: {headline: $headline},
+                fileChanges: {additions: $adds[0], deletions: $dels[0]}}}}' \
+            > /tmp/graphql.json
+          gh api graphql --input /tmp/graphql.json \
+            --jq '.data.createCommitOnBranch.commit.oid'
 
           # Changelog excerpt from the template's GitHub Release for the new
           # tag. Best-effort: a missing release only degrades the PR body.

--- a/session-memory/.github/workflows/close-loop.yml
+++ b/session-memory/.github/workflows/close-loop.yml
@@ -126,63 +126,97 @@ jobs:
               >> /tmp/plan.jsonl
           done < /tmp/live.jsonl
 
-      - name: Append the terminal events
+      - name: Append the terminal events and commit them
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           ledger() { node /tmp/skills/original/thread-ledger/ledger.mjs --root . "$@"; }
 
-          : > /tmp/appended.txt
-          while read -r row; do
-            ticket=$(jq -r .ticket <<<"$row")
-            terminal=$(jq -r .terminal <<<"$row")
-            while read -r item; do
-              thread=$(jq -r .thread <<<"$item")
-              state=$(jq -r .state <<<"$item")
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub and show
+          # as Verified, so the store can require verified signatures
+          # without exempting this bot. expectedHeadOid makes the write
+          # compare-and-swap: if main moves mid-run (a session pushed,
+          # the render bot committed), the mutation fails cleanly, the
+          # clone re-syncs, and the sweep re-applies against the fresh
+          # fold — the dispatch-as-wake-up design makes that re-apply
+          # safe, and nobody's history is ever rebased away.
+          for attempt in 1 2 3; do
+            : > /tmp/appended.txt
+            # Re-read the fold on every attempt: after a re-sync another
+            # writer may already have closed some of these threads.
+            ledger state > /tmp/state.json
+            while read -r row; do
+              ticket=$(jq -r .ticket <<<"$row")
+              terminal=$(jq -r .terminal <<<"$row")
+              while read -r item; do
+                thread=$(jq -r .thread <<<"$item")
+                state=$(jq -r --arg t "$thread" \
+                  '.[] | select(.thread == $t) | .state' /tmp/state.json)
 
-              # `completed` is illegal from `blocked` and from `parked`,
-              # and rightly so: a blocker that was never cleared is a
-              # blocker nobody looked at again. The board says the work
-              # shipped, so the blocker no longer holds — which is what
-              # `unblocked` records. Written as the legal two-step
-              # rather than carved out of the state machine, because a
-              # carve-out weakens the rule for every writer to serve
-              # this one.
-              if [ "$state" = "blocked" ] || [ "$state" = "parked" ]; then
-                ledger append --ev unblocked --thread "$thread" --by bot --no-push \
-                  --note "${ticket} is closed, so whatever this was waiting on no longer holds."
-              fi
+                case "$state" in
+                  "" | completed | dropped) continue ;;
+                esac
 
-              ledger append --ev "$terminal" --thread "$thread" --by bot --no-push \
-                --note "${ticket} closed; recorded by the close-loop workflow, not by a session."
+                # `completed` is illegal from `blocked` and from `parked`,
+                # and rightly so: a blocker that was never cleared is a
+                # blocker nobody looked at again. The board says the work
+                # shipped, so the blocker no longer holds — which is what
+                # `unblocked` records. Written as the legal two-step
+                # rather than carved out of the state machine, because a
+                # carve-out weakens the rule for every writer to serve
+                # this one.
+                if [ "$state" = "blocked" ] || [ "$state" = "parked" ]; then
+                  ledger append --ev unblocked --thread "$thread" --by bot --no-push \
+                    --note "${ticket} is closed, so whatever this was waiting on no longer holds."
+                fi
 
-              echo "- \`${thread}\` -> ${terminal} (${ticket})" >> /tmp/appended.txt
-            done < <(jq -c '.threads[]' <<<"$row")
-          done < /tmp/plan.jsonl
+                ledger append --ev "$terminal" --thread "$thread" --by bot --no-push \
+                  --note "${ticket} closed; recorded by the close-loop workflow, not by a session."
 
-      - name: Push what changed
-        run: |
-          set -euo pipefail
-          git add ledger/
-          # Nothing staged is the ordinary outcome, not a failure: most
-          # runs find every live thread's ticket still open.
-          if git diff --cached --quiet; then
-            echo "No thread changed state."
-            exit 0
-          fi
-          git config user.name "thread-ledger"
-          git config user.email "noreply@anthropic.com"
-          git commit -m "ledger(bot): close threads whose tickets closed" \
-            -m "$(cat /tmp/appended.txt)"
+                echo "- \`${thread}\` -> ${terminal} (${ticket})" >> /tmp/appended.txt
+              done < <(jq -c '.threads[]' <<<"$row")
+            done < /tmp/plan.jsonl
 
-          # Sessions push to this store continuously, and the render job
-          # commits behind us. Rebase and retry rather than force: the
-          # log is append-only and losing someone else's line to win a
-          # race is the one outcome worth failing over.
-          for _ in 1 2 3; do
-            if git push; then exit 0; fi
-            git pull --rebase
+            git add ledger/
+            # Nothing staged is the ordinary outcome, not a failure: most
+            # runs find every live thread's ticket still open.
+            if git diff --cached --quiet; then
+              echo "No thread changed state."
+              exit 0
+            fi
+
+            head="$(git rev-parse HEAD)"
+            printf '[]' > /tmp/additions.json
+            while IFS=$'\t' read -r status path; do
+              [ -z "$status" ] && continue
+              jq --arg p "$path" --arg c "$(base64 -w0 "$path")" \
+                '. + [{path: $p, contents: $c}]' /tmp/additions.json \
+                > /tmp/a.json && mv /tmp/a.json /tmp/additions.json
+            done < <(git -c core.quotePath=false diff --cached --name-status)
+
+            jq -n \
+              --slurpfile adds /tmp/additions.json \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg head "$head" \
+              --rawfile body /tmp/appended.txt \
+              '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+                variables: {input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: "main"},
+                  expectedHeadOid: $head,
+                  message: {headline: "ledger(bot): close threads whose tickets closed", body: $body},
+                  fileChanges: {additions: $adds[0]}}}}' \
+              > /tmp/graphql.json
+            if gh api graphql --input /tmp/graphql.json --silent; then
+              exit 0
+            fi
+            echo "main moved under the sweep (attempt $attempt) — re-syncing."
+            git fetch origin main
+            git reset --hard origin/main
           done
-          git push
+          echo "::error::could not commit the sweep after 3 attempts"
+          exit 1
 
       - name: Say what happened
         if: always()

--- a/session-memory/.github/workflows/render-ledger.yml
+++ b/session-memory/.github/workflows/render-ledger.yml
@@ -50,14 +50,44 @@ jobs:
             --title "${{ github.repository_owner }} — thread ledger"
 
       - name: Commit when it changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- LEDGER.md; then
-            echo "LEDGER.md already current — nothing to commit."
-            exit 0
-          fi
-          git config user.name "thread-ledger"
-          git config user.email "noreply@anthropic.com"
-          git add LEDGER.md
-          git commit -m "chore: render LEDGER.md"
-          git push
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub and show
+          # as Verified, so the store can require verified signatures
+          # without exempting this bot. expectedHeadOid makes the write
+          # compare-and-swap: if main moved (a session pushed, the
+          # close-loop committed), the mutation fails cleanly and the
+          # run re-syncs and re-renders — nobody's history is rebased.
+          for attempt in 1 2 3; do
+            if git diff --quiet -- LEDGER.md; then
+              echo "LEDGER.md already current — nothing to commit."
+              exit 0
+            fi
+            head="$(git rev-parse HEAD)"
+            jq -n \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg head "$head" \
+              --arg c "$(base64 -w0 LEDGER.md)" \
+              '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+                variables: {input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: "main"},
+                  expectedHeadOid: $head,
+                  message: {headline: "chore: render LEDGER.md"},
+                  fileChanges: {additions: [{path: "LEDGER.md", contents: $c}]}}}}' \
+              > /tmp/graphql.json
+            if gh api graphql --input /tmp/graphql.json --silent; then
+              exit 0
+            fi
+            echo "main moved under the render (attempt $attempt) — re-syncing."
+            git fetch origin main
+            git reset --hard origin/main
+            node /tmp/skills/original/thread-ledger/ledger.mjs \
+              --root . \
+              render --format md --out LEDGER.md \
+              --title "${{ github.repository_owner }} — thread ledger"
+          done
+          echo "::error::could not commit LEDGER.md after 3 attempts"
+          exit 1

--- a/session-memory/.github/workflows/template-update.yml
+++ b/session-memory/.github/workflows/template-update.yml
@@ -140,16 +140,50 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/template-update-$NEW_REF"
+          head="$(git rev-parse HEAD)"
 
-          git config user.name "release-bot[bot]"
-          git config user.email "release-bot[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          # Conflicts are committed as copier's inline markers on purpose:
-          # the PR opens either way and red CI flags them for resolution on
-          # the branch, so updates never silently stall.
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub on behalf
+          # of the app and show as Verified, so repos can require
+          # verified signatures without exempting this bot. Conflicts
+          # are still committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution
+          # on the branch, so updates never silently stall.
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$branch" -f sha="$head" --silent
+
           git add -A
-          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
-          git push -u origin "$branch"
+          printf '[]' > /tmp/additions.json
+          printf '[]' > /tmp/deletions.json
+          while IFS=$'\t' read -r status path; do
+            [ -z "$status" ] && continue
+            if [ "$status" = "D" ]; then
+              jq --arg p "$path" '. + [{path: $p}]' /tmp/deletions.json \
+                > /tmp/d.json && mv /tmp/d.json /tmp/deletions.json
+            else
+              jq --arg p "$path" --arg c "$(base64 -w0 "$path")" \
+                '. + [{path: $p, contents: $c}]' /tmp/additions.json \
+                > /tmp/a.json && mv /tmp/a.json /tmp/additions.json
+            fi
+          done < <(git -c core.quotePath=false -c diff.renames=false \
+            diff --cached --name-status)
+
+          jq -n \
+            --slurpfile adds /tmp/additions.json \
+            --slurpfile dels /tmp/deletions.json \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$branch" \
+            --arg head "$head" \
+            --arg headline "chore: update agentic template $OLD_REF -> $NEW_REF" \
+            '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                expectedHeadOid: $head,
+                message: {headline: $headline},
+                fileChanges: {additions: $adds[0], deletions: $dels[0]}}}}' \
+            > /tmp/graphql.json
+          gh api graphql --input /tmp/graphql.json \
+            --jq '.data.createCommitOnBranch.commit.oid'
 
           # Changelog excerpt from the template's GitHub Release for the new
           # tag. Best-effort: a missing release only degrades the PR body.

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
@@ -140,16 +140,50 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/template-update-$NEW_REF"
+          head="$(git rev-parse HEAD)"
 
-          git config user.name "release-bot[bot]"
-          git config user.email "release-bot[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          # Conflicts are committed as copier's inline markers on purpose:
-          # the PR opens either way and red CI flags them for resolution on
-          # the branch, so updates never silently stall.
+          # The commit is created through the API, not the git CLI:
+          # createCommitOnBranch commits are signed by GitHub on behalf
+          # of the app and show as Verified, so repos can require
+          # verified signatures without exempting this bot. Conflicts
+          # are still committed as copier's inline markers on purpose:
+          # the PR opens either way and red CI flags them for resolution
+          # on the branch, so updates never silently stall.
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$branch" -f sha="$head" --silent
+
           git add -A
-          git commit -m "chore: update agentic template $OLD_REF -> $NEW_REF"
-          git push -u origin "$branch"
+          printf '[]' > /tmp/additions.json
+          printf '[]' > /tmp/deletions.json
+          while IFS=$'\t' read -r status path; do
+            [ -z "$status" ] && continue
+            if [ "$status" = "D" ]; then
+              jq --arg p "$path" '. + [{path: $p}]' /tmp/deletions.json \
+                > /tmp/d.json && mv /tmp/d.json /tmp/deletions.json
+            else
+              jq --arg p "$path" --arg c "$(base64 -w0 "$path")" \
+                '. + [{path: $p, contents: $c}]' /tmp/additions.json \
+                > /tmp/a.json && mv /tmp/a.json /tmp/additions.json
+            fi
+          done < <(git -c core.quotePath=false -c diff.renames=false \
+            diff --cached --name-status)
+
+          jq -n \
+            --slurpfile adds /tmp/additions.json \
+            --slurpfile dels /tmp/deletions.json \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$branch" \
+            --arg head "$head" \
+            --arg headline "chore: update agentic template $OLD_REF -> $NEW_REF" \
+            '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                expectedHeadOid: $head,
+                message: {headline: $headline},
+                fileChanges: {additions: $adds[0], deletions: $dels[0]}}}}' \
+            > /tmp/graphql.json
+          gh api graphql --input /tmp/graphql.json \
+            --jq '.data.createCommitOnBranch.commit.oid'
 
           # Changelog excerpt from the template's GitHub Release for the new
           # tag. Best-effort: a missing release only degrades the PR body.


### PR DESCRIPTION
Closes #135. Enables requiring verified signatures org-wide without exempting any bot.

The three bot writers built commits with the git CLI, which produces unsigned commits — so disambiguate's signatures rule made #61 unmergeable, and the rule on the store would reject the renderer and close-loop outright. All three now create their commits through GraphQL `createCommitOnBranch`, which GitHub signs on behalf of the authenticated app (the release-bot for updates, `github-actions` for the store bots) — **Verified**, with no key material in any runner.

## What changed where

- **`template-update.yml`** (consumer template + all three store subtemplates, byte-pinned): the branch is created via the refs API at the current head, the copier diff is enumerated from the index (`git diff --cached --name-status`, renames folded to add+delete), and the commit lands via the mutation. Conflict markers still get committed deliberately — the PR still opens either way and red CI still flags them.
- **`render-ledger.yml`**: the LEDGER.md commit is now compare-and-swap — `expectedHeadOid` pinned to the checkout's head; if main moved (a session pushed, the close-loop committed), the mutation fails cleanly and the run re-syncs and re-renders. Replaces `git push` racing.
- **`close-loop.yml`**: append + commit merged into one CAS loop. On a failed swap the clone resets to the fresh main and the sweep **re-applies against the re-read fold** — a thread another writer closed during the race is skipped, not double-closed (the dispatch-as-wake-up design is what makes the re-apply safe). This *replaces* the old pull-rebase-retry, which could interleave histories; the mutation can never rebase another writer's commits away.

## Notes for review

- The store bots keep using `github.token` — `createCommitOnBranch` signs those as `github-actions[bot]`, equally Verified; only the update workflow authenticates as the release-bot (it needs cross-repo PR rights anyway).
- Payload sizes are small (text files, base64-inlined). The updater handles deletions; the store bots only ever add/modify.
- Suite green (215 passed, 4 skipped); the byte-pin test holds the four `template-update.yml` copies identical.
- Live proof comes free after release: the v3.12.0 fan-out's own bot PRs will be the first Verified ones.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_