### PR TITLE
fix(template): consumers do not lint what the template owns, and a changelog cannot close what it quotes

### DIFF
--- a/decision-memory/.github/workflows/template-update.yml
+++ b/decision-memory/.github/workflows/template-update.yml
@@ -254,6 +254,16 @@ jobs:
             --json body --jq .body \
             || echo "_No release notes found for $NEW_REF in $template_repo._")"
 
+          # The changelog is quoted material from another repo, and it
+          # must not act on this one (#149). Release notes render every
+          # reference as `closes owner/repo#n`, GitHub reads closing
+          # keywords in a PR BODY, and `owner/repo#n` reaches across
+          # repositories — so merging an update PR here closed an
+          # upstream ticket whose work was not done. The verb is
+          # defused and the link kept: `closes [x#1]` -> `ref [x#1]`.
+          changelog="$(printf '%s' "$changelog" | sed -E \
+            's/(close[sd]?|fix(e[sd])?|resolve[sd]?)([[:space:]]+\[?[A-Za-z0-9._\/-]*#[0-9]+)/ref\3/Ig')"
+
           {
             echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
             echo

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -28,17 +28,33 @@ API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 SERVER = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
 
 
+def api_url(path):
+    """The absolute URL for an API path, refusing any non-HTTP scheme.
+
+    `API` comes from the environment, so a hostile or fat-fingered
+    `GITHUB_API_URL` could otherwise steer the gate's own reads at
+    `file:` and have it judge a PR on whatever it found on disk. The
+    scheme is checked here, once, because this is the only place a URL
+    is built.
+    """
+    url = API + path
+    if not url.startswith(("https://", "http://")):
+        scheme = url.split(":", 1)[0] if ":" in url else url
+        raise ValueError(f"GITHUB_API_URL must be http(s) — refusing scheme {scheme!r}")
+    return url
+
+
 def fetch(path, token):
     """GET one API path, parsed. The only network call in this file."""
-    req = urllib.request.Request(
-        API + path,
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
 
 

--- a/evidence-memory/.github/workflows/template-update.yml
+++ b/evidence-memory/.github/workflows/template-update.yml
@@ -254,6 +254,16 @@ jobs:
             --json body --jq .body \
             || echo "_No release notes found for $NEW_REF in $template_repo._")"
 
+          # The changelog is quoted material from another repo, and it
+          # must not act on this one (#149). Release notes render every
+          # reference as `closes owner/repo#n`, GitHub reads closing
+          # keywords in a PR BODY, and `owner/repo#n` reaches across
+          # repositories — so merging an update PR here closed an
+          # upstream ticket whose work was not done. The verb is
+          # defused and the link kept: `closes [x#1]` -> `ref [x#1]`.
+          changelog="$(printf '%s' "$changelog" | sed -E \
+            's/(close[sd]?|fix(e[sd])?|resolve[sd]?)([[:space:]]+\[?[A-Za-z0-9._\/-]*#[0-9]+)/ref\3/Ig')"
+
           {
             echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
             echo

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -28,17 +28,33 @@ API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 SERVER = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
 
 
+def api_url(path):
+    """The absolute URL for an API path, refusing any non-HTTP scheme.
+
+    `API` comes from the environment, so a hostile or fat-fingered
+    `GITHUB_API_URL` could otherwise steer the gate's own reads at
+    `file:` and have it judge a PR on whatever it found on disk. The
+    scheme is checked here, once, because this is the only place a URL
+    is built.
+    """
+    url = API + path
+    if not url.startswith(("https://", "http://")):
+        scheme = url.split(":", 1)[0] if ":" in url else url
+        raise ValueError(f"GITHUB_API_URL must be http(s) — refusing scheme {scheme!r}")
+    return url
+
+
 def fetch(path, token):
     """GET one API path, parsed. The only network call in this file."""
-    req = urllib.request.Request(
-        API + path,
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
 
 

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -28,17 +28,33 @@ API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 SERVER = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
 
 
+def api_url(path):
+    """The absolute URL for an API path, refusing any non-HTTP scheme.
+
+    `API` comes from the environment, so a hostile or fat-fingered
+    `GITHUB_API_URL` could otherwise steer the gate's own reads at
+    `file:` and have it judge a PR on whatever it found on disk. The
+    scheme is checked here, once, because this is the only place a URL
+    is built.
+    """
+    url = API + path
+    if not url.startswith(("https://", "http://")):
+        scheme = url.split(":", 1)[0] if ":" in url else url
+        raise ValueError(f"GITHUB_API_URL must be http(s) — refusing scheme {scheme!r}")
+    return url
+
+
 def fetch(path, token):
     """GET one API path, parsed. The only network call in this file."""
-    req = urllib.request.Request(
-        API + path,
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
 
 

--- a/session-memory/.github/workflows/template-update.yml
+++ b/session-memory/.github/workflows/template-update.yml
@@ -254,6 +254,16 @@ jobs:
             --json body --jq .body \
             || echo "_No release notes found for $NEW_REF in $template_repo._")"
 
+          # The changelog is quoted material from another repo, and it
+          # must not act on this one (#149). Release notes render every
+          # reference as `closes owner/repo#n`, GitHub reads closing
+          # keywords in a PR BODY, and `owner/repo#n` reaches across
+          # repositories — so merging an update PR here closed an
+          # upstream ticket whose work was not done. The verb is
+          # defused and the link kept: `closes [x#1]` -> `ref [x#1]`.
+          changelog="$(printf '%s' "$changelog" | sed -E \
+            's/(close[sd]?|fix(e[sd])?|resolve[sd]?)([[:space:]]+\[?[A-Za-z0-9._\/-]*#[0-9]+)/ref\3/Ig')"
+
           {
             echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
             echo

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -28,17 +28,33 @@ API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 SERVER = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
 
 
+def api_url(path):
+    """The absolute URL for an API path, refusing any non-HTTP scheme.
+
+    `API` comes from the environment, so a hostile or fat-fingered
+    `GITHUB_API_URL` could otherwise steer the gate's own reads at
+    `file:` and have it judge a PR on whatever it found on disk. The
+    scheme is checked here, once, because this is the only place a URL
+    is built.
+    """
+    url = API + path
+    if not url.startswith(("https://", "http://")):
+        scheme = url.split(":", 1)[0] if ":" in url else url
+        raise ValueError(f"GITHUB_API_URL must be http(s) — refusing scheme {scheme!r}")
+    return url
+
+
 def fetch(path, token):
     """GET one API path, parsed. The only network call in this file."""
-    req = urllib.request.Request(
-        API + path,
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
 
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml
@@ -254,6 +254,16 @@ jobs:
             --json body --jq .body \
             || echo "_No release notes found for $NEW_REF in $template_repo._")"
 
+          # The changelog is quoted material from another repo, and it
+          # must not act on this one (#149). Release notes render every
+          # reference as `closes owner/repo#n`, GitHub reads closing
+          # keywords in a PR BODY, and `owner/repo#n` reaches across
+          # repositories — so merging an update PR here closed an
+          # upstream ticket whose work was not done. The verb is
+          # defused and the link kept: `closes [x#1]` -> `ref [x#1]`.
+          changelog="$(printf '%s' "$changelog" | sed -E \
+            's/(close[sd]?|fix(e[sd])?|resolve[sd]?)([[:space:]]+\[?[A-Za-z0-9._\/-]*#[0-9]+)/ref\3/Ig')"
+
           {
             echo "Automated \`copier update\` of the agentic template: \`$OLD_REF\` -> \`$NEW_REF\`."
             echo

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -1,5 +1,11 @@
 # See https://pre-commit.com for more information
-exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills|\\.claude/skills"
+#
+# Vendored paths are excluded: they are template output, byte-pinned
+# upstream, and a fix applied here would be overwritten by the next
+# update. `scripts/ci/` joins the skills directories for that reason —
+# a consumer with stricter lint rules than the template's own would
+# otherwise fail on code it cannot change.
+exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills|\\.claude/skills|scripts/ci/"
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit, commit-msg]
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -185,6 +186,51 @@ def test_claude_skills_symlink_bridges_agents_skills(
     # through the symlink.
     _check_file_contents(dst_path / ".markdownlint-cli2.yaml", [".claude/skills/**"])
     _check_file_contents(dst_path / ".pre-commit-config.yaml", ["\\.claude/skills"])
+
+
+def test_update_pr_body_cannot_close_an_upstream_ticket(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Release notes render references as `closes owner/repo#n`, GitHub
+    reads closing keywords in a PR body, and `owner/repo#n` crosses
+    repositories — so merging an update PR here closed a ticket in the
+    template repo (#149). The changelog is quoted material and must not
+    act on anything.
+
+    Behavioural, not textual: the defusing pipeline is lifted out of the
+    rendered workflow and run against a real release-notes excerpt.
+    """
+    dst_path = _render(tmp_path, base_answers, "changelog-defuse")
+    workflow = (dst_path / ".github" / "workflows" / "template-update.yml").read_text()
+
+    defuse = re.search(r'changelog="\$\(printf[\s\S]*?\)"', workflow)
+    assert defuse, "the update workflow no longer defuses the changelog"
+
+    excerpt = (
+        "* **ci:** the gate knows its workflow ([abc1234](u)), closes "
+        "[pandoscope/agentic-engineering-template#137]"
+        "(https://github.com/pandoscope/agentic-engineering-template/issues/137)\n"
+        "* prose that merely closes a chapter, and a fix that helps"
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"changelog={excerpt!r}\n{defuse.group(0)}\nprintf '%s' \"$changelog\"",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "closes [" not in result.stdout, (
+        "a closing keyword still precedes a reference"
+    )
+    assert "ref [pandoscope/agentic-engineering-template#137]" in result.stdout
+    # The link survives, and prose that never named an issue is untouched.
+    assert "/issues/137)" in result.stdout
+    assert "closes a chapter, and a fix that helps" in result.stdout
 
 
 def test_vendored_gate_script_is_excluded_from_consumer_lint(

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -187,6 +187,21 @@ def test_claude_skills_symlink_bridges_agents_skills(
     _check_file_contents(dst_path / ".pre-commit-config.yaml", ["\\.claude/skills"])
 
 
+def test_vendored_gate_script_is_excluded_from_consumer_lint(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """The gate script is template output, byte-pinned upstream, so a
+    consumer cannot fix a lint finding in it — the next update would
+    overwrite the fix. A consumer whose rules are stricter than the
+    template's own (bandit, full pycodestyle) hit exactly that (#137).
+    """
+    dst_path = _render(tmp_path, base_answers, "vendored-lint")
+
+    assert (dst_path / "scripts" / "ci" / "check_gate.py").exists()
+    _check_file_contents(dst_path / ".pre-commit-config.yaml", ["scripts/ci/"])
+
+
 def test_project_kind_code_renders_code_artifacts(
     tmp_path: Path,
     base_answers: dict[str, str],


### PR DESCRIPTION
## What

Two fan-out defects the v3.15.0 rollout surfaced, both in template-owned material reaching consumers.

ADVANCES pandoscope/agentic-engineering-template#137
FIXES pandoscope/agentic-engineering-template#149

## 1. A consumer must not lint what the template owns

Five of six consumers went green on v3.15.0. disambiguate stayed red, and not on the gate's logic: its ruff config selects flake8-bandit and full pycodestyle, so the **vendored** `scripts/ci/check_gate.py` failed `prek` there — on code the repo cannot fix, because the next update overwrites it.

`scripts/ci/` joins the prek exclude beside `.agents/skills` and `.claude/skills`: the template lints what it owns, a consumer does not lint what it cannot change.

The `S310` finding is kept on its merits — `API` comes from `GITHUB_API_URL`, so a hostile or fat-fingered value could steer the gate's own reads at `file:` and have it judge a PR on whatever it found on disk. `api_url()` now builds every URL in one place and refuses anything but http(s); the two `noqa`s name that guard rather than silencing the rule blindly.

## 2. A changelog cannot close the repo it is quoted into

**This one bit while the rollout was running.** Merging `skills!112` — a consumer's update PR — closed **this repo's** #137 at 18:24:48Z, one second before the merge. The update workflow embeds the template's release notes verbatim, semantic-release renders every reference as `closes owner/repo#n`, GitHub reads closing keywords in a PR *body*, and `owner/repo#n` crosses repositories. Six consumers merge that body per release, so any ticket named in a release's notes is closed by the first consumer merge that lands — silently, with the rollout unfinished.

The gate's ticket job exists partly to catch this (it rejects native lowercase keywords for exactly this reason), but an update PR is bot-authored and labeled `automated`, so the whole job takes the escape — deny-scan included. #149 records that the escape's scope may be too wide.

The changelog is quoted material from another repo and must not act on this one: the verb is defused, the link kept (`closes [x#137]` → `ref [x#137]`).

## Proof

- **Behavioural test**, not a text pin: the defusing pipeline is lifted out of the rendered workflow and run against a real release-notes excerpt — the keyword before a reference is gone, the link survives, and prose that merely "closes a chapter" is untouched.
- New test pins the vendored exclusion: the gate script renders **and** `scripts/ci/` is excluded — either half alone passes for the wrong reason.
- Verified against the original failure: `ruff --select S,B,C4,E,F,I,RUF,UP,W` no longer reports S310 on the template copy.
- 242 tests + `prek run --all-files` green; byte-identical copy tests confirm all copies moved together.

Shipped template-first throughout: each source commit changes only `template/` and tests, each followed by its own restamp — the two-commit route !147's guard now enforces.