### PR TITLE
feat(dev): the self-application route is enforced, not conventional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,30 @@ jobs:
       - run: prek run --all-files --show-diff-on-failure
         shell: bash
 
+  template-route:
+    # The route guard where it actually bites. prek hooks run only in
+    # clones that installed them, and a fresh container or a CI-only
+    # contributor has not — the two violations that motivated #130 were
+    # both caught by human review, not by a hook. Every commit the PR
+    # adds is judged on its own diff, so the boundary information is
+    # still there when this runs.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: "Template-first route (per commit)"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+      - name: No commit edits a template source and its own stamp
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/dev/self_application.py --range "$BASE_SHA..$HEAD_SHA"
+        shell: bash
+
   conflict-detection:
     # Enforcement arm of the file-ownership policy: copier update merges and
     # writes .rej files but still exits 0. Generate a fixture, run the update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,20 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit.ci): pre-commit autoupdate"
 
 repos:
+  - repo: local
+    hooks:
+      # The self-application route, checked where the information still
+      # exists (#130). A root file with a `template/` counterpart is
+      # render output, so a commit edits the source or the stamp, never
+      # both. Reads the staged diff itself rather than the filenames
+      # prek passes, which is what keeps `--all-files` runs quiet: with
+      # nothing staged there is no commit to judge.
+      - id: self-application-route
+        name: "template-first route (source and stamp never in one commit)"
+        entry: python3 scripts/dev/self_application.py
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0
     hooks:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -37,10 +37,18 @@ For any change touching a templated file, always follow this route:
 This doubles as a proving ground: the self-applied root files are the rendered
 template output, reviewed in the same PR as the template change.
 
+The route is enforced, not merely conventional: a commit that edits a template
+source and the root file it stamps is rejected, by the `self-application-route`
+prek hook at commit time and by the `Template-first route (per commit)` CI job
+over every commit a PR adds. State cannot catch this — a hand-edit that happens
+to match the render leaves a valid tree — so provenance is checked where the
+information still exists, at the commit boundary.
+
 Exception: root files that intentionally diverge from the template are NOT
 overwritten by self-application. The authoritative list is
-`DELIBERATE_DIVERGENCE` in `tests/test_self_application.py`, which fails the
-build when the root and the render disagree anywhere else — so adding a
+`DELIBERATE_DIVERGENCE` in `scripts/dev/self_application.py`, read by both the
+state check (`tests/test_self_application.py`, which fails the build when the
+root and the render disagree anywhere else) and the route guard — so adding a
 template file forces a decision: adopt it at root, or list it with a reason.
 Paths in copier's `_skip_if_exists` are excluded structurally (they are seeded
 once and can never match) rather than listed as choices.

--- a/scripts/dev/self_application.py
+++ b/scripts/dev/self_application.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""The self-application route, enforced at the commit boundary (#130).
+
+This repo is the template AND uses itself as a template, so a root file
+with a `template/` counterpart is render OUTPUT. The route is: edit the
+source, commit it, render, then adopt the render as a separate restamp
+commit (docs/conventions.md - Template-First Changes).
+
+`tests/test_self_application.py` compares the root against the render,
+which is a statement about STATE. The route is about PROVENANCE, and no
+content comparison can check it: when a hand-edit happens to produce
+exactly what the render would have produced, the state is valid and
+there is nothing to detect. The commit is the only place where the
+information still exists, so that is where this looks. Under the
+documented route a commit touches sources or stamps, never both -- one
+touching both is a hand-edit or a mixed commit, and both are already
+forbidden.
+
+Repo-local by construction: the rule exists only where `template/`
+does, and a generated repo has no template directory to violate.
+
+With no arguments it judges the staged diff, which is the prek hook.
+With `--range BASE..HEAD` it judges every commit in that range, which
+is CI -- hooks only run in clones that installed them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+TEMPLATE = "template"
+CONVENTIONS = "docs/conventions.md - Template-First Changes"
+
+# Root paths that deliberately diverge from the render. Everything NOT
+# listed here must match, so adding a template file forces a decision:
+# adopt it at root, or list it with a reason.
+#
+# Lives here rather than in the test that reads it: the state test and
+# this route guard need the same list, and a commit hook must not have
+# to import a test module (and through it copier) to know it.
+DELIBERATE_DIVERGENCE = {
+    # Carries jinja lint hooks the generated config must not have.
+    ".pre-commit-config.yaml": "template-development hooks",
+    # Globs *.md.jinja so the template's own sources are linted.
+    ".markdownlint-cli2.yaml": "lints jinja sources",
+    # This repo has its own ci.yml/release.yml; the rendered workflows
+    # target generated repos, not the template itself.
+    ".github/workflows/lint.yml": "repo has its own CI",
+    ".github/workflows/template-update.yml": "template does not update itself",
+    # The template is not stamped from another template.
+    ".copier-answers.agentic.yml": "not a generated repo",
+    # Agent settings here are repo-local, not the generated defaults.
+    ".claude/settings.json": "repo-local agent settings",
+}
+
+# `{% if agentic_forge == 'github' %}.github{% endif %}` renders to the
+# literal between the tags for this repo's own answers.
+CONDITIONAL = re.compile(r"\{%.*?%\}")
+
+# One entry of copier's `_skip_if_exists` list, as written in copier.yml.
+SKIP_ENTRY = re.compile(r"^\s*-\s*[\"']?(.+?)[\"']?\s*$")
+
+
+def skip_if_exists(copier_yml: str) -> set[str]:
+    """Paths copier seeds once and never overwrites.
+
+    Read without a YAML parser on purpose: this runs inside a commit
+    hook, on whatever `python3` the contributor has, and a dependency
+    there would make the guard the reason a commit cannot be made. The
+    block is a flat list of strings, which is exactly as much YAML as
+    this needs to understand. `tests/test_self_application_route`
+    pins the result against a real parse.
+
+    Seeded files stop being render output the moment they exist, so the
+    route does not apply to them — the state check excludes them for
+    the same reason.
+    """
+    paths: set[str] = set()
+    collecting = False
+    for line in copier_yml.splitlines():
+        if line.startswith("_skip_if_exists:"):
+            collecting = True
+            continue
+        if collecting:
+            if line and not line[0].isspace():
+                break
+            if line.lstrip().startswith("#"):
+                continue
+            match = SKIP_ENTRY.match(line)
+            if not match:
+                continue
+            entry = match.group(1)
+            literal = CONDITIONAL.sub("", entry).strip()
+            if literal:
+                paths.add(literal)
+    return paths
+
+
+def stamp_of(path: str) -> str | None:
+    """The root file `path` stamps to, or None when there is no pair.
+
+    None covers three cases, all of them "this is not a source with a
+    knowable stamp": a path outside `template/`, a name interpolating an
+    answer (`{{ agentic_project_slug }}.md`) that only a render can
+    resolve, and a conditional segment that leaves nothing behind.
+    """
+    prefix = f"{TEMPLATE}/"
+    if not path.startswith(prefix):
+        return None
+    rest = path[len(prefix) :]
+    if "{{" in rest:
+        return None
+    rest = CONDITIONAL.sub("", rest)
+    if rest.endswith(".jinja"):
+        rest = rest[: -len(".jinja")]
+    parts = [part for part in rest.split("/") if part]
+    return "/".join(parts) or None
+
+
+def route_violations(
+    paths: list[str], exempt: set[str] | None = None
+) -> list[tuple[str, str]]:
+    """(source, stamp) pairs this set of paths carries, in path order.
+
+    Pure over plain data: the caller decides whether the paths came from
+    a staged diff or a commit, and the same rule judges both. `exempt`
+    defaults to the paths no route applies to — those that deliberately
+    diverge, and those copier seeds once.
+    """
+    if exempt is None:
+        exempt = exempt_paths()
+    touched = set(paths)
+    found = []
+    for path in sorted(touched):
+        stamp = stamp_of(path)
+        if stamp is None or stamp in exempt:
+            continue
+        if stamp in touched:
+            found.append((path, stamp))
+    return found
+
+
+def exempt_paths(root: str = ".") -> set[str]:
+    """Root paths the route does not govern, from both reasons at once."""
+    try:
+        with open(f"{root}/copier.yml", encoding="utf-8") as handle:
+            seeded = skip_if_exists(handle.read())
+    except OSError:
+        # Not the template repo (or not its root): nothing here stamps
+        # anything, and the guard has no business inventing pairs.
+        seeded = set()
+    return set(DELIBERATE_DIVERGENCE) | seeded
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def staged_paths() -> list[str]:
+    """Paths in the index — empty outside a commit, so `--all-files`
+    runs of the hook are a silent no-op rather than a false alarm."""
+    return [
+        line for line in git("diff", "--cached", "--name-only").splitlines() if line
+    ]
+
+
+def commits_in(rev_range: str) -> list[str]:
+    return [
+        line for line in git("rev-list", "--reverse", rev_range).splitlines() if line
+    ]
+
+
+def commit_paths(sha: str) -> list[str]:
+    """Paths one commit changed. A merge commit reports nothing here,
+    which is right: it introduces no edit of its own to attribute."""
+    changed = git(
+        "diff-tree", "--no-commit-id", "--name-only", "-r", "-m", "--first-parent", sha
+    )
+    return [line for line in changed.splitlines() if line]
+
+
+def report(where: str, violations: list[tuple[str, str]]) -> None:
+    print(f"{where} edits a template source and its own stamp:", file=sys.stderr)
+    for source, stamp in violations:
+        print(f"  {source}", file=sys.stderr)
+        print(f"  {stamp}   <- render output of the line above", file=sys.stderr)
+    print(
+        f"\nThe stamp is render output, never hand-edited ({CONVENTIONS}).\n"
+        "Split this: commit the template change alone, render the template "
+        "from that commit, and adopt the render as a separate restamp commit.",
+        file=sys.stderr,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--range",
+        dest="rev_range",
+        help="judge every commit in BASE..HEAD instead of the staged diff",
+    )
+    # prek passes filenames to hooks that ask for them; this one reads
+    # the diff itself, so anything else on the line is accepted and
+    # ignored rather than turned into a usage error mid-commit.
+    parser.add_argument("paths", nargs="*", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if not args.rev_range:
+        violations = route_violations(staged_paths())
+        if violations:
+            report("this commit", violations)
+            return 1
+        return 0
+
+    failed = False
+    for sha in commits_in(args.rev_range):
+        violations = route_violations(commit_paths(sha))
+        if violations:
+            report(f"commit {sha[:9]}", violations)
+            failed = True
+    if failed:
+        return 1
+    print(f"Every commit in {args.rev_range} kept sources and stamps apart.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_self_application.py
+++ b/tests/test_self_application.py
@@ -19,32 +19,25 @@ import re
 import copier
 import yaml
 
+from tests.conftest import load_module
+
 PROJECT_ROOT = Path(__file__).parent.parent
 
-# Root paths that deliberately diverge from the render. Everything NOT
-# listed here must match, so adding a template file forces a decision:
-# adopt it at root, or list it with a reason.
-DELIBERATE_DIVERGENCE = {
-    # Carries jinja lint hooks the generated config must not have.
-    ".pre-commit-config.yaml": "template-development hooks",
-    # Globs *.md.jinja so the template's own sources are linted.
-    ".markdownlint-cli2.yaml": "lints jinja sources",
-    # This repo has its own ci.yml/release.yml; the rendered workflows
-    # target generated repos, not the template itself.
-    ".github/workflows/lint.yml": "repo has its own CI",
-    ".github/workflows/template-update.yml": "template does not update itself",
-    # The template is not stamped from another template.
-    ".copier-answers.agentic.yml": "not a generated repo",
-    # Agent settings here are repo-local, not the generated defaults.
-    ".claude/settings.json": "repo-local agent settings",
-}
+# The divergence list is the route guard's, not a second copy: the state
+# check here and the provenance check there exempt the same paths, and
+# two lists would drift into disagreeing about what "diverges".
+DELIBERATE_DIVERGENCE = load_module(
+    "self_application", PROJECT_ROOT / "scripts" / "dev" / "self_application.py"
+).DELIBERATE_DIVERGENCE
 
 
 def _skip_if_exists_paths() -> set[str]:
     """Paths copier seeds once and never overwrites.
 
     These can never match after seeding, so they are excluded
-    structurally rather than listed as a choice.
+    structurally rather than listed as a choice. Parsed here with a real
+    YAML reader; `test_self_application_route` pins the route guard's
+    dependency-free reading of the same block against this one.
     """
     config = yaml.safe_load((PROJECT_ROOT / "copier.yml").read_text())
     paths: set[str] = set()

--- a/tests/test_self_application_route.py
+++ b/tests/test_self_application_route.py
@@ -1,0 +1,151 @@
+"""The provenance half of self-application (#130).
+
+`test_self_application` asks whether the root MATCHES the render;
+these ask how it got there. The distinction is the whole point of the
+guard: the commit that motivated the ticket produced a byte-identical
+tree to the correct two-commit route, so state could not tell them
+apart and only the diff could.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module
+
+PROJECT_ROOT = Path(__file__).parent.parent
+route = load_module(
+    "self_application", PROJECT_ROOT / "scripts" / "dev" / "self_application.py"
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "stamp"),
+    [
+        # A jinja source and its rendered root file.
+        ("template/AGENTS.md.jinja", "AGENTS.md"),
+        # Copied verbatim, no jinja suffix — the shape of the commit
+        # that prompted this guard.
+        ("template/scripts/ci/check_gate.py", "scripts/ci/check_gate.py"),
+        # A conditional path segment renders to the literal inside it.
+        (
+            "template/{% if agentic_forge == 'github' %}.github{% endif %}"
+            "/workflows/ci-ok.yml.jinja",
+            ".github/workflows/ci-ok.yml",
+        ),
+        # A conditional FILE name, jinja-suffixed.
+        (
+            "template/docs/{% if agentic_project_kind == 'code' %}architecture.md{% endif %}.jinja",
+            "docs/architecture.md",
+        ),
+    ],
+)
+def test_stamp_of_maps_a_source_to_its_render(source: str, stamp: str) -> None:
+    assert route.stamp_of(source) == stamp
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # Outside the template: a stamp is not a source.
+        "AGENTS.md",
+        "tests/test_self_application.py",
+        # Only a render can resolve an answer interpolated into a name,
+        # so this pair is not knowable here and is not guessed at.
+        "template/docs/glossary/{{ agentic_project_slug }}.md.jinja",
+    ],
+)
+def test_stamp_of_declines_what_it_cannot_know(path: str) -> None:
+    assert route.stamp_of(path) is None
+
+
+def test_editing_a_source_and_its_stamp_together_is_the_violation() -> None:
+    """The #129 shape: one commit hand-editing both halves."""
+    found = route.route_violations(["template/AGENTS.md.jinja", "AGENTS.md"])
+    assert found == [("template/AGENTS.md.jinja", "AGENTS.md")]
+
+
+def test_both_legs_of_the_documented_route_stay_quiet() -> None:
+    """The correct two-commit route, judged one commit at a time."""
+    template_leg = [
+        "template/AGENTS.md.jinja",
+        "template/scripts/ci/check_gate.py",
+        "copier.yml",
+        "tests/test_ci_gate.py",
+    ]
+    restamp_leg = ["AGENTS.md", "scripts/ci/check_gate.py"]
+    assert route.route_violations(template_leg) == []
+    assert route.route_violations(restamp_leg) == []
+
+
+def test_a_deliberate_divergence_may_be_edited_with_its_source() -> None:
+    """Listed paths are not render output, so no route applies to them."""
+    assert (
+        route.route_violations(
+            [
+                "template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja",
+                ".pre-commit-config.yaml",
+            ]
+        )
+        == []
+    )
+
+
+def test_every_violation_is_reported_not_just_the_first() -> None:
+    found = route.route_violations(
+        [
+            "template/AGENTS.md.jinja",
+            "AGENTS.md",
+            "template/scripts/ci/check_gate.py",
+            "scripts/ci/check_gate.py",
+        ]
+    )
+    assert found == [
+        ("template/AGENTS.md.jinja", "AGENTS.md"),
+        ("template/scripts/ci/check_gate.py", "scripts/ci/check_gate.py"),
+    ]
+
+
+def test_a_seeded_file_is_not_render_output() -> None:
+    """`_skip_if_exists` paths stop being output the moment they exist,
+    so this repo's own conventions doc may be edited beside the template
+    source that once seeded it.
+    """
+    assert (
+        route.route_violations(
+            ["template/docs/conventions.md.jinja", "docs/conventions.md"]
+        )
+        == []
+    )
+
+
+def test_the_seeded_list_reads_the_same_without_a_yaml_parser() -> None:
+    """The guard reads copier.yml with no dependency so a commit hook
+    never fails for want of one; this pins that reading against a real
+    parse of the same block.
+    """
+    state_test = load_module(
+        "test_self_application", PROJECT_ROOT / "tests" / "test_self_application.py"
+    )
+    parsed = route.skip_if_exists((PROJECT_ROOT / "copier.yml").read_text())
+    assert parsed == state_test._skip_if_exists_paths()
+    assert parsed, "the block is not empty, so an empty parse means a broken reader"
+
+
+def test_the_divergence_list_has_one_home() -> None:
+    """The state check reads this module's list rather than keeping its
+    own; a second copy would drift into a different idea of divergence.
+
+    Both halves are asserted, because either alone passes for the wrong
+    reason: equal contents today says nothing about a literal that can
+    drift tomorrow, and an absent literal says nothing about what the
+    state check ended up reading.
+    """
+    state_test = load_module(
+        "test_self_application", PROJECT_ROOT / "tests" / "test_self_application.py"
+    )
+    assert state_test.DELIBERATE_DIVERGENCE == route.DELIBERATE_DIVERGENCE
+    source = (PROJECT_ROOT / "tests" / "test_self_application.py").read_text()
+    assert "DELIBERATE_DIVERGENCE = {" not in source


### PR DESCRIPTION
## What

A root file with a `template/` counterpart is render output, so a commit edits the source or the stamp, never both. That rule was conventional; it is now checked.

CLOSES pandoscope/agentic-engineering-template#130

## Why state cannot catch it

`test_self_application` compares root against the render — a statement about **state**. The route is about **provenance**, and no content comparison can see it: a hand-edit that happens to produce exactly what the render would have leaves a valid tree. The ticket measured this (`b19d0cd` and the correct pair produce the same tree, both green). The commit is the only place the information still exists, so that is where this looks.

## How

`scripts/dev/self_application.py` — one pure rule (`stamp_of`, `route_violations`) with two entry points:

- **The `self-application-route` prek hook** at commit time. It reads the staged diff itself rather than the filenames prek passes, which is what keeps `prek run --all-files` quiet: with nothing staged there is no commit to judge.
- **A `Template-first route (per commit)` CI job** over every commit a PR adds. Hooks run only in clones that installed them — both violations that motivated this ticket were caught by human review, and a third slipped through on !146 in a container whose clone has no hook installed. This is the arm that actually bites.

Exempt by construction, because no route governs them: paths that deliberately diverge, and paths copier seeds once (`_skip_if_exists` — after seeding, the root file is this repo's own document; editing it beside its template origin is legitimate).

**One deviation from the acceptance wording**, flagged for your call: the criterion says `DELIBERATE_DIVERGENCE` should be "sourced from the test". Importing `tests/test_self_application.py` inside a commit hook would drag `copier` and `yaml` into every commit, so the direction is inverted instead — the list moves to `scripts/dev/self_application.py` and the test imports it from there. Single source preserved, which is the criterion's intent; `docs/conventions.md` now points at the new home. Same reasoning for `_skip_if_exists`: read without a YAML parser so a commit hook never fails for want of a dependency, and pinned in tests against a real parse of the same block.

## Proof

- 14 route tests: the #129 shape fires; both legs of the documented two-commit route stay quiet; a deliberate divergence and a seeded file are exempt; every violation is reported, not just the first; the divergence list has one home (equal contents **and** no second literal); the no-YAML read of `_skip_if_exists` equals the real parse.
- Exercised against real git history in a scratch repo: staged violation → exit 1 naming both paths, correct two-commit route → exit 0 on each leg and across both, `--range` including the violation → exit 1 naming the commit.
- `prek run --all-files` clean, `uv run pytest` green (254 + 9 e2e).
- The guard passes on its own commit — this change touches no `template/` source.

## Not in scope

Making CI *perform* the self-application, per the ticket. Also left alone: the store subtemplates' byte-pinned copies (`decision-memory/scripts/ci/check_gate.py` and friends) are a second stamp relationship, but same-named files there are not all copies — some are the subtemplate's own — so extending the rule to them needs a declared list first. Worth a follow-up ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_