### PR TITLE
fix(ci): the ticket gate judges the live pull request, not the event payload

### DIFF
--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -214,9 +214,13 @@ def live_pr(payload, token):
     if not token:
         return payload
     try:
-        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+        fresh = fetch(
+            f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token
+        )
     except OSError as err:
-        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        print(
+            f"::notice::could not read the live pull request ({err}) — judging the event payload"
+        )
         return payload
     return fresh
 

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -198,10 +198,33 @@ def warn_premature_close(body, config, repo, number, token):
             )
 
 
+def live_pr(payload, token):
+    """The PR as it is NOW, falling back to the event's snapshot.
+
+    The payload is frozen when the run is created, and a re-run replays
+    that same payload — so a body corrected after a red run stays
+    invisible to every re-run of it, and the gate fails forever for a
+    reason that no longer exists (#159). Only the number is taken from
+    the event; everything judged is read live.
+
+    A read that fails leaves the payload in place: the gate judges a
+    possibly-stale body rather than erroring, which is the same verdict
+    it gave before this existed, and never a pass it did not earn.
+    """
+    if not token:
+        return payload
+    try:
+        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+    except OSError as err:
+        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        return payload
+    return fresh
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
-    pr = event["pull_request"]
+    pr = live_pr(event["pull_request"], os.environ.get("GH_TOKEN"))
     config = reference_config()
     problems, escaped = ticket_violations(
         pr.get("body"),

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -214,9 +214,13 @@ def live_pr(payload, token):
     if not token:
         return payload
     try:
-        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+        fresh = fetch(
+            f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token
+        )
     except OSError as err:
-        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        print(
+            f"::notice::could not read the live pull request ({err}) — judging the event payload"
+        )
         return payload
     return fresh
 

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -198,10 +198,33 @@ def warn_premature_close(body, config, repo, number, token):
             )
 
 
+def live_pr(payload, token):
+    """The PR as it is NOW, falling back to the event's snapshot.
+
+    The payload is frozen when the run is created, and a re-run replays
+    that same payload — so a body corrected after a red run stays
+    invisible to every re-run of it, and the gate fails forever for a
+    reason that no longer exists (#159). Only the number is taken from
+    the event; everything judged is read live.
+
+    A read that fails leaves the payload in place: the gate judges a
+    possibly-stale body rather than erroring, which is the same verdict
+    it gave before this existed, and never a pass it did not earn.
+    """
+    if not token:
+        return payload
+    try:
+        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+    except OSError as err:
+        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        return payload
+    return fresh
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
-    pr = event["pull_request"]
+    pr = live_pr(event["pull_request"], os.environ.get("GH_TOKEN"))
     config = reference_config()
     problems, escaped = ticket_violations(
         pr.get("body"),

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -214,9 +214,13 @@ def live_pr(payload, token):
     if not token:
         return payload
     try:
-        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+        fresh = fetch(
+            f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token
+        )
     except OSError as err:
-        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        print(
+            f"::notice::could not read the live pull request ({err}) — judging the event payload"
+        )
         return payload
     return fresh
 

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -198,10 +198,33 @@ def warn_premature_close(body, config, repo, number, token):
             )
 
 
+def live_pr(payload, token):
+    """The PR as it is NOW, falling back to the event's snapshot.
+
+    The payload is frozen when the run is created, and a re-run replays
+    that same payload — so a body corrected after a red run stays
+    invisible to every re-run of it, and the gate fails forever for a
+    reason that no longer exists (#159). Only the number is taken from
+    the event; everything judged is read live.
+
+    A read that fails leaves the payload in place: the gate judges a
+    possibly-stale body rather than erroring, which is the same verdict
+    it gave before this existed, and never a pass it did not earn.
+    """
+    if not token:
+        return payload
+    try:
+        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+    except OSError as err:
+        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        return payload
+    return fresh
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
-    pr = event["pull_request"]
+    pr = live_pr(event["pull_request"], os.environ.get("GH_TOKEN"))
     config = reference_config()
     problems, escaped = ticket_violations(
         pr.get("body"),

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -214,9 +214,13 @@ def live_pr(payload, token):
     if not token:
         return payload
     try:
-        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+        fresh = fetch(
+            f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token
+        )
     except OSError as err:
-        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        print(
+            f"::notice::could not read the live pull request ({err}) — judging the event payload"
+        )
         return payload
     return fresh
 

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -198,10 +198,33 @@ def warn_premature_close(body, config, repo, number, token):
             )
 
 
+def live_pr(payload, token):
+    """The PR as it is NOW, falling back to the event's snapshot.
+
+    The payload is frozen when the run is created, and a re-run replays
+    that same payload — so a body corrected after a red run stays
+    invisible to every re-run of it, and the gate fails forever for a
+    reason that no longer exists (#159). Only the number is taken from
+    the event; everything judged is read live.
+
+    A read that fails leaves the payload in place: the gate judges a
+    possibly-stale body rather than erroring, which is the same verdict
+    it gave before this existed, and never a pass it did not earn.
+    """
+    if not token:
+        return payload
+    try:
+        fresh = fetch(f"/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{payload['number']}", token)
+    except OSError as err:
+        print(f"::notice::could not read the live pull request ({err}) — judging the event payload")
+        return payload
+    return fresh
+
+
 def run_ticket():
     with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
         event = json.load(handle)
-    pr = event["pull_request"]
+    pr = live_pr(event["pull_request"], os.environ.get("GH_TOKEN"))
     config = reference_config()
     problems, escaped = ticket_violations(
         pr.get("body"),

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -384,3 +384,54 @@ def test_store_gate_workflows_are_identical_and_unticketed():
     root_copy = (ROOT / ".github" / "workflows" / "ci-ok.yml").read_text()
     assert KEYWORDS["no_commit_marker"] in root_copy
     assert "{%" not in root_copy and "reference_keywords" not in root_copy
+
+
+def test_the_gate_judges_the_live_body_not_the_event_payload(tmp_path, monkeypatch, capsys):
+    """A re-run replays the payload the run was created with (#159).
+
+    GitHub's re-run hands the job the ORIGINAL event, so a body fixed
+    after the first failure is invisible to it and the gate fails for
+    a reason that no longer exists — permanently, since every re-run
+    replays the same stale payload. The body therefore comes from the
+    live PR; only the number comes from the event.
+    """
+    event = tmp_path / "event.json"
+    event.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "number": 155,
+                    "body": "no reference here",
+                    "head": {"ref": "claude/159-thing"},
+                    "labels": [],
+                    "user": {"login": "pando-ramet"},
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "pandoscope/agentic-engineering-template")
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setenv(
+        "REFERENCE_KEYWORDS",
+        str(
+            ROOT
+            / "template"
+            / "{% if agentic_forge == 'github' %}.github{% endif %}"
+            / "reference-keywords.json"
+        ),
+    )
+    monkeypatch.setattr(
+        gate,
+        "fetch",
+        lambda path, token: {
+            "number": 155,
+            "body": "CLOSES #159",
+            "head": {"ref": "claude/159-thing"},
+            "labels": [],
+            "user": {"login": "pando-ramet"},
+        },
+    )
+    monkeypatch.setattr(gate, "paginate", lambda path, token: [])
+    assert gate.run_ticket() == 0
+    assert "::error::" not in capsys.readouterr().out

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -386,7 +386,9 @@ def test_store_gate_workflows_are_identical_and_unticketed():
     assert "{%" not in root_copy and "reference_keywords" not in root_copy
 
 
-def test_the_gate_judges_the_live_body_not_the_event_payload(tmp_path, monkeypatch, capsys):
+def test_the_gate_judges_the_live_body_not_the_event_payload(
+    tmp_path, monkeypatch, capsys
+):
     """A re-run replays the payload the run was created with (#159).
 
     GitHub's re-run hands the job the ORIGINAL event, so a body fixed


### PR DESCRIPTION
`run_ticket()` read the PR body from `GITHUB_EVENT_PATH`, the payload frozen when the run was created. GitHub's re-run replays that payload, so a body corrected after a red `ticket reference` run stayed invisible to every re-run of it — the gate failed forever for a reason that no longer existed, and the natural human response (fix the body, press re-run) was exactly what could never work.

Measured on #155, same head SHA: the fresh `edited` event at 23:31:35 passed, and a re-run of the older run at 23:32:05 failed. The re-run being newer, branch protection read the required `ci-ok` context as failing and refused the merge on a PR whose body satisfied the gate.

## Changes

- `live_pr()` fetches the PR from the API and `run_ticket()` judges that. Only the number comes from the event.
- A failed read leaves the payload in place and emits a `::notice::`, so the gate degrades to the verdict it gave before this existed — never to a pass it did not earn.
- No token, no fetch: the payload is used, as before.

Two commits on the template-first route: the source edit, then the restamp adopting it into the root and both subtemplate copies (`test_gate_script_copies_are_byte_identical_template_first` pins all three).

## Verification

271 tests pass. New test `test_the_gate_judges_the_live_body_not_the_event_payload` pins the behaviour by making the payload body and the live body disagree — it fails on the old code with the exact error this fixes. `self_application.py --range origin/main..HEAD` reports sources and stamps kept apart.

CLOSES #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE8RnGa2a9CZJUBzCJhNsA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FE8RnGa2a9CZJUBzCJhNsA)_