### PR TITLE
docs(agents): judge CI by the newest check run per name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,9 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
   - Any obstacles that diverged from the initial plan, and — in the rare event spec deviation was unavoidable — what deviated and why.
   - All `DECISION:` markers present in the diff, rendered per the `documenting-decisions` skill format.
 - Check CI → `ghx run list` / `ghx run view` (or `ghx pr checks` once the PR exists).
+  Judge CI by the **newest check run per check name**, not per workflow run:
+  a head commit can accumulate several runs of the same check (re-runs, retriggers),
+  and a stale red run coexisting with a newer green one is a pass, not a failure.
 - If CI fails, fix it by re-entering this **Implement** workflow.
 
 #### Review

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -295,6 +295,9 @@ The modes below are the kinds of work the user will ask for. **Each runs in its 
   - Any obstacles that diverged from the initial plan, and — in the rare event spec deviation was unavoidable — what deviated and why.
   - All `DECISION:` markers present in the diff, rendered per the `documenting-decisions` skill format.
 - Check CI → `{{ agentic_tracker_cli }} run list` / `{{ agentic_tracker_cli }} run view` (or `{{ agentic_tracker_cli }} pr checks` once the PR exists).
+  Judge CI by the **newest check run per check name**, not per workflow run:
+  a head commit can accumulate several runs of the same check (re-runs, retriggers),
+  and a stale red run coexisting with a newer green one is a pass, not a failure.
 - If CI fails, fix it by re-entering this **Implement** workflow.
 
 #### Review


### PR DESCRIPTION
A head commit accumulates multiple runs of the same check across re-runs and retriggers, so judging CI per workflow run reads a stale red run beside a newer green one as a failure. The Implement workflow's CI step now states the rule: judge by the newest check run per check name.

Two commits, on the template-first route (docs/conventions.md):

1. `template/AGENTS.md.jinja` — the source edit.
2. `chore: reapply template to self` — the root `AGENTS.md` restamp, adopted from a clean render.

The first push of this branch edited the root `AGENTS.md` directly, which is render output; `test_self_application.py` caught it (`Root files differ from the template render: ['AGENTS.md']`) and that failure propagated into `ci-ok`. Rebuilt on the documented route and force-pushed. Verified locally: `self_application.py --range origin/main..HEAD` reports sources and stamps kept apart, and `tests/test_self_application.py` passes.

Note on this PR's own CI history: the `ticket reference` gate reads the PR body from `GITHUB_EVENT_PATH`, the frozen event payload, so re-running a job that failed before the body was fixed replays the old body and fails again regardless of the current body. The remedy is a fresh event (any body edit re-fires `edited`), not a re-run. Filed separately.

CLOSES #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE8RnGa2a9CZJUBzCJhNsA