### PR TITLE
Forge budget discipline: push over poll, git over REST, frugal fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,23 @@ CLIs there — the environment actively sabotages them. The environment's
 tool declarations override any command examples elsewhere in this repo,
 including `AGENTS.md`.
 
+## Forge Budget
+
+API budget per-account, shared by all sessions.
+
+- No PR subscriptions unless the principal asks.
+- Git before REST. Clone answers: file contents, diffs, history,
+  branch state. API only for: check runs, job logs, comments,
+  reviews, labels, PR/issue state.
+- Fetch only needed fields and items; need everything → few large
+  pages. Already-fetched state is cached until an event invalidates
+  it.
+
+## Learnings
+
+New non-obvious findings — tools, environment, failure modes — go in
+this file, tersely.
+
 ## Pull Requests
 
 Share PR URL in response to user.

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -11,27 +11,22 @@ CLIs there — the environment actively sabotages them. The environment's
 tool declarations override any command examples elsewhere in this repo,
 including `AGENTS.md`.
 
-## Forge Budget Discipline
+## Forge Budget
 
-The forge API budget is per-account and shared by every session on
-that account. Spend it like it runs out mid-review, because it does:
+API budget per-account, shared by all sessions.
 
-1. **Push over poll.** Subscribe to PR activity for PRs under active
-   review instead of re-reading them for new comments or CI results;
-   unsubscribe at merge. The read that never happens cannot be
-   rate-limited.
-2. **Git over REST.** Anything a clone answers — file contents,
-   diffs, history, branch state — comes from git, which spends no API
-   budget. The API is only for what git cannot see: check runs,
-   comments, labels.
-3. **Frugal calls.** Request field subsets and minimal output, page
-   small, continue from cursors instead of restarting, fetch a log
-   once with an adequate tail. Treat already-fetched state as cached
-   until an event invalidates it.
-4. **Rate-limited anyway → degrade in order.** Decisions travel via
-   chat, persistence via git, forge writes queue behind a single
-   timer. Never spend the remaining budget probing whether the limit
-   lifted.
+- No PR subscriptions unless the principal asks.
+- Git before REST. Clone answers: file contents, diffs, history,
+  branch state. API only for: check runs, job logs, comments,
+  reviews, labels, PR/issue state.
+- Fetch only needed fields and items; need everything → few large
+  pages. Already-fetched state is cached until an event invalidates
+  it.
+
+## Learnings
+
+New non-obvious findings — tools, environment, failure modes — go in
+this file, tersely.
 
 ## Pull Requests
 

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -11,6 +11,28 @@ CLIs there — the environment actively sabotages them. The environment's
 tool declarations override any command examples elsewhere in this repo,
 including `AGENTS.md`.
 
+## Forge Budget Discipline
+
+The forge API budget is per-account and shared by every session on
+that account. Spend it like it runs out mid-review, because it does:
+
+1. **Push over poll.** Subscribe to PR activity for PRs under active
+   review instead of re-reading them for new comments or CI results;
+   unsubscribe at merge. The read that never happens cannot be
+   rate-limited.
+2. **Git over REST.** Anything a clone answers — file contents,
+   diffs, history, branch state — comes from git, which spends no API
+   budget. The API is only for what git cannot see: check runs,
+   comments, labels.
+3. **Frugal calls.** Request field subsets and minimal output, page
+   small, continue from cursors instead of restarting, fetch a log
+   once with an adequate tail. Treat already-fetched state as cached
+   until an event invalidates it.
+4. **Rate-limited anyway → degrade in order.** Decisions travel via
+   chat, persistence via git, forge writes queue behind a single
+   timer. Never spend the remaining budget probing whether the limit
+   lifted.
+
 ## Pull Requests
 
 Share PR URL in response to user.


### PR DESCRIPTION
CLOSES #156

Adds a **Forge Budget Discipline** section to `template/CLAUDE.md.jinja`, beside the existing Environment Tooling rules, so every consumer repo primes its sessions with it:

1. **Push over poll** — subscribe to PR activity for PRs under review; unsubscribe at merge. The read that never happens cannot be rate-limited.
2. **Git over REST** — clones answer file contents, diffs, history and branch state at zero API cost; the API is only for what git cannot see.
3. **Frugal calls** — field subsets, small pages, cursor continuation, one adequately-sized log fetch, and already-fetched state treated as cached until an event invalidates it.
4. **Rate-limited anyway → degrade in order** — decisions via chat, persistence via git, forge writes queued behind a single timer; never spend remaining budget probing whether the limit lifted.

Motivated by measurement, not theory: the session account's hourly budget ran out mid-review on pandoscope/decision-memory#14 today, with two concurrent sessions sharing one bucket. Point 4 is transcribed from what actually worked — the review ruling reached the store through chat and git while the PR reply queued.

The org-side half (partitioning identities so concurrent sessions stop sharing one budget) is recorded on the ticket as a principal decision; it is not something a docs section can enact.

Docs only; fans out with the next release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_