### PR TITLE
fix(ci): the reviews gate is the agent's worklist — resolved threads exempt, violations name their thread

### DIFF
--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -6,7 +6,7 @@ Three subcommands, one per job in ci-ok.yml:
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
-             `no_commit_marker`
+             `no_commit_marker`, or resolved by the reviewer
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -56,6 +56,31 @@ def fetch(path, token):
     )
     with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
+
+
+def graphql(query, variables, token):
+    """POST one GraphQL query — the read for what REST does not expose.
+
+    Review-thread resolution exists only in the GraphQL schema, so this
+    is the file's second and last network door: a POST to the fixed
+    /graphql path, under the same scheme guard as `fetch`.
+    """
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url("/graphql"),
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload["data"]
 
 
 def paginate(path, token, key=None):
@@ -266,14 +291,24 @@ def thread_of(comments):
     return list(threads.values())
 
 
-def review_violations(threads, pr_author, pr_shas, base_url, marker):
-    """Human threads left without a qualifying author reply.
+def review_violations(
+    threads, pr_author, pr_shas, base_url, marker, resolved=frozenset()
+):
+    """The agent's worklist: human threads still needing a response.
 
-    Qualifying: a full commit URL under `base_url` whose sha is one of
+    Each violation names its exact thread — opener, path, a quote of
+    the comment and its URL — because the reader is the agent deciding
+    what to do next, not a human who already knows which comment they
+    left.
+
+    Answered: a full commit URL under `base_url` whose sha is one of
     this PR's own commits — a pasted-but-wrong link fails, and a bare
     hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. Resolving a thread is not answering it;
-    this never reads resolution.
+    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    the worklist regardless: resolution is the reviewer's own sign-off
+    that nothing more is needed, and demanding a reply on top of it
+    gated pandoscope/skills#30 on wording nobody was waiting for
+    (agentic-engineering-template#166).
     """
     url_re = re.compile(
         re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
@@ -283,6 +318,8 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
         first = comments[0]
         opener = first["user"]["login"]
         if opener == pr_author or opener.endswith("[bot]"):
+            continue
+        if first.get("id") in resolved:
             continue
         answered = False
         for reply in comments[1:]:
@@ -299,11 +336,66 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
                 break
         if not answered:
             where = first.get("path") or "(general)"
+            quote = " ".join((first.get("body") or "").split())
+            if len(quote) > 90:
+                quote = quote[:87] + "..."
+            link = first.get("html_url") or ""
             problems.append(
-                f"review thread by {opener} at {where} has no reply from "
-                f"{pr_author} carrying a commit URL on this PR or a '{marker} <why>' line"
+                f'unanswered review thread by {opener} at {where}: "{quote}"'
+                + (f" ({link})" if link else "")
+                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
+                " line, or the reviewer resolves the thread"
             )
     return problems
+
+
+RESOLVED_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved comments(first: 1) { nodes { databaseId } } }
+      }
+    }
+  }
+}
+"""
+
+
+def resolved_roots(nodes):
+    """Root-comment ids of resolved threads, from reviewThreads nodes.
+
+    The databaseId is the same id the REST comments endpoint returns,
+    which is what lets resolution — GraphQL-only — exempt threads built
+    from REST data.
+    """
+    roots = set()
+    for node in nodes:
+        if not node.get("isResolved"):
+            continue
+        for comment in (node.get("comments") or {}).get("nodes") or []:
+            if comment.get("databaseId") is not None:
+                roots.add(comment["databaseId"])
+    return roots
+
+
+def resolved_thread_roots(repo, number, token):
+    """Every resolved thread's root id, paged."""
+    owner, name = repo.split("/", 1)
+    nodes = []
+    cursor = None
+    while True:
+        data = graphql(
+            RESOLVED_QUERY,
+            {"owner": owner, "name": name, "number": number, "cursor": cursor},
+            token,
+        )
+        threads = data["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(threads["nodes"])
+        if not threads["pageInfo"]["hasNextPage"]:
+            return resolved_roots(nodes)
+        cursor = threads["pageInfo"]["endCursor"]
 
 
 def reference_config():
@@ -329,7 +421,12 @@ def run_reviews():
     shas = [c["sha"] for c in paginate(f"/repos/{repo}/pulls/{number}/commits", token)]
     marker = reference_config()["no_commit_marker"]
     problems = review_violations(
-        thread_of(comments), pr["user"]["login"], shas, SERVER, marker
+        thread_of(comments),
+        pr["user"]["login"],
+        shas,
+        SERVER,
+        marker,
+        resolved=resolved_thread_roots(repo, number, token),
     )
     for problem in problems:
         print(f"::error::{problem}")

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -6,7 +6,7 @@ Three subcommands, one per job in ci-ok.yml:
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
-             `no_commit_marker`
+             `no_commit_marker`, or resolved by the reviewer
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -56,6 +56,31 @@ def fetch(path, token):
     )
     with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
+
+
+def graphql(query, variables, token):
+    """POST one GraphQL query — the read for what REST does not expose.
+
+    Review-thread resolution exists only in the GraphQL schema, so this
+    is the file's second and last network door: a POST to the fixed
+    /graphql path, under the same scheme guard as `fetch`.
+    """
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url("/graphql"),
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload["data"]
 
 
 def paginate(path, token, key=None):
@@ -266,14 +291,24 @@ def thread_of(comments):
     return list(threads.values())
 
 
-def review_violations(threads, pr_author, pr_shas, base_url, marker):
-    """Human threads left without a qualifying author reply.
+def review_violations(
+    threads, pr_author, pr_shas, base_url, marker, resolved=frozenset()
+):
+    """The agent's worklist: human threads still needing a response.
 
-    Qualifying: a full commit URL under `base_url` whose sha is one of
+    Each violation names its exact thread — opener, path, a quote of
+    the comment and its URL — because the reader is the agent deciding
+    what to do next, not a human who already knows which comment they
+    left.
+
+    Answered: a full commit URL under `base_url` whose sha is one of
     this PR's own commits — a pasted-but-wrong link fails, and a bare
     hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. Resolving a thread is not answering it;
-    this never reads resolution.
+    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    the worklist regardless: resolution is the reviewer's own sign-off
+    that nothing more is needed, and demanding a reply on top of it
+    gated pandoscope/skills#30 on wording nobody was waiting for
+    (agentic-engineering-template#166).
     """
     url_re = re.compile(
         re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
@@ -283,6 +318,8 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
         first = comments[0]
         opener = first["user"]["login"]
         if opener == pr_author or opener.endswith("[bot]"):
+            continue
+        if first.get("id") in resolved:
             continue
         answered = False
         for reply in comments[1:]:
@@ -299,11 +336,66 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
                 break
         if not answered:
             where = first.get("path") or "(general)"
+            quote = " ".join((first.get("body") or "").split())
+            if len(quote) > 90:
+                quote = quote[:87] + "..."
+            link = first.get("html_url") or ""
             problems.append(
-                f"review thread by {opener} at {where} has no reply from "
-                f"{pr_author} carrying a commit URL on this PR or a '{marker} <why>' line"
+                f'unanswered review thread by {opener} at {where}: "{quote}"'
+                + (f" ({link})" if link else "")
+                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
+                " line, or the reviewer resolves the thread"
             )
     return problems
+
+
+RESOLVED_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved comments(first: 1) { nodes { databaseId } } }
+      }
+    }
+  }
+}
+"""
+
+
+def resolved_roots(nodes):
+    """Root-comment ids of resolved threads, from reviewThreads nodes.
+
+    The databaseId is the same id the REST comments endpoint returns,
+    which is what lets resolution — GraphQL-only — exempt threads built
+    from REST data.
+    """
+    roots = set()
+    for node in nodes:
+        if not node.get("isResolved"):
+            continue
+        for comment in (node.get("comments") or {}).get("nodes") or []:
+            if comment.get("databaseId") is not None:
+                roots.add(comment["databaseId"])
+    return roots
+
+
+def resolved_thread_roots(repo, number, token):
+    """Every resolved thread's root id, paged."""
+    owner, name = repo.split("/", 1)
+    nodes = []
+    cursor = None
+    while True:
+        data = graphql(
+            RESOLVED_QUERY,
+            {"owner": owner, "name": name, "number": number, "cursor": cursor},
+            token,
+        )
+        threads = data["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(threads["nodes"])
+        if not threads["pageInfo"]["hasNextPage"]:
+            return resolved_roots(nodes)
+        cursor = threads["pageInfo"]["endCursor"]
 
 
 def reference_config():
@@ -329,7 +421,12 @@ def run_reviews():
     shas = [c["sha"] for c in paginate(f"/repos/{repo}/pulls/{number}/commits", token)]
     marker = reference_config()["no_commit_marker"]
     problems = review_violations(
-        thread_of(comments), pr["user"]["login"], shas, SERVER, marker
+        thread_of(comments),
+        pr["user"]["login"],
+        shas,
+        SERVER,
+        marker,
+        resolved=resolved_thread_roots(repo, number, token),
     )
     for problem in problems:
         print(f"::error::{problem}")

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -6,7 +6,7 @@ Three subcommands, one per job in ci-ok.yml:
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
-             `no_commit_marker`
+             `no_commit_marker`, or resolved by the reviewer
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -56,6 +56,31 @@ def fetch(path, token):
     )
     with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
+
+
+def graphql(query, variables, token):
+    """POST one GraphQL query — the read for what REST does not expose.
+
+    Review-thread resolution exists only in the GraphQL schema, so this
+    is the file's second and last network door: a POST to the fixed
+    /graphql path, under the same scheme guard as `fetch`.
+    """
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url("/graphql"),
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload["data"]
 
 
 def paginate(path, token, key=None):
@@ -266,14 +291,24 @@ def thread_of(comments):
     return list(threads.values())
 
 
-def review_violations(threads, pr_author, pr_shas, base_url, marker):
-    """Human threads left without a qualifying author reply.
+def review_violations(
+    threads, pr_author, pr_shas, base_url, marker, resolved=frozenset()
+):
+    """The agent's worklist: human threads still needing a response.
 
-    Qualifying: a full commit URL under `base_url` whose sha is one of
+    Each violation names its exact thread — opener, path, a quote of
+    the comment and its URL — because the reader is the agent deciding
+    what to do next, not a human who already knows which comment they
+    left.
+
+    Answered: a full commit URL under `base_url` whose sha is one of
     this PR's own commits — a pasted-but-wrong link fails, and a bare
     hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. Resolving a thread is not answering it;
-    this never reads resolution.
+    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    the worklist regardless: resolution is the reviewer's own sign-off
+    that nothing more is needed, and demanding a reply on top of it
+    gated pandoscope/skills#30 on wording nobody was waiting for
+    (agentic-engineering-template#166).
     """
     url_re = re.compile(
         re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
@@ -283,6 +318,8 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
         first = comments[0]
         opener = first["user"]["login"]
         if opener == pr_author or opener.endswith("[bot]"):
+            continue
+        if first.get("id") in resolved:
             continue
         answered = False
         for reply in comments[1:]:
@@ -299,11 +336,66 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
                 break
         if not answered:
             where = first.get("path") or "(general)"
+            quote = " ".join((first.get("body") or "").split())
+            if len(quote) > 90:
+                quote = quote[:87] + "..."
+            link = first.get("html_url") or ""
             problems.append(
-                f"review thread by {opener} at {where} has no reply from "
-                f"{pr_author} carrying a commit URL on this PR or a '{marker} <why>' line"
+                f'unanswered review thread by {opener} at {where}: "{quote}"'
+                + (f" ({link})" if link else "")
+                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
+                " line, or the reviewer resolves the thread"
             )
     return problems
+
+
+RESOLVED_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved comments(first: 1) { nodes { databaseId } } }
+      }
+    }
+  }
+}
+"""
+
+
+def resolved_roots(nodes):
+    """Root-comment ids of resolved threads, from reviewThreads nodes.
+
+    The databaseId is the same id the REST comments endpoint returns,
+    which is what lets resolution — GraphQL-only — exempt threads built
+    from REST data.
+    """
+    roots = set()
+    for node in nodes:
+        if not node.get("isResolved"):
+            continue
+        for comment in (node.get("comments") or {}).get("nodes") or []:
+            if comment.get("databaseId") is not None:
+                roots.add(comment["databaseId"])
+    return roots
+
+
+def resolved_thread_roots(repo, number, token):
+    """Every resolved thread's root id, paged."""
+    owner, name = repo.split("/", 1)
+    nodes = []
+    cursor = None
+    while True:
+        data = graphql(
+            RESOLVED_QUERY,
+            {"owner": owner, "name": name, "number": number, "cursor": cursor},
+            token,
+        )
+        threads = data["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(threads["nodes"])
+        if not threads["pageInfo"]["hasNextPage"]:
+            return resolved_roots(nodes)
+        cursor = threads["pageInfo"]["endCursor"]
 
 
 def reference_config():
@@ -329,7 +421,12 @@ def run_reviews():
     shas = [c["sha"] for c in paginate(f"/repos/{repo}/pulls/{number}/commits", token)]
     marker = reference_config()["no_commit_marker"]
     problems = review_violations(
-        thread_of(comments), pr["user"]["login"], shas, SERVER, marker
+        thread_of(comments),
+        pr["user"]["login"],
+        shas,
+        SERVER,
+        marker,
+        resolved=resolved_thread_roots(repo, number, token),
     )
     for problem in problems:
         print(f"::error::{problem}")

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -6,7 +6,7 @@ Three subcommands, one per job in ci-ok.yml:
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
-             `no_commit_marker`
+             `no_commit_marker`, or resolved by the reviewer
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -56,6 +56,31 @@ def fetch(path, token):
     )
     with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
         return json.load(response)
+
+
+def graphql(query, variables, token):
+    """POST one GraphQL query — the read for what REST does not expose.
+
+    Review-thread resolution exists only in the GraphQL schema, so this
+    is the file's second and last network door: a POST to the fixed
+    /graphql path, under the same scheme guard as `fetch`.
+    """
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url("/graphql"),
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload["data"]
 
 
 def paginate(path, token, key=None):
@@ -266,14 +291,24 @@ def thread_of(comments):
     return list(threads.values())
 
 
-def review_violations(threads, pr_author, pr_shas, base_url, marker):
-    """Human threads left without a qualifying author reply.
+def review_violations(
+    threads, pr_author, pr_shas, base_url, marker, resolved=frozenset()
+):
+    """The agent's worklist: human threads still needing a response.
 
-    Qualifying: a full commit URL under `base_url` whose sha is one of
+    Each violation names its exact thread — opener, path, a quote of
+    the comment and its URL — because the reader is the agent deciding
+    what to do next, not a human who already knows which comment they
+    left.
+
+    Answered: a full commit URL under `base_url` whose sha is one of
     this PR's own commits — a pasted-but-wrong link fails, and a bare
     hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. Resolving a thread is not answering it;
-    this never reads resolution.
+    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    the worklist regardless: resolution is the reviewer's own sign-off
+    that nothing more is needed, and demanding a reply on top of it
+    gated pandoscope/skills#30 on wording nobody was waiting for
+    (agentic-engineering-template#166).
     """
     url_re = re.compile(
         re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
@@ -283,6 +318,8 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
         first = comments[0]
         opener = first["user"]["login"]
         if opener == pr_author or opener.endswith("[bot]"):
+            continue
+        if first.get("id") in resolved:
             continue
         answered = False
         for reply in comments[1:]:
@@ -299,11 +336,66 @@ def review_violations(threads, pr_author, pr_shas, base_url, marker):
                 break
         if not answered:
             where = first.get("path") or "(general)"
+            quote = " ".join((first.get("body") or "").split())
+            if len(quote) > 90:
+                quote = quote[:87] + "..."
+            link = first.get("html_url") or ""
             problems.append(
-                f"review thread by {opener} at {where} has no reply from "
-                f"{pr_author} carrying a commit URL on this PR or a '{marker} <why>' line"
+                f'unanswered review thread by {opener} at {where}: "{quote}"'
+                + (f" ({link})" if link else "")
+                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
+                " line, or the reviewer resolves the thread"
             )
     return problems
+
+
+RESOLVED_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved comments(first: 1) { nodes { databaseId } } }
+      }
+    }
+  }
+}
+"""
+
+
+def resolved_roots(nodes):
+    """Root-comment ids of resolved threads, from reviewThreads nodes.
+
+    The databaseId is the same id the REST comments endpoint returns,
+    which is what lets resolution — GraphQL-only — exempt threads built
+    from REST data.
+    """
+    roots = set()
+    for node in nodes:
+        if not node.get("isResolved"):
+            continue
+        for comment in (node.get("comments") or {}).get("nodes") or []:
+            if comment.get("databaseId") is not None:
+                roots.add(comment["databaseId"])
+    return roots
+
+
+def resolved_thread_roots(repo, number, token):
+    """Every resolved thread's root id, paged."""
+    owner, name = repo.split("/", 1)
+    nodes = []
+    cursor = None
+    while True:
+        data = graphql(
+            RESOLVED_QUERY,
+            {"owner": owner, "name": name, "number": number, "cursor": cursor},
+            token,
+        )
+        threads = data["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(threads["nodes"])
+        if not threads["pageInfo"]["hasNextPage"]:
+            return resolved_roots(nodes)
+        cursor = threads["pageInfo"]["endCursor"]
 
 
 def reference_config():
@@ -329,7 +421,12 @@ def run_reviews():
     shas = [c["sha"] for c in paginate(f"/repos/{repo}/pulls/{number}/commits", token)]
     marker = reference_config()["no_commit_marker"]
     problems = review_violations(
-        thread_of(comments), pr["user"]["login"], shas, SERVER, marker
+        thread_of(comments),
+        pr["user"]["login"],
+        shas,
+        SERVER,
+        marker,
+        resolved=resolved_thread_roots(repo, number, token),
     )
     for problem in problems:
         print(f"::error::{problem}")

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -254,6 +254,60 @@ def test_a_reply_from_someone_else_does_not_answer():
     )
 
 
+def test_resolved_thread_is_off_the_worklist():
+    """The reviewer's resolution exempts a thread, answered or not."""
+    threads = [thread("pando-genet")]
+    assert (
+        gate.review_violations(
+            threads,
+            "pando-ramet",
+            SHAS,
+            "https://github.com",
+            "No commit:",
+            resolved={1},
+        )
+        == []
+    )
+    # And an unrelated resolved id exempts nothing.
+    assert gate.review_violations(
+        threads,
+        "pando-ramet",
+        SHAS,
+        "https://github.com",
+        "No commit:",
+        resolved={999},
+    )
+
+
+def test_violation_names_the_exact_thread():
+    """The reader is the agent deciding what to do next, so the message
+    carries the quote and the URL that identify the thread."""
+    comments = [
+        {
+            "id": 1,
+            "user": {"login": "pando-genet"},
+            "body": "Should we add a requirement here?",
+            "path": "derived/writing-skills/SKILL.md",
+            "html_url": "https://github.com/o/r/pull/30#discussion_r1",
+        }
+    ]
+    [problem] = gate.review_violations(
+        [comments], "pando-ramet", SHAS, "https://github.com", "No commit:"
+    )
+    assert '"Should we add a requirement here?"' in problem
+    assert "https://github.com/o/r/pull/30#discussion_r1" in problem
+    assert "resolves the thread" in problem
+
+
+def test_resolved_roots_reads_graphql_nodes():
+    nodes = [
+        {"isResolved": True, "comments": {"nodes": [{"databaseId": 11}]}},
+        {"isResolved": False, "comments": {"nodes": [{"databaseId": 22}]}},
+        {"isResolved": True, "comments": {"nodes": []}},
+    ]
+    assert gate.resolved_roots(nodes) == {11}
+
+
 def test_threads_group_by_root():
     comments = [
         {"id": 1, "user": {"login": "a"}, "body": "x", "path": "f"},


### PR DESCRIPTION
CLOSES #166.

Ruled by the principal after the gate blocked [skills!30](https://github.com/pandoscope/skills/pull/30): the check exists to tell the **agent** which threads still need addressing, so it changes in two ways — and the ticket's original `AGENT_ACCOUNTS` proposal is deliberately not implemented, superseded by this framing (accounts stay unsplit today, so any account list would have misconfigured heartbeat check 14; measured on the `review-gate-agent-identity` thread).

**Resolution exempts.** A thread the reviewer resolved is off the worklist whether or not a qualifying reply exists — resolution is the reviewer's own sign-off that nothing more is needed. The old behavior ("resolving a thread is not answering it; this never reads resolution") demanded a reply that, on a PR authored by a rotated agent account, *nobody could write* — which pressed toward false `No commit:` waivers, worse than a red check. Resolution exists only in the GraphQL schema, so the file gains its second and last network door: a POST to the fixed `/graphql` path under the same scheme guard as `fetch`, with node parsing kept pure (`resolved_roots`) so tests need no network.

**Violations identify their thread.** Each message now carries the opener, path, a quote of the comment, its URL, and names both ways out:

```
unanswered review thread by pando-genet at derived/writing-skills/SKILL.md: "Should we add a requirement here?" (https://…#discussion_r1) — reply with a commit URL on this PR or a 'No commit: <why>' line, or the reviewer resolves the thread
```

All four copies (root, template, decision-memory, evidence-memory) synced byte-identical — the identity test caught the intermediate state where they were not. 35 tests, four new: resolved-exempt both directions, message contents, GraphQL node parsing.

Reaches [skills!30](https://github.com/pandoscope/skills/pull/30) via the template fan-out; until skills consumes the release, that PR stays gated by its old copy.

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_