### PR TITLE
docs(template): rebase around a commit you did not write, never force

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,17 @@ Code-specific skills:
 - Create PR immediately on branch creation
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
+- **A push rejected over a commit you did not write is rebased around, never forced.**
+  Branch rules re-evaluate every commit an update spans, not just the new ones,
+  so moving a branch that was parked before a rule-violating commit reached `main`
+  is rejected for *that* commit — one already merged, that no push can fix.
+  The rejection names the SHA: if `git log --format='%an %s' -1 <sha>` is not your work,
+  this is what happened.
+  Restart the branch from its own base instead of from `main`
+  (`git rebase --onto <old-base> origin/main <branch>`),
+  which keeps the span clear of the offending commit and leaves the diff unchanged.
+  Forcing the push or deleting the branch to escape the rule
+  is the step that turns a rejected push into lost work.
 
 ### Tracker Content Formatting
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -143,6 +143,17 @@ Code-specific skills:
 - Create PR immediately on branch creation
 - Commits: conventional commits
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
+- **A push rejected over a commit you did not write is rebased around, never forced.**
+  Branch rules re-evaluate every commit an update spans, not just the new ones,
+  so moving a branch that was parked before a rule-violating commit reached `main`
+  is rejected for *that* commit — one already merged, that no push can fix.
+  The rejection names the SHA: if `git log --format='%an %s' -1 <sha>` is not your work,
+  this is what happened.
+  Restart the branch from its own base instead of from `main`
+  (`git rebase --onto <old-base> origin/main <branch>`),
+  which keeps the span clear of the offending commit and leaves the diff unchanged.
+  Forcing the push or deleting the branch to escape the rule
+  is the step that turns a rejected push into lost work.
 
 ### Tracker Content Formatting
 


### PR DESCRIPTION
Encodes the ruling on pandoscope/meta#58: accept the sharp edge, document the recovery. Per «Failures Become Rules», the prevention belongs in the template so every generated repo inherits it rather than in the ticket nobody reads at the moment of failure.

## What

One rule in the template's `## Git` section: when a push is rejected over a commit you did not write, restart the branch from its own base (`git rebase --onto «old-base» origin/main «branch»`) instead of from `main`. Forcing or deleting the branch to escape the rule is named as the step that loses work.

Two commits per the Template-First route in `docs/conventions.md`: the template-only edit, then `chore: reapply template to self` carrying the render's `AGENTS.md` verbatim. `tests/test_self_application.py` passes, 219 tests green.

## Why this exact failure

Measured on pandoscope/skills#82. Branch rules re-evaluate every commit a ref update spans, not only the new ones — so fast-forwarding a branch that was parked before an unsigned commit reached `main` is rejected naming *that* commit, which is already merged and unfixable by any push. The tempting recoveries are both destructive.

The audit the meta ticket asked for, run across the four public repos: **skills** carries two (`fa1a327`, `c06fb76`), **disambiguate** two (`bbd9f44`, `e8c9631`), **ghx** one (`aee235b`) — every bot template-update through v3.12.0, since the API-commit mechanism that makes bot commits arrive Verified shipped *in* that release. This repo carries none. So the edge is real in three of four repos and cannot grow: v3.13.0 onward commits through the API.

## Obstacle

`docs:` does not trigger semantic-release under the default commit-analyzer rules, so merging this cuts no release and starts no fan-out. The rule reaches the eight repos with the next `feat:`/`fix:` release. That is the honest sequencing for a documentation change — flagged here rather than gamed with a release-triggering type.

No `DECISION:` markers in the diff; the ruling is recorded in decision-memory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_