### PR TITLE
fix(scripts): ensure-prek installs into every clone of a multi-repo session

### DIFF
--- a/scripts/ensure-prek.sh
+++ b/scripts/ensure-prek.sh
@@ -4,7 +4,12 @@
 # Copier runs `prek install` at generation time, but git hooks do not
 # survive `git clone` — a fresh checkout (every remote agent session)
 # has no pre-commit hook and nothing blocking lint-dirty commits.
-# Best-effort and quiet: a broken bootstrap must never block a session.
+# Best-effort and quiet when it installs somewhere: a broken bootstrap
+# must never block a session. Installing NOWHERE warns, because that
+# silent branch was the measured defect (#139): in a multi-repo session
+# the project dir is the parent holding every clone and is itself no
+# repository, so the old single-repo guard was false and the script
+# exited 0 having installed nothing — in any clone, saying nothing.
 set -u
 
 if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
@@ -12,11 +17,31 @@ if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
     hash -r 2>/dev/null || true
 fi
 
-if command -v prek >/dev/null 2>&1; then
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        prek install --install-hooks >/dev/null 2>&1 \
-            || echo "ensure-prek: 'prek install' failed — lint-dirty commits are NOT blocked; run scripts/doctor.sh" >&2
-    fi
-else
+if ! command -v prek >/dev/null 2>&1; then
     echo "ensure-prek: prek unavailable (and uv missing to install it) — lint-dirty commits are NOT blocked; run scripts/doctor.sh --install" >&2
+    exit 0
+fi
+
+install_into() {
+    # $1: a work tree. Failure warns and never blocks the session.
+    (cd "$1" && prek install --install-hooks >/dev/null 2>&1) \
+        || echo "ensure-prek: 'prek install' failed in $1 — lint-dirty commits are NOT blocked there; run scripts/doctor.sh" >&2
+}
+
+installed=0
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Single-repo session: the project dir is the clone, as before.
+    install_into "$PWD"
+    installed=1
+else
+    # Multi-repo session: install into every clone the session holds.
+    for dir in */; do
+        [ -e "$dir/.git" ] || continue
+        install_into "$PWD/${dir%/}"
+        installed=$((installed + 1))
+    done
+fi
+
+if [ "$installed" -eq 0 ]; then
+    echo "ensure-prek: no repository found at or under $PWD — no pre-commit hook installed anywhere; lint-dirty commits are NOT blocked" >&2
 fi

--- a/template/scripts/{% if agentic_precommit == 'prek' %}ensure-prek.sh{% endif %}
+++ b/template/scripts/{% if agentic_precommit == 'prek' %}ensure-prek.sh{% endif %}
@@ -4,7 +4,12 @@
 # Copier runs `prek install` at generation time, but git hooks do not
 # survive `git clone` — a fresh checkout (every remote agent session)
 # has no pre-commit hook and nothing blocking lint-dirty commits.
-# Best-effort and quiet: a broken bootstrap must never block a session.
+# Best-effort and quiet when it installs somewhere: a broken bootstrap
+# must never block a session. Installing NOWHERE warns, because that
+# silent branch was the measured defect (#139): in a multi-repo session
+# the project dir is the parent holding every clone and is itself no
+# repository, so the old single-repo guard was false and the script
+# exited 0 having installed nothing — in any clone, saying nothing.
 set -u
 
 if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
@@ -12,11 +17,31 @@ if ! command -v prek >/dev/null 2>&1 && command -v uv >/dev/null 2>&1; then
     hash -r 2>/dev/null || true
 fi
 
-if command -v prek >/dev/null 2>&1; then
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        prek install --install-hooks >/dev/null 2>&1 \
-            || echo "ensure-prek: 'prek install' failed — lint-dirty commits are NOT blocked; run scripts/doctor.sh" >&2
-    fi
-else
+if ! command -v prek >/dev/null 2>&1; then
     echo "ensure-prek: prek unavailable (and uv missing to install it) — lint-dirty commits are NOT blocked; run scripts/doctor.sh --install" >&2
+    exit 0
+fi
+
+install_into() {
+    # $1: a work tree. Failure warns and never blocks the session.
+    (cd "$1" && prek install --install-hooks >/dev/null 2>&1) \
+        || echo "ensure-prek: 'prek install' failed in $1 — lint-dirty commits are NOT blocked there; run scripts/doctor.sh" >&2
+}
+
+installed=0
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Single-repo session: the project dir is the clone, as before.
+    install_into "$PWD"
+    installed=1
+else
+    # Multi-repo session: install into every clone the session holds.
+    for dir in */; do
+        [ -e "$dir/.git" ] || continue
+        install_into "$PWD/${dir%/}"
+        installed=$((installed + 1))
+    done
+fi
+
+if [ "$installed" -eq 0 ]; then
+    echo "ensure-prek: no repository found at or under $PWD — no pre-commit hook installed anywhere; lint-dirty commits are NOT blocked" >&2
 fi

--- a/tests/test_ensure_prek.py
+++ b/tests/test_ensure_prek.py
@@ -1,0 +1,108 @@
+"""Behavior tests for scripts/ensure-prek.sh (#139).
+
+The script is a SessionStart bootstrap. Its one measured failure mode
+was the layout every remote agent session actually uses: a multi-repo
+session whose project dir is the parent of the clones and is itself no
+repository — the old guard was false there, and the script exited 0
+having installed nothing, silently.
+
+`prek` is stubbed with a script that records the directory it ran in,
+so the assertions are about where installs happened, not about prek.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SCRIPT = PROJECT_ROOT / "scripts" / "ensure-prek.sh"
+
+
+def _stub_prek(tmp_path: Path) -> tuple[Path, Path]:
+    """A fake prek on PATH that logs its cwd per invocation."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "prek-calls.log"
+    stub = bindir / "prek"
+    stub.write_text(f'#!/bin/sh\npwd >> "{log}"\nexit 0\n')
+    stub.chmod(0o755)
+    return bindir, log
+
+
+def _run(cwd: Path, bindir: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "HOME": str(cwd),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+
+
+def test_multi_repo_layout_installs_into_every_clone(tmp_path: Path) -> None:
+    bindir, log = _stub_prek(tmp_path)
+    parent = tmp_path / "session"
+    for name in ("alpha", "beta"):
+        _git_repo(parent / name)
+    (parent / "not-a-repo").mkdir()
+
+    result = _run(parent, bindir)
+
+    assert result.returncode == 0
+    ran_in = sorted(
+        Path(line).name for line in log.read_text().splitlines() if line.strip()
+    )
+    assert ran_in == ["alpha", "beta"]
+    assert "NOT blocked" not in result.stderr
+
+
+def test_single_repo_layout_behaves_as_before(tmp_path: Path) -> None:
+    bindir, log = _stub_prek(tmp_path)
+    repo = tmp_path / "solo"
+    _git_repo(repo)
+
+    result = _run(repo, bindir)
+
+    assert result.returncode == 0
+    ran_in = [Path(line).name for line in log.read_text().splitlines() if line.strip()]
+    assert ran_in == ["solo"]
+
+
+def test_installing_nowhere_warns_and_names_the_directory(tmp_path: Path) -> None:
+    """The silent branch was the defect: exiting 0 having installed
+    nothing, in the exact layout the script's own header names."""
+    bindir, log = _stub_prek(tmp_path)
+    parent = tmp_path / "empty-session"
+    parent.mkdir()
+
+    result = _run(parent, bindir)
+
+    assert result.returncode == 0, "a broken bootstrap must never block a session"
+    assert not log.exists() or not log.read_text().strip()
+    assert "no repository found" in result.stderr
+    assert str(parent) in result.stderr
+    assert "NOT blocked" in result.stderr
+
+
+def test_template_copy_matches_the_rendered_one() -> None:
+    """Template-first: the self copy is stamped from template/, and a
+    drift between them means one of the two audiences runs old code."""
+    template = (
+        PROJECT_ROOT
+        / "template"
+        / "scripts"
+        / "{% if agentic_precommit == 'prek' %}ensure-prek.sh{% endif %}"
+    )
+    assert template.read_bytes() == SCRIPT.read_bytes()


### PR DESCRIPTION
Closes #139.

## What

- **Multi-repo layout** (the shape every remote agent session here uses): when the project dir is not itself a work tree, `ensure-prek.sh` now iterates its immediate-subdirectory work trees and installs the hook in each.
- **Single-repo layout** behaves exactly as before.
- **Installing nowhere warns** on stderr, naming the directory it searched — the silent branch was the defect, not the fallback, and the script still exits 0 (a broken bootstrap must never block a session).
- **`doctor.sh`** reports a missing `pre-commit` hook per clone in the multi-root layout, judged only for clones carrying a `.pre-commit-config.yaml` (the hook is inert without one). Template and self copies updated together.

## Root-cause caveat, and the discriminator this ships

The ticket's mechanism (guard false at the non-repo parent) is verified, but my audit note stands: it is not yet proven that SessionStart hooks *fire at all* in multi-root sessions (the shim was equally absent while `bats` existed). The warn-on-nowhere is the discriminator: after this lands, the next session either shows installs, or names where it looked, or — if the hook never ran — stays silent with hooks still missing, which now distinguishes the two hypotheses instead of conflating them.

## Tests

New `tests/test_ensure_prek.py` with a stubbed `prek` that records where it ran:
- multi-repo layout installs into every clone (and skips the non-repo directory)
- single-repo layout unchanged
- installing nowhere warns, names the directory, exits 0
- template copy and rendered self copy are byte-identical (template-first pin)

The first and third fail against the old script. Full suite (minus e2e) 214 pass locally; prek clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_