### PR TITLE
feat(session-memory): the store judges every push with ledger guard

### DIFF
--- a/session-memory/.github/workflows/ledger-guard.yml
+++ b/session-memory/.github/workflows/ledger-guard.yml
@@ -1,0 +1,62 @@
+name: Ledger guard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "ledger/**"
+      - "diligence/**"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: "append-only + fold"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # The guard judges a RANGE, so the pushed-from commit has to
+          # exist locally; a depth-1 checkout only has the tip.
+          fetch-depth: 0
+
+      - name: Fetch the guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The tool lives with the skill, not with the data — one
+          # source, and this store never carries a second copy to
+          # drift from it. `<owner>/skills` is the convention for
+          # where the thread-ledger skill lives.
+          git clone --depth 1 --filter=blob:none --sparse \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository_owner }}/skills.git" \
+            /tmp/skills
+          git -C /tmp/skills sparse-checkout set original/thread-ledger
+
+      - name: Judge the push
+        run: |
+          set -euo pipefail
+          # Two rules, both from measured incidents: no push removes a
+          # line from ledger/ or diligence/ (the log is append-only,
+          # skills#79), and no event added by the push may be illegal
+          # from the history that precedes it — the union of concurrent
+          # writers merges cleanly in git, and this is where that union
+          # is finally judged (skills#78). A red run here means the
+          # store's history needs a human: the repair is re-appending,
+          # never rewriting.
+          before="${{ github.event.before }}"
+          after="${{ github.event.after }}"
+          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            # A new branch has no before; judge the tip commit alone,
+            # unless it is the very first commit and there is nothing
+            # to diff against.
+            if ! git rev-parse -q --verify "${after}^" >/dev/null; then
+              echo "first commit — nothing to judge against."
+              exit 0
+            fi
+            before="${after}^"
+          fi
+          node /tmp/skills/original/thread-ledger/ledger.mjs \
+            --root . guard --range "${before}..${after}"

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -25,6 +25,7 @@ STORE_FILES = frozenset(
     {
         ".copier-answers.agentic.yml",
         ".github/workflows/close-loop.yml",
+        ".github/workflows/ledger-guard.yml",
         ".github/workflows/render-ledger.yml",
         ".github/workflows/template-update.yml",
         ".github/workflows/ticket-closed.yml",


### PR DESCRIPTION
The store half of pandoscope/skills#90 — the CI layer of pandoscope/skills#79 and pandoscope/skills#78.

## What

One thin workflow in the session-memory subtemplate, on push to `main` over `ledger/` and `diligence/`: sparse-checkout the thread-ledger skill (same pattern as `render-ledger.yml` — the tool lives with the skill, the store never carries a copy to drift from it) and run `ledger guard` over the pushed range.

The guard's two rules, both from measured incidents:

- **No removed lines** in `ledger/*.jsonl` or `diligence/*.jsonl`. skills#79: two routine git commands (`git stash pop`, `git checkout --theirs .`) deleted a published event and nothing anywhere objected.
- **No added event that is illegal from the history preceding it.** skills#78: concurrent writers' files merge cleanly in git, so the union can land a transition nobody validated — a bot's `completed` overridden by a stale session's `progress` 86 seconds later.

A red run means the store's history needs a human, and the workflow says so: the repair is re-appending, never rewriting. Historic pre-guard interleaves stay quiet — only the pushed range is judged, which is what lets the guard turn on without the history rewrite its own deletion rule forbids.

The new-branch edge (`before` all zeros) judges the tip commit alone, and the true first commit of a store is skipped with a note rather than failed.

`STORE_FILES` in the subtemplate render test gains the file; 219 tests green.

## Merge order

**pandoscope/skills#90 first** — the workflow checks out `«owner»/skills@main`, so the `guard` subcommand must exist there before any store runs this. Then this PR; the fan-out delivers it to the stores with the next release (`feat:` here, so merging this cuts one).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_