### PR TITLE
feat(gate): a close that leaves open PRs behind is loud

### DIFF
--- a/.github/workflows/ci-ok.yml
+++ b/.github/workflows/ci-ok.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   actions: read
   pull-requests: read
+  # The ticket job reads closing targets' timelines (#150): a CLOSES
+  # whose ticket other open PRs still reference warns before the merge
+  # closes it under them.
+  issues: read
 
 concurrency:
   group: ci-ok-${{ github.event.pull_request.number }}
@@ -35,13 +39,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # Reads only the event payload and the central keyword file:
-      # the allow-list is exact ALL CAPS (ADVANCES/CLOSES/FIXES — rendered here
+      # Reads the event payload, the central keyword file, and — for
+      # tickets a closing keyword names — the ticket's timeline: the
+      # allow-list is exact ALL CAPS (ADVANCES/CLOSES/FIXES — rendered here
       # from reference-keywords.json, the single source), any native
       # closing keyword in any other casing fails the PR, and the only
-      # escape is the `automated` label on a bot-authored PR.
+      # escape is the `automated` label on a bot-authored PR. A close
+      # whose ticket other open PRs still reference is a warning (#150).
       - name: The PR names its tickets canonically
         env:
+          GH_TOKEN: ${{ github.token }}
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py ticket
 

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -126,6 +126,78 @@ def ticket_violations(body, branch, labels, author, config):
     return problems, False
 
 
+def closing_refs(body, config, repo):
+    """The tickets this PR would close on merge, as owner/repo#n.
+
+    Only keywords the central file tags `closing` count — ADVANCES is
+    non-closing by design, and hardcoding the split here would be the
+    second copy of a fact reference-keywords.json already owns. Bare
+    `#n` is the merging repo's own ticket, so it normalizes against
+    `repo` rather than staying ambiguous.
+    """
+    closers = sorted(w for w, kind in config["allowed"].items() if kind == "closing")
+    refs = set()
+    pattern = r"\b(?:" + "|".join(map(re.escape, closers)) + r") (" + REF + r")"
+    for match in re.finditer(pattern, body or ""):
+        ref = match.group(1)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def open_prs_of(events, exclude):
+    """Open PRs among a ticket's cross-references, as owner/repo#n.
+
+    The timeline is the forge's own reference index: no text search to
+    miss a phrasing, cross-repo for free, and sources the token cannot
+    read are simply absent rather than errors. `exclude` drops the PR
+    under judgement — it always references its own tickets.
+    """
+    prs = set()
+    for event in events:
+        if event.get("event") != "cross-referenced":
+            continue
+        source = event.get("source", {}).get("issue") or {}
+        if "pull_request" not in source or source.get("state") != "open":
+            continue
+        name = f"{source['repository']['full_name']}#{source['number']}"
+        if name != exclude:
+            prs.add(name)
+    return sorted(prs)
+
+
+def warn_premature_close(body, config, repo, number, token):
+    """#150: closing a ticket other open PRs still reference is loud.
+
+    A warning, never a failure — a shared mention is often legitimate
+    (a see-also, a quoted changelog), and forcing ADVANCES onto a
+    genuinely final PR would teach people to stop declaring closes.
+    Anything unreadable is a notice for the same reason a consumer
+    whose workflow lags the script by one release must not go red.
+    """
+    tickets = closing_refs(body, config, repo)
+    if not tickets:
+        return
+    if not token:
+        print("::notice::no GH_TOKEN — cannot check closing targets for other open PRs")
+        return
+    for ticket in tickets:
+        ticket_repo, _, ticket_number = ticket.rpartition("#")
+        try:
+            events = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/timeline", token
+            )
+        except (OSError, ValueError) as error:
+            print(f"::notice::could not check {ticket} for other open PRs: {error}")
+            continue
+        others = open_prs_of(events, exclude=f"{repo}#{number}")
+        if others:
+            print(
+                f"::warning::merging closes {ticket}, but other open PRs still "
+                f"reference it: {', '.join(others)}. If they share its work, "
+                f"this PR should ADVANCES the ticket and the last one close it."
+            )
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
@@ -145,6 +217,13 @@ def run_ticket():
         print(f"::error::{problem}")
     if not problems:
         print("Ticket references are canonical.")
+    warn_premature_close(
+        pr.get("body"),
+        config,
+        os.environ["GITHUB_REPOSITORY"],
+        pr["number"],
+        os.environ.get("GH_TOKEN"),
+    )
     return 1 if problems else 0
 
 

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -126,6 +126,78 @@ def ticket_violations(body, branch, labels, author, config):
     return problems, False
 
 
+def closing_refs(body, config, repo):
+    """The tickets this PR would close on merge, as owner/repo#n.
+
+    Only keywords the central file tags `closing` count — ADVANCES is
+    non-closing by design, and hardcoding the split here would be the
+    second copy of a fact reference-keywords.json already owns. Bare
+    `#n` is the merging repo's own ticket, so it normalizes against
+    `repo` rather than staying ambiguous.
+    """
+    closers = sorted(w for w, kind in config["allowed"].items() if kind == "closing")
+    refs = set()
+    pattern = r"\b(?:" + "|".join(map(re.escape, closers)) + r") (" + REF + r")"
+    for match in re.finditer(pattern, body or ""):
+        ref = match.group(1)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def open_prs_of(events, exclude):
+    """Open PRs among a ticket's cross-references, as owner/repo#n.
+
+    The timeline is the forge's own reference index: no text search to
+    miss a phrasing, cross-repo for free, and sources the token cannot
+    read are simply absent rather than errors. `exclude` drops the PR
+    under judgement — it always references its own tickets.
+    """
+    prs = set()
+    for event in events:
+        if event.get("event") != "cross-referenced":
+            continue
+        source = event.get("source", {}).get("issue") or {}
+        if "pull_request" not in source or source.get("state") != "open":
+            continue
+        name = f"{source['repository']['full_name']}#{source['number']}"
+        if name != exclude:
+            prs.add(name)
+    return sorted(prs)
+
+
+def warn_premature_close(body, config, repo, number, token):
+    """#150: closing a ticket other open PRs still reference is loud.
+
+    A warning, never a failure — a shared mention is often legitimate
+    (a see-also, a quoted changelog), and forcing ADVANCES onto a
+    genuinely final PR would teach people to stop declaring closes.
+    Anything unreadable is a notice for the same reason a consumer
+    whose workflow lags the script by one release must not go red.
+    """
+    tickets = closing_refs(body, config, repo)
+    if not tickets:
+        return
+    if not token:
+        print("::notice::no GH_TOKEN — cannot check closing targets for other open PRs")
+        return
+    for ticket in tickets:
+        ticket_repo, _, ticket_number = ticket.rpartition("#")
+        try:
+            events = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/timeline", token
+            )
+        except (OSError, ValueError) as error:
+            print(f"::notice::could not check {ticket} for other open PRs: {error}")
+            continue
+        others = open_prs_of(events, exclude=f"{repo}#{number}")
+        if others:
+            print(
+                f"::warning::merging closes {ticket}, but other open PRs still "
+                f"reference it: {', '.join(others)}. If they share its work, "
+                f"this PR should ADVANCES the ticket and the last one close it."
+            )
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
@@ -145,6 +217,13 @@ def run_ticket():
         print(f"::error::{problem}")
     if not problems:
         print("Ticket references are canonical.")
+    warn_premature_close(
+        pr.get("body"),
+        config,
+        os.environ["GITHUB_REPOSITORY"],
+        pr["number"],
+        os.environ.get("GH_TOKEN"),
+    )
     return 1 if problems else 0
 
 

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -126,6 +126,78 @@ def ticket_violations(body, branch, labels, author, config):
     return problems, False
 
 
+def closing_refs(body, config, repo):
+    """The tickets this PR would close on merge, as owner/repo#n.
+
+    Only keywords the central file tags `closing` count — ADVANCES is
+    non-closing by design, and hardcoding the split here would be the
+    second copy of a fact reference-keywords.json already owns. Bare
+    `#n` is the merging repo's own ticket, so it normalizes against
+    `repo` rather than staying ambiguous.
+    """
+    closers = sorted(w for w, kind in config["allowed"].items() if kind == "closing")
+    refs = set()
+    pattern = r"\b(?:" + "|".join(map(re.escape, closers)) + r") (" + REF + r")"
+    for match in re.finditer(pattern, body or ""):
+        ref = match.group(1)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def open_prs_of(events, exclude):
+    """Open PRs among a ticket's cross-references, as owner/repo#n.
+
+    The timeline is the forge's own reference index: no text search to
+    miss a phrasing, cross-repo for free, and sources the token cannot
+    read are simply absent rather than errors. `exclude` drops the PR
+    under judgement — it always references its own tickets.
+    """
+    prs = set()
+    for event in events:
+        if event.get("event") != "cross-referenced":
+            continue
+        source = event.get("source", {}).get("issue") or {}
+        if "pull_request" not in source or source.get("state") != "open":
+            continue
+        name = f"{source['repository']['full_name']}#{source['number']}"
+        if name != exclude:
+            prs.add(name)
+    return sorted(prs)
+
+
+def warn_premature_close(body, config, repo, number, token):
+    """#150: closing a ticket other open PRs still reference is loud.
+
+    A warning, never a failure — a shared mention is often legitimate
+    (a see-also, a quoted changelog), and forcing ADVANCES onto a
+    genuinely final PR would teach people to stop declaring closes.
+    Anything unreadable is a notice for the same reason a consumer
+    whose workflow lags the script by one release must not go red.
+    """
+    tickets = closing_refs(body, config, repo)
+    if not tickets:
+        return
+    if not token:
+        print("::notice::no GH_TOKEN — cannot check closing targets for other open PRs")
+        return
+    for ticket in tickets:
+        ticket_repo, _, ticket_number = ticket.rpartition("#")
+        try:
+            events = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/timeline", token
+            )
+        except (OSError, ValueError) as error:
+            print(f"::notice::could not check {ticket} for other open PRs: {error}")
+            continue
+        others = open_prs_of(events, exclude=f"{repo}#{number}")
+        if others:
+            print(
+                f"::warning::merging closes {ticket}, but other open PRs still "
+                f"reference it: {', '.join(others)}. If they share its work, "
+                f"this PR should ADVANCES the ticket and the last one close it."
+            )
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
@@ -145,6 +217,13 @@ def run_ticket():
         print(f"::error::{problem}")
     if not problems:
         print("Ticket references are canonical.")
+    warn_premature_close(
+        pr.get("body"),
+        config,
+        os.environ["GITHUB_REPOSITORY"],
+        pr["number"],
+        os.environ.get("GH_TOKEN"),
+    )
     return 1 if problems else 0
 
 

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -126,6 +126,78 @@ def ticket_violations(body, branch, labels, author, config):
     return problems, False
 
 
+def closing_refs(body, config, repo):
+    """The tickets this PR would close on merge, as owner/repo#n.
+
+    Only keywords the central file tags `closing` count — ADVANCES is
+    non-closing by design, and hardcoding the split here would be the
+    second copy of a fact reference-keywords.json already owns. Bare
+    `#n` is the merging repo's own ticket, so it normalizes against
+    `repo` rather than staying ambiguous.
+    """
+    closers = sorted(w for w, kind in config["allowed"].items() if kind == "closing")
+    refs = set()
+    pattern = r"\b(?:" + "|".join(map(re.escape, closers)) + r") (" + REF + r")"
+    for match in re.finditer(pattern, body or ""):
+        ref = match.group(1)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def open_prs_of(events, exclude):
+    """Open PRs among a ticket's cross-references, as owner/repo#n.
+
+    The timeline is the forge's own reference index: no text search to
+    miss a phrasing, cross-repo for free, and sources the token cannot
+    read are simply absent rather than errors. `exclude` drops the PR
+    under judgement — it always references its own tickets.
+    """
+    prs = set()
+    for event in events:
+        if event.get("event") != "cross-referenced":
+            continue
+        source = event.get("source", {}).get("issue") or {}
+        if "pull_request" not in source or source.get("state") != "open":
+            continue
+        name = f"{source['repository']['full_name']}#{source['number']}"
+        if name != exclude:
+            prs.add(name)
+    return sorted(prs)
+
+
+def warn_premature_close(body, config, repo, number, token):
+    """#150: closing a ticket other open PRs still reference is loud.
+
+    A warning, never a failure — a shared mention is often legitimate
+    (a see-also, a quoted changelog), and forcing ADVANCES onto a
+    genuinely final PR would teach people to stop declaring closes.
+    Anything unreadable is a notice for the same reason a consumer
+    whose workflow lags the script by one release must not go red.
+    """
+    tickets = closing_refs(body, config, repo)
+    if not tickets:
+        return
+    if not token:
+        print("::notice::no GH_TOKEN — cannot check closing targets for other open PRs")
+        return
+    for ticket in tickets:
+        ticket_repo, _, ticket_number = ticket.rpartition("#")
+        try:
+            events = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/timeline", token
+            )
+        except (OSError, ValueError) as error:
+            print(f"::notice::could not check {ticket} for other open PRs: {error}")
+            continue
+        others = open_prs_of(events, exclude=f"{repo}#{number}")
+        if others:
+            print(
+                f"::warning::merging closes {ticket}, but other open PRs still "
+                f"reference it: {', '.join(others)}. If they share its work, "
+                f"this PR should ADVANCES the ticket and the last one close it."
+            )
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
@@ -145,6 +217,13 @@ def run_ticket():
         print(f"::error::{problem}")
     if not problems:
         print("Ticket references are canonical.")
+    warn_premature_close(
+        pr.get("body"),
+        config,
+        os.environ["GITHUB_REPOSITORY"],
+        pr["number"],
+        os.environ.get("GH_TOKEN"),
+    )
     return 1 if problems else 0
 
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -25,6 +25,10 @@ permissions:
   contents: read
   actions: read
   pull-requests: read
+  # The ticket job reads closing targets' timelines (#150): a CLOSES
+  # whose ticket other open PRs still reference warns before the merge
+  # closes it under them.
+  issues: read
 
 concurrency:
   group: ci-ok-{% raw %}${{ github.event.pull_request.number }}{% endraw %}
@@ -37,13 +41,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # Reads only the event payload and the central keyword file:
-      # the allow-list is exact ALL CAPS ({{ caps }} — rendered here
+      # Reads the event payload, the central keyword file, and — for
+      # tickets a closing keyword names — the ticket's timeline: the
+      # allow-list is exact ALL CAPS ({{ caps }} — rendered here
       # from reference-keywords.json, the single source), any native
       # closing keyword in any other casing fails the PR, and the only
-      # escape is the `automated` label on a bot-authored PR.
+      # escape is the `automated` label on a bot-authored PR. A close
+      # whose ticket other open PRs still reference is a warning (#150).
       - name: The PR names its tickets canonically
         env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py ticket
 

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -94,6 +94,75 @@ def test_automated_escape_is_bot_only():
     assert not escaped and problems
 
 
+# ----------------------------------------------- premature close (#150)
+
+
+def test_closing_refs_come_from_the_central_files_closing_tag():
+    body = "CLOSES #5, FIXES pandoscope/skills#9, ADVANCES #7"
+    refs = gate.closing_refs(body, KEYWORDS, "pandoscope/meta")
+    assert refs == ["pandoscope/meta#5", "pandoscope/skills#9"]
+
+
+def test_bare_refs_normalize_and_duplicates_collapse():
+    body = "CLOSES #5 and again CLOSES pandoscope/meta#5"
+    assert gate.closing_refs(body, KEYWORDS, "pandoscope/meta") == ["pandoscope/meta#5"]
+    assert gate.closing_refs("ADVANCES #5", KEYWORDS, "pandoscope/meta") == []
+    assert gate.closing_refs(None, KEYWORDS, "pandoscope/meta") == []
+
+
+def cross_ref(repo, number, state="open", pr=True):
+    issue = {
+        "state": state,
+        "number": number,
+        "repository": {"full_name": repo},
+    }
+    if pr:
+        issue["pull_request"] = {}
+    return {"event": "cross-referenced", "source": {"issue": issue}}
+
+
+def test_open_prs_of_keeps_only_other_open_prs():
+    events = [
+        cross_ref("pandoscope/meta", 66),
+        cross_ref("pandoscope/skills", 113),
+        cross_ref("pandoscope/skills", 112, state="closed"),
+        cross_ref("pandoscope/ghx", 4, pr=False),
+        {"event": "labeled"},
+        cross_ref("pandoscope/skills", 113),
+    ]
+    assert gate.open_prs_of(events, exclude="pandoscope/meta#66") == [
+        "pandoscope/skills#113"
+    ]
+
+
+def test_warning_names_the_open_prs_and_notices_never_fail(capsys, monkeypatch):
+    monkeypatch.setattr(
+        gate, "paginate", lambda path, token: [cross_ref("pandoscope/skills", 113)]
+    )
+    gate.warn_premature_close("CLOSES #5", KEYWORDS, "pandoscope/meta", 66, "tok")
+    out = capsys.readouterr().out
+    assert "::warning::" in out and "pandoscope/skills#113" in out
+
+    gate.warn_premature_close("CLOSES #5", KEYWORDS, "pandoscope/meta", 66, None)
+    assert "::notice::" in capsys.readouterr().out
+
+    def boom(path, token):
+        raise OSError("404")
+
+    monkeypatch.setattr(gate, "paginate", boom)
+    gate.warn_premature_close("CLOSES #5", KEYWORDS, "pandoscope/meta", 66, "tok")
+    out = capsys.readouterr().out
+    assert "::notice::" in out and "::warning::" not in out
+
+
+def test_no_closing_ref_asks_nothing_of_the_network(monkeypatch):
+    def boom(path, token):
+        raise AssertionError("the network must not be touched")
+
+    monkeypatch.setattr(gate, "paginate", boom)
+    gate.warn_premature_close("ADVANCES #5", KEYWORDS, "pandoscope/meta", 66, "tok")
+
+
 # ------------------------------------------------------------ reviews
 
 


### PR DESCRIPTION
CLOSES pandoscope/agentic-engineering-template#150

## What

The ticket job gains a premature-close guard: for every ticket the body names with a **closing** keyword, the gate reads the ticket's timeline and, if other **open PRs** still cross-reference it, emits a `::warning::` naming them — before the merge closes the ticket under them. The sibling failure mode to #149: that one was quoted changelogs closing tickets nobody meant to close; this one is deliberate closes landing while sibling PRs still ride the same ticket.

## Design points

- **Warning, never failure.** A shared mention is often legitimate (a see-also, a quoted-but-defused changelog); forcing ADVANCES onto genuinely final PRs would teach people to stop declaring closes.
- **The closing/non-closing split comes from `reference-keywords.json`'s `allowed` map** — the central file already owns which keywords close; no second list.
- **Timeline, not text search**: GitHub's own cross-reference index — no phrasing to miss, cross-repo for free, and sources the token cannot read are absent rather than errors.
- **Degrades to a notice**: missing `GH_TOKEN` (a consumer whose workflow lags the script by one release — the v3.16.1 lesson), an unreadable foreign ticket, or a malformed ref never reddens the gate.
- Workflow: ticket job gains `GH_TOKEN`; `permissions` gains `issues: read`. The store workflow variants carry no ticket job and do not move.

## Route

Two commits, template-first: source (`template/scripts/ci/check_gate.py`, `ci-ok.yml.jinja`, tests), then `chore: restamp` moving the three stamped `check_gate.py` copies and the rendered root workflow together. `self_application.py --range` clean on both.

## Tests

`pytest` 270/270. New: closing-ref collection from the central file's tags (bare-ref normalization, dedupe, ADVANCES excluded), timeline filtering (self excluded, closed and non-PR sources dropped), warning/notice paths, and a no-closing-ref case that asserts the network is never touched.

## Note for the rollout

This releases as v3.17.0 and supersedes the v3.16.1 wave — whose PR bodies were built by the pre-#149 workflow and still carry live `closes …#137` keywords. Converging on this release instead avoids re-closing #137.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_