### PR TITLE
Preference lines are fundamentals: one line, one preference, plainest form

### DIFF
--- a/decision-memory/.agents/skills/compact-preferences/SKILL.md
+++ b/decision-memory/.agents/skills/compact-preferences/SKILL.md
@@ -118,7 +118,11 @@ preference:
 2. **Merge overlapping rules.** Two rules firing on the same condition
    become one. The merged rule takes the **lowest** counter of its
    constituents and the **most recent** `last:` date — a merged claim
-   is only as well-evidenced as its weakest part.
+   is only as well-evidenced as its weakest part. A merge is for rules
+   that say the same thing twice — never for two preferences that
+   merely fit on one line. One line states one preference (the
+   fundamentals rule in `docs/conventions.md`); re-fusing split lines
+   to save tokens is a format violation, not a compression.
 3. **Tighten wording.** Same condition, same falsifiable outcome,
    fewer tokens. This is the safest move and usually the smallest win.
 

--- a/decision-memory/.agents/skills/extract-preferences/SKILL.md
+++ b/decision-memory/.agents/skills/extract-preferences/SKILL.md
@@ -135,6 +135,12 @@ decision, not a recommendation dressed as one.
 rule per file, conditional and falsifiable: a condition, an outcome,
 and a way to be wrong.
 
+State the candidate as a **fundamental**: one preference, in the
+plainest words that survive a cold read. A rule that needs a
+corollary is two rules — write two files. Decomposing at proposal
+time is cheaper than decomposing at promotion, when a counter has to
+be divided along with the words.
+
 ```text
 pref-proposal: prefers the simplest solution that solves the actual problem
 ```

--- a/decision-memory/docs/conventions.md
+++ b/decision-memory/docs/conventions.md
@@ -253,11 +253,18 @@ Storage and priming are two concerns, so the set is a pair:
   absence stays observable, never ambiguous. The render never emits
   it; consumers that display a rule (e.g. the grilling skill's lineage
   panel) link the doc from here instead of guessing.
-- `rule` is one plain single-spaced line; the render never wraps. It
-  may hold a joined qualifier sentence under the one counter — "one
-  line, one preference" counts preferences, not sentences: a qualifier
-  the decider reads as part of the rule belongs to it, not to a second
-  entry.
+- `rule` is one plain single-spaced line stating **one preference, in
+  the plainest words that survive a cold read** — a line the reader
+  has to ask about has failed. The render never wraps. "One line, one
+  preference" counts preferences, not sentences: a qualifier the
+  decider reads as part of the rule joins it on the same line, under
+  the one counter. A line holding two preferences is split instead,
+  and the counter follows the evidence — whichever split line the
+  records actually support inherits it, the others start at zero.
+  (Ruled 2026-08-10/11, records `preference-lines-are-fundamental`,
+  `preference-lines-never-wrap` and `decompose-and-residue-one-line`:
+  seven compound lines became twelve plain ones and the file got
+  cheaper.)
 - Rule text is unique within the set (bumps match by text).
 
 Counter semantics:


### PR DESCRIPTION
CLOSES #153

Persists the style the principal ruled on pandoscope/decision-memory#14 (*"each line should express one preference in the most basic, most simple manner possible"*, recorded as `preference-lines-are-fundamental`) at the three points in the subtemplate where rule text gets written:

- **`docs/conventions.md`** — the active-set contract gains the fundamentals rule: one line, one preference, plainest words that survive a cold read; a line the reader has to ask about has failed; compound lines are split with the counter following the evidence (the supported line inherits, others start at zero).
- **`.agents/skills/extract-preferences/SKILL.md`** — the propose step states candidates as fundamentals from the start: a rule needing a corollary is two rules, two files. Decomposing at proposal time beats dividing a counter at promotion time.
- **`.agents/skills/compact-preferences/SKILL.md`** — the merge move is fenced: merging is for rules that say the same thing twice, never for two preferences that fit on one line; re-fusing split lines to save tokens is a format violation, not a compression.

Live evidence for the style, from the ruling's application: seven compound lines → twelve plain ones, 392 → 385 tokens — splitting made the file *cheaper*, because compound precision was costing connective prose as well as clarity.

Docs only; no tool or guard behaviour changes. Fans out to the store on the next release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_