### PR TITLE
feat(store): required-nullable doc field — promotion-doc provenance per preference rule

### DIFF
--- a/decision-memory/.github/guards/decision_validator.py
+++ b/decision-memory/.github/guards/decision_validator.py
@@ -98,6 +98,10 @@ PREFERENCES_RENDERED = "preferences.txt"
 COUNTER_KEY = "confirmed"
 INDEPENDENT_KEY = "independent"
 DATE_KEY = "last"
+# Promotion-doc provenance, required-but-nullable: null is the explicit
+# "no promotion doc exists" declaration, so a missing key is always a
+# defect rather than an ambiguity. The render never emits it.
+DOC_KEY = "doc"
 
 # Exactly these, on every rule. A closed set is what keeps a rule from
 # gaining keys nothing reads: adding one is a deliberate change here,
@@ -109,7 +113,7 @@ DATE_KEY = "last"
 # append at the end; moving one is a rewrite of the active set and
 # gated like any other. Nothing here enforces a particular order — the
 # order IS the ruling.
-RULE_KEYS = ("rule", COUNTER_KEY, INDEPENDENT_KEY, DATE_KEY)
+RULE_KEYS = ("rule", COUNTER_KEY, INDEPENDENT_KEY, DATE_KEY, DOC_KEY)
 
 
 def parse_preferences(text: str) -> tuple[dict | None, list[str]]:
@@ -155,6 +159,14 @@ def _validate_rule(index: int, rule: object) -> list[str]:
         )
     if not isinstance(rule[DATE_KEY], str) or not DATE_RE.fullmatch(rule[DATE_KEY]):
         errors.append(f"{where}: {DATE_KEY}={rule[DATE_KEY]!r} is not YYYY-MM-DD")
+    doc = rule[DOC_KEY]
+    if doc is not None and (
+        not isinstance(doc, str) or not doc.startswith(("http://", "https://"))
+    ):
+        errors.append(
+            f"{where}: {DOC_KEY}={doc!r} must be null (no promotion doc "
+            "exists) or the http(s) URL of the doc that promoted the rule"
+        )
     return errors
 
 

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -73,12 +73,14 @@ def make_rule(
     confirmed=1,
     independent=0,
     last="2026-07-15",
+    doc=None,
 ):
     return {
         "rule": text,
         "confirmed": confirmed,
         "independent": independent,
         "last": last,
+        "doc": doc,
     }
 
 
@@ -88,6 +90,44 @@ def make_preferences(*rules):
 
 def source_text(*rules):
     return json.dumps(make_preferences(*rules))
+
+
+class PreferenceDocTests(unittest.TestCase):
+    """The doc field: required-but-nullable promotion-doc provenance.
+
+    Every rule entry carries `doc` — a null is the explicit "no
+    promotion doc exists" declaration, a missing key is a defect, and
+    absence therefore stays observable. The render never emits it: the
+    injected surface stays a plain rule list.
+    """
+
+    def test_doc_null_is_a_valid_declared_absence(self):
+        data = make_preferences(make_rule(doc=None))
+        self.assertEqual(guards.decision_validator.validate_preferences(data), [])
+
+    def test_doc_url_is_valid(self):
+        data = make_preferences(make_rule(doc="https://example.com/proposals/x.md"))
+        self.assertEqual(guards.decision_validator.validate_preferences(data), [])
+
+    def test_a_rule_without_doc_is_rejected(self):
+        rule = make_rule()
+        del rule["doc"]
+        errors = guards.decision_validator.validate_preferences(make_preferences(rule))
+        self.assertTrue(errors and any("keys must be exactly" in e for e in errors))
+
+    def test_doc_must_be_null_or_http_url(self):
+        for bad in ("proposals/x.md", "", True, 7):
+            with self.subTest(doc=bad):
+                errors = guards.decision_validator.validate_preferences(
+                    make_preferences(make_rule(doc=bad))
+                )
+                self.assertTrue(any("doc" in e for e in errors))
+
+    def test_render_never_emits_the_doc(self):
+        data = make_preferences(make_rule(doc="https://example.com/proposals/x.md"))
+        rendered = guards.decision_validator.render_preferences(data)
+        self.assertNotIn("example.com", rendered)
+        self.assertIn(make_rule()["rule"], rendered)
 
 
 class ConfigTests(unittest.TestCase):

--- a/decision-memory/docs/conventions.md
+++ b/decision-memory/docs/conventions.md
@@ -206,7 +206,8 @@ Storage and priming are two concerns, so the set is a pair:
   ```json
   {"rules": [
     {"rule": "Prefers machine checks over model checks wherever feasible.",
-     "confirmed": 3, "independent": 1, "last": "2026-08-11"}
+     "confirmed": 3, "independent": 1, "last": "2026-08-11",
+     "doc": "https://github.com/<owner>/<store>/blob/main/proposals/2026-08-06-machine-checks.md"}
   ]}
   ```
 
@@ -241,9 +242,17 @@ Storage and priming are two concerns, so the set is a pair:
   where a later rule beat an earlier one are extraction findings that
   PROPOSE a reorder, never apply one.
 - Rules are conditional and falsifiable, one object each. The schema
-  is a closed set — `rule`, `confirmed`, `independent`, `last`,
+  is a closed set — `rule`, `confirmed`, `independent`, `last`, `doc`,
   nothing else — so a rule cannot gain keys nothing reads, and a
   hand-added rule cannot enter without counters.
+- **`doc` is the rule's promotion provenance, required-but-nullable**:
+  the http(s) URL of the doc that promoted the rule (typically its
+  `proposals/` file), written by the promoting human in the promoting
+  commit. `doc: null` is the explicit "no promotion doc exists"
+  declaration, so a missing key is always a defect the guard rejects —
+  absence stays observable, never ambiguous. The render never emits
+  it; consumers that display a rule (e.g. the grilling skill's lineage
+  panel) link the doc from here instead of guessing.
 - `rule` is one plain single-spaced line; the render never wraps. It
   may hold a joined qualifier sentence under the one counter — "one
   line, one preference" counts preferences, not sentences: a qualifier

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -35,12 +35,15 @@ def test_foreign_commit_subjects_fail() -> None:
         assert guards.check_commit_subject(subject) is not None, subject
 
 
-def _rule(text="Rejects new deps.", confirmed=3, independent=0, last="2026-07-15"):
+def _rule(
+    text="Rejects new deps.", confirmed=3, independent=0, last="2026-07-15", doc=None
+):
     return {
         "rule": text,
         "confirmed": confirmed,
         "independent": independent,
         "last": last,
+        "doc": doc,
     }
 
 


### PR DESCRIPTION
ADVANCES pandoscope/decision-memory#20

**Reworked onto the post-#163 format** (the original sidecar approach collided with `preferences.json` becoming the source of truth — see the earlier comment; the branch was rebuilt from current main, no sidecar remnants).

## What

Every `preferences.json` rule entry now carries a fifth key, **`doc`** — the promotion-doc provenance:

- **Required-but-nullable**: `doc` is either the http(s) URL of the doc that promoted the rule (typically its `proposals/` file) or `null` as the explicit "no promotion doc exists" declaration. A missing key fails the closed-key-set check, so absence is always observable — "no doc" and "forgot to write it" can never look the same.
- `decision_validator.py`: `DOC_KEY` added to `RULE_KEYS`; `_validate_rule` accepts null or an http(s) URL and rejects everything else with a field-naming error. `render_preferences` is untouched — the injected `preferences.txt` stays a plain rule list, and a test now pins that the render never emits the doc.
- Written by the promoting human in the promoting commit; the mirror/carve-out/budget guards all apply unchanged since `doc` lives inside the existing source of truth — no second file, nothing new to drift.
- `docs/conventions.md`: schema example and closed-set bullet updated; new `doc` bullet under the active-preference-set section.

## Tests

Test-first: `PreferenceDocTests` in the subtemplate store suite (null passes, URL passes, missing key rejected, non-URL/bool/int rejected, render never emits) — red at 8 errors before the implementation. Both rule factories gained `doc=None`. Subtemplate suite 177 green; root pytest 271 green (copier e2e renders included, so seeds and the recorder's counter bumps survive the change).

## Consumers

The single live store backfills `doc` values in its conversion-era PR (pandoscope/decision-memory!21 is retired in favor of that); the grilling skill fills `preferenceDocs` from `preferences.json` at injection time (pandoscope/skills#134).