### PR TITLE
feat(ci): re-run the gate when a review is re-requested

### DIFF
--- a/.github/workflows/ci-ok.yml
+++ b/.github/workflows/ci-ok.yml
@@ -9,11 +9,19 @@
 #
 # Label, body and review events re-run only THIS workflow — the gate
 # re-judges without re-running the test matrix.
+#
+# Re-requesting a review re-runs the gate too (#168). That is the path
+# for a reviewer who RESOLVED threads rather than replying: resolution
+# emits no Actions event at all — `pull_request_review_thread` is an
+# App-only webhook — and a job re-run reuses the merge commit from the
+# original run, so it re-judges the old base with the old gate. A
+# fresh event is the only thing that recomputes the merge ref.
 name: CI gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled,
+            review_requested, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:

--- a/decision-memory/.github/workflows/ci-ok.yml.jinja
+++ b/decision-memory/.github/workflows/ci-ok.yml.jinja
@@ -13,11 +13,19 @@
 #
 # Label, body and review events re-run only THIS workflow — the gate
 # re-judges without re-running the test matrix.
+#
+# Re-requesting a review re-runs the gate too (#168). That is the path
+# for a reviewer who RESOLVED threads rather than replying: resolution
+# emits no Actions event at all — `pull_request_review_thread` is an
+# App-only webhook — and a job re-run reuses the merge commit from the
+# original run, so it re-judges the old base with the old gate. A
+# fresh event is the only thing that recomputes the merge ref.
 name: CI gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled,
+            review_requested, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:

--- a/evidence-memory/.github/workflows/ci-ok.yml.jinja
+++ b/evidence-memory/.github/workflows/ci-ok.yml.jinja
@@ -13,11 +13,19 @@
 #
 # Label, body and review events re-run only THIS workflow — the gate
 # re-judges without re-running the test matrix.
+#
+# Re-requesting a review re-runs the gate too (#168). That is the path
+# for a reviewer who RESOLVED threads rather than replying: resolution
+# emits no Actions event at all — `pull_request_review_thread` is an
+# App-only webhook — and a job re-run reuses the merge commit from the
+# original run, so it re-judges the old base with the old gate. A
+# fresh event is the only thing that recomputes the merge ref.
 name: CI gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled,
+            review_requested, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -11,11 +11,19 @@
 #
 # Label, body and review events re-run only THIS workflow — the gate
 # re-judges without re-running the test matrix.
+#
+# Re-requesting a review re-runs the gate too (#168). That is the path
+# for a reviewer who RESOLVED threads rather than replying: resolution
+# emits no Actions event at all — `pull_request_review_thread` is an
+# App-only webhook — and a job re-run reuses the merge commit from the
+# original run, so it re-judges the old base with the old gate. A
+# fresh event is the only thing that recomputes the merge ref.
 name: CI gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled,
+            review_requested, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:


### PR DESCRIPTION
CLOSES #168

Two commits: `74a2204` changes the template source and both store
subtemplates, `07c26b4` restamps the root, per the self-application
route (#130).

## The gap this closes

The reviews gate now exempts resolved threads (#167). But nothing tells
CI a thread was resolved, so the exemption could not fire on its own.
Measured on pandoscope/skills#30 today: the reviewer resolved both
violating threads and the gate stayed red, because the newest run
predated the resolutions.

Two independent facts, both verified rather than assumed:

- **Resolution is not an Actions event.** GitHub's
  `pull_request_review_thread` webhook (`resolved`/`unresolved`) is
  App-only. It is absent from the Actions events reference, and
  `actionlint` rejects it as an unknown webhook event — identically to
  an invented event name used as a control.
- **A job re-run cannot substitute.** Re-running reuses the merge
  commit computed for the original run, so it re-judges the old base
  with the old gate. A re-run of skills run 31890585373 emitted the
  pre-#166 error text after the fix had already merged into that
  repo's main.

Replying to a thread was always covered: that is a
`pull_request_review_comment` / `created`, already subscribed.

## The change

`review_requested` and `ready_for_review` join `ci-ok`'s
`pull_request` activity types. The re-request-review button becomes the
signal, which is what it already means to a reviewer — and because it
is a fresh event rather than a re-run, the PR merge ref is recomputed
and the run judges the current base with the current gate.

The header comment now carries the reasoning, so the next reader does
not re-derive why resolution itself is absent from the list.

Not proposed: a GitHub App receiving the webhook and calling
`repository_dispatch` — a service to replace one click.

## Verification

`actionlint` and `yamllint` pass on the rendered workflow;
`review_requested` and `ready_for_review` were both confirmed valid
activity types before use. 268 tests pass, 3 skipped. The route guard
confirms no commit mixes source and stamp.


---
_Generated by [Claude Code](https://claude.ai/code/session_015EAmu4EbQ2s3nw4Q1aNVWz)_