### PR TITLE
feat: agentic_actions_runner copier answer (Blacksmith runners)

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -80,6 +80,15 @@ agentic_precommit:
   default: prek
   when: "{{ agentic_subtemplate == 'template' }}"
 
+agentic_actions_runner:
+  type: str
+  help: >-
+    runs-on label for every rendered GitHub Actions workflow. The default
+    stays ubuntu-latest because a third-party label (e.g.
+    blacksmith-2vcpu-ubuntu-2204) makes jobs queue forever on a repo
+    without that runner provider's app installed.
+  default: "ubuntu-latest"
+
 agentic_tracker_cli:
   type: str
   help: "Tracker CLI agents must use for repository interaction (issues/PRs/CI)."

--- a/decision-memory/.github/workflows/ci-ok.yml.jinja
+++ b/decision-memory/.github/workflows/ci-ok.yml.jinja
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   review-answers:
     name: "review answers"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -60,7 +60,7 @@ jobs:
 
   ci-ok:
     name: "ci-ok"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/decision-memory/.github/workflows/guards.yml.jinja
+++ b/decision-memory/.github/workflows/guards.yml.jinja
@@ -10,7 +10,7 @@ on:
 
 jobs:
   guards:
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
-      - run: python .github/guards/guards.py --base "${{ github.event.pull_request.base.sha }}"
+      - run: python .github/guards/guards.py --base "{% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}"

--- a/decision-memory/.github/workflows/preferences-budget.yml.jinja
+++ b/decision-memory/.github/workflows/preferences-budget.yml.jinja
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   budget:
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -38,11 +38,11 @@ jobs:
 
       - name: Sync the compression-due issue
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          LEVEL: ${{ steps.budget.outputs.level }}
-          PERCENT: ${{ steps.budget.outputs.percent }}
-          SHA: ${{ github.sha }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
+          LEVEL: {% raw %}${{ steps.budget.outputs.level }}{% endraw %}
+          PERCENT: {% raw %}${{ steps.budget.outputs.percent }}{% endraw %}
+          SHA: {% raw %}${{ github.sha }}{% endraw %}
         run: |
           set -euo pipefail
           label="$(python -c "import json;print(json.load(open('store.config.json'))['budget_issue_label'])")"

--- a/decision-memory/.github/workflows/preferences-guard.yml.jinja
+++ b/decision-memory/.github/workflows/preferences-guard.yml.jinja
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   preference-guards:
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -36,9 +36,9 @@ jobs:
         env:
           # Via env, never inline in the script: the PR description is
           # attacker-controlled text.
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY: {% raw %}${{ github.event.pull_request.body }}{% endraw %}
+          PR_LABELS: {% raw %}${{ join(github.event.pull_request.labels.*.name, ',') }}{% endraw %}
+          BASE_SHA: {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}
         run: |
           printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
           python .github/store/preferences_guard.py \

--- a/decision-memory/.github/workflows/template-update.yml.jinja
+++ b/decision-memory/.github/workflows/template-update.yml.jinja
@@ -33,7 +33,7 @@ jobs:
   # update job is about to fix.
   audit:
     name: "template drift audit"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     permissions:
       contents: read
       pull-requests: read
@@ -43,8 +43,8 @@ jobs:
       - name: Report — is this repo actually on the latest template?
         id: report
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -84,7 +84,7 @@ jobs:
 
   update:
     name: "copier update (agentic template)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       # Named refusal before the octokit stack trace (#134): on GitHub
       # Free, org variables and secrets do not reach private repos, and
@@ -92,8 +92,8 @@ jobs:
       # The audit job above still reports drift on the default token.
       - name: Refuse without release-bot credentials, naming the gap
         env:
-          HAS_ID: ${{ vars.RELEASE_BOT_CLIENT_ID != '' }}
-          HAS_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
+          HAS_ID: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID != '' }}{% endraw %}
+          HAS_KEY: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}{% endraw %}
         run: |
           set -euo pipefail
           if [ "$HAS_ID" != "true" ] || [ "$HAS_KEY" != "true" ]; then
@@ -107,13 +107,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Push the update branch as the app so the resulting PR runs CI.
-          token: ${{ steps.app-token.outputs.token }}
+          token: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           fetch-depth: 0
 
       # An open update PR for the CURRENT release is genuine dedupe. A
@@ -125,8 +125,8 @@ jobs:
       - name: Skip on a current update PR, join a stale one
         id: dedupe
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -189,11 +189,11 @@ jobs:
       - name: Open update PR, or land the commit on the joined one
         if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OLD_REF: ${{ steps.update.outputs.old_ref }}
-          NEW_REF: ${{ steps.update.outputs.new_ref }}
-          EXISTING_BRANCH: ${{ steps.dedupe.outputs.existing_branch }}
-          EXISTING_PR: ${{ steps.dedupe.outputs.existing_pr }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          OLD_REF: {% raw %}${{ steps.update.outputs.old_ref }}{% endraw %}
+          NEW_REF: {% raw %}${{ steps.update.outputs.new_ref }}{% endraw %}
+          EXISTING_BRANCH: {% raw %}${{ steps.dedupe.outputs.existing_branch }}{% endraw %}
+          EXISTING_PR: {% raw %}${{ steps.dedupe.outputs.existing_pr }}{% endraw %}
         run: |
           set -euo pipefail
           branch="${EXISTING_BRANCH:-chore/template-update-$NEW_REF}"

--- a/decision-memory/.github/workflows/ticket-closed.yml.jinja
+++ b/decision-memory/.github/workflows/ticket-closed.yml.jinja
@@ -12,23 +12,23 @@ on:
 permissions: {}
 
 concurrency:
-  group: ticket-closed-${{ github.event.issue.number }}
+  group: ticket-closed-{% raw %}${{ github.event.issue.number }}{% endraw %}
 
 jobs:
   dispatch:
     name: "tell the store"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Repos in an org without a session-memory store show this SKIPPED
     # rather than green. The variable carries owner/repo, set once at
     # org level — deliberately not baked in at stamping time, so the
     # rendered file names no org's store and a store move is one
     # variable edit, not a re-stamp of every repo.
-    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    if: {% raw %}${{ vars.SESSION_MEMORY_REPO != '' }}{% endraw %}
     steps:
       - name: Name the store's repository
         id: store
         env:
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
         run: |
           set -euo pipefail
           echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
@@ -43,15 +43,15 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.store.outputs.name }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+          repositories: {% raw %}${{ steps.store.outputs.name }}{% endraw %}
 
       - env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
-          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
+          TICKET: {% raw %}${{ github.repository }}{% endraw %}#{% raw %}${{ github.event.issue.number }}{% endraw %}
         run: |
           set -euo pipefail
           # The payload carries only the ticket's name. The store

--- a/evidence-memory/.github/workflows/ci-ok.yml.jinja
+++ b/evidence-memory/.github/workflows/ci-ok.yml.jinja
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   review-answers:
     name: "review answers"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -60,7 +60,7 @@ jobs:
 
   ci-ok:
     name: "ci-ok"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/evidence-memory/.github/workflows/guards.yml.jinja
+++ b/evidence-memory/.github/workflows/guards.yml.jinja
@@ -12,7 +12,7 @@ on:
 
 jobs:
   guards:
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
-      - run: python .github/guards/guards.py --base "${{ github.event.pull_request.base.sha }}"
+      - run: python .github/guards/guards.py --base "{% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}"

--- a/evidence-memory/.github/workflows/labels.yml.jinja
+++ b/evidence-memory/.github/workflows/labels.yml.jinja
@@ -1,5 +1,10 @@
 name: Sync labels
 
+# Copier-vendored from the agentic-engineering-template evidence
+# subtemplate. The tier-2 gate (agentic-engineering-template#103) selects
+# on these labels, so they have to exist before that gate is mechanical
+# rather than conventional.
+
 on:
   push:
     branches:
@@ -13,16 +18,16 @@ on:
 permissions: {}
 
 concurrency:
-  group: labels-${{ github.ref }}
+  group: labels-{% raw %}${{ github.ref }}{% endraw %}
 
 jobs:
   sync:
     name: "labels sync"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Opt-in per repo. A repo that never sets the variable shows this job
     # as SKIPPED, which is visibly different from a green run — an absent
     # sync must never be indistinguishable from a successful one.
-    if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    if: {% raw %}${{ vars.LABELS_SYNC_ENABLED == 'true' }}{% endraw %}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -34,7 +39,7 @@ jobs:
         env:
           # Needs a PAT with `repo` scope: the default GITHUB_TOKEN cannot
           # manage labels across an org from a shared config.
-          LABELS_TOKEN: ${{ secrets.LABELS_TOKEN }}
+          LABELS_TOKEN: {% raw %}${{ secrets.LABELS_TOKEN }}{% endraw %}
         run: |
           set -euo pipefail
           if [ -z "${LABELS_TOKEN:-}" ]; then
@@ -42,7 +47,7 @@ jobs:
             exit 1
           fi
           pip install labels
-          labels -u "${{ github.repository_owner }}" -t "$LABELS_TOKEN" \
-            sync -o "${{ github.repository_owner }}" \
-                 -r "${{ github.event.repository.name }}" \
+          labels -u "{% raw %}${{ github.repository_owner }}{% endraw %}" -t "$LABELS_TOKEN" \
+            sync -o "{% raw %}${{ github.repository_owner }}{% endraw %}" \
+                 -r "{% raw %}${{ github.event.repository.name }}{% endraw %}" \
                  -f .github/labels.toml

--- a/evidence-memory/.github/workflows/template-update.yml.jinja
+++ b/evidence-memory/.github/workflows/template-update.yml.jinja
@@ -33,7 +33,7 @@ jobs:
   # update job is about to fix.
   audit:
     name: "template drift audit"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     permissions:
       contents: read
       pull-requests: read
@@ -43,8 +43,8 @@ jobs:
       - name: Report — is this repo actually on the latest template?
         id: report
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -84,7 +84,7 @@ jobs:
 
   update:
     name: "copier update (agentic template)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       # Named refusal before the octokit stack trace (#134): on GitHub
       # Free, org variables and secrets do not reach private repos, and
@@ -92,8 +92,8 @@ jobs:
       # The audit job above still reports drift on the default token.
       - name: Refuse without release-bot credentials, naming the gap
         env:
-          HAS_ID: ${{ vars.RELEASE_BOT_CLIENT_ID != '' }}
-          HAS_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
+          HAS_ID: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID != '' }}{% endraw %}
+          HAS_KEY: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}{% endraw %}
         run: |
           set -euo pipefail
           if [ "$HAS_ID" != "true" ] || [ "$HAS_KEY" != "true" ]; then
@@ -107,13 +107,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Push the update branch as the app so the resulting PR runs CI.
-          token: ${{ steps.app-token.outputs.token }}
+          token: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           fetch-depth: 0
 
       # An open update PR for the CURRENT release is genuine dedupe. A
@@ -125,8 +125,8 @@ jobs:
       - name: Skip on a current update PR, join a stale one
         id: dedupe
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -189,11 +189,11 @@ jobs:
       - name: Open update PR, or land the commit on the joined one
         if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OLD_REF: ${{ steps.update.outputs.old_ref }}
-          NEW_REF: ${{ steps.update.outputs.new_ref }}
-          EXISTING_BRANCH: ${{ steps.dedupe.outputs.existing_branch }}
-          EXISTING_PR: ${{ steps.dedupe.outputs.existing_pr }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          OLD_REF: {% raw %}${{ steps.update.outputs.old_ref }}{% endraw %}
+          NEW_REF: {% raw %}${{ steps.update.outputs.new_ref }}{% endraw %}
+          EXISTING_BRANCH: {% raw %}${{ steps.dedupe.outputs.existing_branch }}{% endraw %}
+          EXISTING_PR: {% raw %}${{ steps.dedupe.outputs.existing_pr }}{% endraw %}
         run: |
           set -euo pipefail
           branch="${EXISTING_BRANCH:-chore/template-update-$NEW_REF}"

--- a/evidence-memory/.github/workflows/ticket-closed.yml.jinja
+++ b/evidence-memory/.github/workflows/ticket-closed.yml.jinja
@@ -12,23 +12,23 @@ on:
 permissions: {}
 
 concurrency:
-  group: ticket-closed-${{ github.event.issue.number }}
+  group: ticket-closed-{% raw %}${{ github.event.issue.number }}{% endraw %}
 
 jobs:
   dispatch:
     name: "tell the store"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Repos in an org without a session-memory store show this SKIPPED
     # rather than green. The variable carries owner/repo, set once at
     # org level — deliberately not baked in at stamping time, so the
     # rendered file names no org's store and a store move is one
     # variable edit, not a re-stamp of every repo.
-    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    if: {% raw %}${{ vars.SESSION_MEMORY_REPO != '' }}{% endraw %}
     steps:
       - name: Name the store's repository
         id: store
         env:
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
         run: |
           set -euo pipefail
           echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
@@ -43,15 +43,15 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.store.outputs.name }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+          repositories: {% raw %}${{ steps.store.outputs.name }}{% endraw %}
 
       - env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
-          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
+          TICKET: {% raw %}${{ github.repository }}{% endraw %}#{% raw %}${{ github.event.issue.number }}{% endraw %}
         run: |
           set -euo pipefail
           # The payload carries only the ticket's name. The store

--- a/session-memory/.github/workflows/close-loop.yml.jinja
+++ b/session-memory/.github/workflows/close-loop.yml.jinja
@@ -41,20 +41,20 @@ concurrency:
 jobs:
   reconcile:
     name: "closed ticket -> completed thread"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Fetch the recorder
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
         run: |
           set -euo pipefail
           # The tool lives with the skill, not with the data — one
           # source, and this store never carries a second copy to
           # drift from it.
           git clone --depth 1 --filter=blob:none --sparse \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository_owner }}/skills.git" \
+            "https://x-access-token:${GH_TOKEN}@github.com/{% raw %}${{ github.repository_owner }}{% endraw %}/skills.git" \
             /tmp/skills
           git -C /tmp/skills sparse-checkout set original/thread-ledger
 
@@ -71,16 +71,16 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
 
       - name: Ask each live thread's ticket whether it is closed
         env:
           # Tickets the token cannot read are reported below rather
           # than skipped: a reconciler that goes quiet about what it
           # did not check reads exactly like one that found nothing.
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token || github.token }}{% endraw %}
         run: |
           set -euo pipefail
           node /tmp/skills/original/thread-ledger/ledger.mjs --root . state > /tmp/state.json
@@ -128,7 +128,7 @@ jobs:
 
       - name: Append the terminal events and commit them
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
         run: |
           set -euo pipefail
           ledger() { node /tmp/skills/original/thread-ledger/ledger.mjs --root . "$@"; }

--- a/session-memory/.github/workflows/ledger-guard.yml.jinja
+++ b/session-memory/.github/workflows/ledger-guard.yml.jinja
@@ -13,7 +13,7 @@ permissions:
 jobs:
   guard:
     name: "append-only + fold"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -23,15 +23,15 @@ jobs:
 
       - name: Fetch the guard
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
         run: |
           set -euo pipefail
           # The tool lives with the skill, not with the data — one
           # source, and this store never carries a second copy to
-          # drift from it. `<owner>/skills` is the convention for
+          # drift from it. `owner/skills` is the convention for
           # where the thread-ledger skill lives.
           git clone --depth 1 --filter=blob:none --sparse \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository_owner }}/skills.git" \
+            "https://x-access-token:${GH_TOKEN}@github.com/{% raw %}${{ github.repository_owner }}{% endraw %}/skills.git" \
             /tmp/skills
           git -C /tmp/skills sparse-checkout set original/thread-ledger
 
@@ -46,8 +46,8 @@ jobs:
           # is finally judged (skills#78). A red run here means the
           # store's history needs a human: the repair is re-appending,
           # never rewriting.
-          before="${{ github.event.before }}"
-          after="${{ github.event.after }}"
+          before="{% raw %}${{ github.event.before }}{% endraw %}"
+          after="{% raw %}${{ github.event.after }}{% endraw %}"
           if [ "$before" = "0000000000000000000000000000000000000000" ]; then
             # A new branch has no before; judge the tip commit alone,
             # unless it is the very first commit and there is nothing

--- a/session-memory/.github/workflows/render-ledger.yml
+++ b/session-memory/.github/workflows/render-ledger.yml
@@ -1,13 +1,10 @@
 name: Render ledger
 
+# On-demand only. Rendering on every ledger push billed a minimum
+# minute per append while the principal read the local heartbeat
+# render (LEDGER_RENDER_PATH) instead; LEDGER.md may therefore lag
+# the log until the next dispatch.
 on:
-  push:
-    branches: [main]
-    paths:
-      # Only the sources. LEDGER.md is the OUTPUT and is deliberately
-      # absent here, so the commit this job makes cannot retrigger it.
-      - "ledger/**"
-      - "repo-codes.json"
   workflow_dispatch:
 
 permissions:

--- a/session-memory/.github/workflows/render-ledger.yml.jinja
+++ b/session-memory/.github/workflows/render-ledger.yml.jinja
@@ -17,21 +17,21 @@ concurrency:
 jobs:
   render:
     name: "LEDGER.md"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Fetch the renderer
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
         run: |
           set -euo pipefail
           # The tool lives with the skill, not with the data — one
           # source, and this store never carries a second copy to
-          # drift from it. `<owner>/skills` is the convention for
+          # drift from it. `owner/skills` is the convention for
           # where the thread-ledger skill lives.
           git clone --depth 1 --filter=blob:none --sparse \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository_owner }}/skills.git" \
+            "https://x-access-token:${GH_TOKEN}@github.com/{% raw %}${{ github.repository_owner }}{% endraw %}/skills.git" \
             /tmp/skills
           git -C /tmp/skills sparse-checkout set original/thread-ledger
 
@@ -44,11 +44,11 @@ jobs:
           node /tmp/skills/original/thread-ledger/ledger.mjs \
             --root . \
             render --format md --out LEDGER.md \
-            --title "${{ github.repository_owner }} — thread ledger"
+            --title "{% raw %}${{ github.repository_owner }}{% endraw %} — thread ledger"
 
       - name: Commit when it changed
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
         run: |
           set -euo pipefail
           # The commit is created through the API, not the git CLI:
@@ -84,7 +84,7 @@ jobs:
             node /tmp/skills/original/thread-ledger/ledger.mjs \
               --root . \
               render --format md --out LEDGER.md \
-              --title "${{ github.repository_owner }} — thread ledger"
+              --title "{% raw %}${{ github.repository_owner }}{% endraw %} — thread ledger"
           done
           echo "::error::could not commit LEDGER.md after 3 attempts"
           exit 1

--- a/session-memory/.github/workflows/template-update.yml.jinja
+++ b/session-memory/.github/workflows/template-update.yml.jinja
@@ -33,7 +33,7 @@ jobs:
   # update job is about to fix.
   audit:
     name: "template drift audit"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     permissions:
       contents: read
       pull-requests: read
@@ -43,8 +43,8 @@ jobs:
       - name: Report — is this repo actually on the latest template?
         id: report
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -84,7 +84,7 @@ jobs:
 
   update:
     name: "copier update (agentic template)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       # Named refusal before the octokit stack trace (#134): on GitHub
       # Free, org variables and secrets do not reach private repos, and
@@ -92,8 +92,8 @@ jobs:
       # The audit job above still reports drift on the default token.
       - name: Refuse without release-bot credentials, naming the gap
         env:
-          HAS_ID: ${{ vars.RELEASE_BOT_CLIENT_ID != '' }}
-          HAS_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
+          HAS_ID: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID != '' }}{% endraw %}
+          HAS_KEY: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}{% endraw %}
         run: |
           set -euo pipefail
           if [ "$HAS_ID" != "true" ] || [ "$HAS_KEY" != "true" ]; then
@@ -107,13 +107,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Push the update branch as the app so the resulting PR runs CI.
-          token: ${{ steps.app-token.outputs.token }}
+          token: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           fetch-depth: 0
 
       # An open update PR for the CURRENT release is genuine dedupe. A
@@ -125,8 +125,8 @@ jobs:
       - name: Skip on a current update PR, join a stale one
         id: dedupe
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -189,11 +189,11 @@ jobs:
       - name: Open update PR, or land the commit on the joined one
         if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OLD_REF: ${{ steps.update.outputs.old_ref }}
-          NEW_REF: ${{ steps.update.outputs.new_ref }}
-          EXISTING_BRANCH: ${{ steps.dedupe.outputs.existing_branch }}
-          EXISTING_PR: ${{ steps.dedupe.outputs.existing_pr }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          OLD_REF: {% raw %}${{ steps.update.outputs.old_ref }}{% endraw %}
+          NEW_REF: {% raw %}${{ steps.update.outputs.new_ref }}{% endraw %}
+          EXISTING_BRANCH: {% raw %}${{ steps.dedupe.outputs.existing_branch }}{% endraw %}
+          EXISTING_PR: {% raw %}${{ steps.dedupe.outputs.existing_pr }}{% endraw %}
         run: |
           set -euo pipefail
           branch="${EXISTING_BRANCH:-chore/template-update-$NEW_REF}"

--- a/session-memory/.github/workflows/ticket-closed.yml.jinja
+++ b/session-memory/.github/workflows/ticket-closed.yml.jinja
@@ -12,23 +12,23 @@ on:
 permissions: {}
 
 concurrency:
-  group: ticket-closed-${{ github.event.issue.number }}
+  group: ticket-closed-{% raw %}${{ github.event.issue.number }}{% endraw %}
 
 jobs:
   dispatch:
     name: "tell the store"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Repos in an org without a session-memory store show this SKIPPED
     # rather than green. The variable carries owner/repo, set once at
     # org level — deliberately not baked in at stamping time, so the
     # rendered file names no org's store and a store move is one
     # variable edit, not a re-stamp of every repo.
-    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    if: {% raw %}${{ vars.SESSION_MEMORY_REPO != '' }}{% endraw %}
     steps:
       - name: Name the store's repository
         id: store
         env:
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
         run: |
           set -euo pipefail
           echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
@@ -43,15 +43,15 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.store.outputs.name }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+          repositories: {% raw %}${{ steps.store.outputs.name }}{% endraw %}
 
       - env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
-          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
+          TICKET: {% raw %}${{ github.repository }}{% endraw %}#{% raw %}${{ github.event.issue.number }}{% endraw %}
         run: |
           set -euo pipefail
           # The payload carries only the ticket's name. The store

--- a/session-memory/README.md
+++ b/session-memory/README.md
@@ -37,9 +37,10 @@ rejects an entry that claims neither.
   no conversation to link to.
 - `transcripts/<session-id>/` — exported conversation text.
 - `LEDGER.md` — the folded state as markdown. Rendered, not written:
-  `.github/workflows/render-ledger.yml` regenerates it on every push
-  that touches the sources, so edits to it are overwritten on the next
-  push.
+  `.github/workflows/render-ledger.yml` regenerates it on manual
+  dispatch only, so it may lag the log; the fresh view is the local
+  heartbeat render (`LEDGER_RENDER_PATH`). Edits to it are overwritten
+  on the next dispatch.
 - `repo-codes.json` — short codes for ticket prefixes in the rendered
   view. Seeded once and store-owned, because the template ships no
   org's names; an unmapped repo renders under its own name, so a

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/add-to-project.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/add-to-project.yml.jinja
@@ -13,23 +13,23 @@ on:
 permissions: {}
 
 concurrency:
-  group: add-to-project-${{ github.event.number || github.event.issue.number }}
+  group: add-to-project-{% raw %}${{ github.event.number || github.event.issue.number }}{% endraw %}
 
 jobs:
   add:
     name: "add to board"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # GitHub's built-in auto-add workflow is plan-limited to a single
     # repository, so the board is populated from here instead. Repos that
     # set no board URL show this job as SKIPPED rather than green.
-    if: ${{ vars.PROJECT_BOARD_URL != '' }}
+    if: {% raw %}${{ vars.PROJECT_BOARD_URL != '' }}{% endraw %}
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
-          project-url: ${{ vars.PROJECT_BOARD_URL }}
+          project-url: {% raw %}${{ vars.PROJECT_BOARD_URL }}{% endraw %}
           # An ORG-level project is outside the repo-scoped GITHUB_TOKEN's
           # reach, so this needs a PAT with organization Projects: write.
           # It expires; when it does, items stop reaching the board and the
           # only visible signal is this job going red. Do not soften that
           # into a warning.
-          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}
+          github-token: {% raw %}${{ secrets.PROJECT_BOARD_TOKEN }}{% endraw %}

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   ticket:
     name: "ticket reference"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -64,7 +64,7 @@ jobs:
 
   review-answers:
     name: "review answers"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -81,7 +81,7 @@ jobs:
 
   ci-ok:
     name: "ci-ok"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml.jinja
@@ -1,10 +1,5 @@
 name: Sync labels
 
-# Copier-vendored from the agentic-engineering-template evidence
-# subtemplate. The tier-2 gate (agentic-engineering-template#103) selects
-# on these labels, so they have to exist before that gate is mechanical
-# rather than conventional.
-
 on:
   push:
     branches:
@@ -18,16 +13,16 @@ on:
 permissions: {}
 
 concurrency:
-  group: labels-${{ github.ref }}
+  group: labels-{% raw %}${{ github.ref }}{% endraw %}
 
 jobs:
   sync:
     name: "labels sync"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Opt-in per repo. A repo that never sets the variable shows this job
     # as SKIPPED, which is visibly different from a green run — an absent
     # sync must never be indistinguishable from a successful one.
-    if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    if: {% raw %}${{ vars.LABELS_SYNC_ENABLED == 'true' }}{% endraw %}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -39,7 +34,7 @@ jobs:
         env:
           # Needs a PAT with `repo` scope: the default GITHUB_TOKEN cannot
           # manage labels across an org from a shared config.
-          LABELS_TOKEN: ${{ secrets.LABELS_TOKEN }}
+          LABELS_TOKEN: {% raw %}${{ secrets.LABELS_TOKEN }}{% endraw %}
         run: |
           set -euo pipefail
           if [ -z "${LABELS_TOKEN:-}" ]; then
@@ -47,7 +42,7 @@ jobs:
             exit 1
           fi
           pip install labels
-          labels -u "${{ github.repository_owner }}" -t "$LABELS_TOKEN" \
-            sync -o "${{ github.repository_owner }}" \
-                 -r "${{ github.event.repository.name }}" \
+          labels -u "{% raw %}${{ github.repository_owner }}{% endraw %}" -t "$LABELS_TOKEN" \
+            sync -o "{% raw %}${{ github.repository_owner }}{% endraw %}" \
+                 -r "{% raw %}${{ github.event.repository.name }}{% endraw %}" \
                  -f .github/labels.toml

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -18,7 +18,7 @@ jobs:
   # turn CI red), not the hook configuration.
   conflict-markers:
     name: "conflict markers (template updates)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -38,7 +38,7 @@ jobs:
   commitlint:
     name: "commitlint (PR commits)"
     if: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -57,7 +57,7 @@ jobs:
 
   prek:
     name: "prek (all hooks, all files)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
@@ -33,7 +33,7 @@ jobs:
   # update job is about to fix.
   audit:
     name: "template drift audit"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     permissions:
       contents: read
       pull-requests: read
@@ -43,8 +43,8 @@ jobs:
       - name: Report — is this repo actually on the latest template?
         id: report
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -84,7 +84,7 @@ jobs:
 
   update:
     name: "copier update (agentic template)"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     steps:
       # Named refusal before the octokit stack trace (#134): on GitHub
       # Free, org variables and secrets do not reach private repos, and
@@ -92,8 +92,8 @@ jobs:
       # The audit job above still reports drift on the default token.
       - name: Refuse without release-bot credentials, naming the gap
         env:
-          HAS_ID: ${{ vars.RELEASE_BOT_CLIENT_ID != '' }}
-          HAS_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
+          HAS_ID: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID != '' }}{% endraw %}
+          HAS_KEY: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY != '' }}{% endraw %}
         run: |
           set -euo pipefail
           if [ "$HAS_ID" != "true" ] || [ "$HAS_KEY" != "true" ]; then
@@ -107,13 +107,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Push the update branch as the app so the resulting PR runs CI.
-          token: ${{ steps.app-token.outputs.token }}
+          token: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           fetch-depth: 0
 
       # An open update PR for the CURRENT release is genuine dedupe. A
@@ -125,8 +125,8 @@ jobs:
       - name: Skip on a current update PR, join a stale one
         id: dedupe
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         run: |
           set -euo pipefail
           answers_file=".copier-answers.agentic.yml"
@@ -189,11 +189,11 @@ jobs:
       - name: Open update PR, or land the commit on the joined one
         if: steps.dedupe.outputs.skip == 'false' && steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OLD_REF: ${{ steps.update.outputs.old_ref }}
-          NEW_REF: ${{ steps.update.outputs.new_ref }}
-          EXISTING_BRANCH: ${{ steps.dedupe.outputs.existing_branch }}
-          EXISTING_PR: ${{ steps.dedupe.outputs.existing_pr }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          OLD_REF: {% raw %}${{ steps.update.outputs.old_ref }}{% endraw %}
+          NEW_REF: {% raw %}${{ steps.update.outputs.new_ref }}{% endraw %}
+          EXISTING_BRANCH: {% raw %}${{ steps.dedupe.outputs.existing_branch }}{% endraw %}
+          EXISTING_PR: {% raw %}${{ steps.dedupe.outputs.existing_pr }}{% endraw %}
         run: |
           set -euo pipefail
           branch="${EXISTING_BRANCH:-chore/template-update-$NEW_REF}"

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ticket-closed.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ticket-closed.yml.jinja
@@ -12,23 +12,23 @@ on:
 permissions: {}
 
 concurrency:
-  group: ticket-closed-${{ github.event.issue.number }}
+  group: ticket-closed-{% raw %}${{ github.event.issue.number }}{% endraw %}
 
 jobs:
   dispatch:
     name: "tell the store"
-    runs-on: ubuntu-latest
+    runs-on: {{ agentic_actions_runner }}
     # Repos in an org without a session-memory store show this SKIPPED
     # rather than green. The variable carries owner/repo, set once at
     # org level — deliberately not baked in at stamping time, so the
     # rendered file names no org's store and a store move is one
     # variable edit, not a re-stamp of every repo.
-    if: ${{ vars.SESSION_MEMORY_REPO != '' }}
+    if: {% raw %}${{ vars.SESSION_MEMORY_REPO != '' }}{% endraw %}
     steps:
       - name: Name the store's repository
         id: store
         env:
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
         run: |
           set -euo pipefail
           echo "name=${STORE##*/}" >> "$GITHUB_OUTPUT"
@@ -43,15 +43,15 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
-          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.store.outputs.name }}
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+          repositories: {% raw %}${{ steps.store.outputs.name }}{% endraw %}
 
       - env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STORE: ${{ vars.SESSION_MEMORY_REPO }}
-          TICKET: ${{ github.repository }}#${{ github.event.issue.number }}
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          STORE: {% raw %}${{ vars.SESSION_MEMORY_REPO }}{% endraw %}
+          TICKET: {% raw %}${{ github.repository }}{% endraw %}#{% raw %}${{ github.event.issue.number }}{% endraw %}
         run: |
           set -euo pipefail
           # The payload carries only the ticket's name. The store

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -54,7 +54,7 @@ STORE_FILES = frozenset(
 SHARED_CORES = (
     "tools/record_core.py",
     ".github/guards/validator_core.py",
-    ".github/workflows/template-update.yml",
+    ".github/workflows/template-update.yml.jinja",
 )
 
 validator = load_module(
@@ -368,7 +368,9 @@ def test_the_store_updater_matches_the_one_consumers_get() -> None:
         / "template"
         / "{% if agentic_forge == 'github' %}.github{% endif %}"
         / "workflows"
-        / "template-update.yml"
+        / "template-update.yml.jinja"
     ).read_bytes()
-    store = (SUBTEMPLATE / ".github" / "workflows" / "template-update.yml").read_bytes()
+    store = (
+        SUBTEMPLATE / ".github" / "workflows" / "template-update.yml.jinja"
+    ).read_bytes()
     assert store == consumer

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -161,8 +161,8 @@ def test_default_render_carries_no_store_rules(tmp_path: Path) -> None:
 # the consumer copy of a shared workflow. Managed duplication, per
 # AGENTS.md: declared here, and pinned identical by the test below.
 SHARED_WITH_CONSUMERS = (
-    ".github/workflows/template-update.yml",
-    ".github/workflows/ticket-closed.yml",
+    ".github/workflows/template-update.yml.jinja",
+    ".github/workflows/ticket-closed.yml.jinja",
 )
 
 CONSUMER_GITHUB = (
@@ -189,5 +189,7 @@ def test_every_store_reports_its_ticket_closes() -> None:
     without the sender is a hole in the loop: its closes reach the
     ledger only when somebody runs the sweep by hand."""
     for subtemplate in ("session-memory", "decision-memory", "evidence-memory"):
-        sender = PROJECT_ROOT / subtemplate / ".github/workflows/ticket-closed.yml"
+        sender = (
+            PROJECT_ROOT / subtemplate / ".github/workflows/ticket-closed.yml.jinja"
+        )
         assert sender.is_file(), f"{subtemplate} ships no ticket-close sender"


### PR DESCRIPTION
Split out of #170 as the **infrastructure half**, to merge first and fan out to the consumers before the ontology docs follow in #170.

## What

- **New copier answer `agentic_actions_runner`** (str, default `ubuntu-latest`), templated into every vendored workflow's `runs-on:` — the main scaffold and all three store subtemplates. A consumer points CI at a third-party runner (e.g. `blacksmith-2vcpu-ubuntu-2204`) via its answers file, so the next `copier update` no longer reverts the choice to `ubuntu-latest`.
- Default stays `ubuntu-latest` on purpose: an unknown runner label queues forever on any repo without that provider's app installed, so a hardcoded third-party label would hang CI for every default consumer.
- Plain `.yml` workflows become `.yml.jinja` (copier copies plain files verbatim, so the `runs-on` substitution needs the rename). GitHub Actions' own `${{ … }}` expressions are wrapped in `{% raw %}…{% endraw %}` so Jinja emits them literally — **the default render is byte-identical to before**.
- **`fix(session-memory): render LEDGER.md on dispatch only`** — the ledger render workflow drops its per-push trigger (`workflow_dispatch:` only), cutting private-repo Actions minutes; folded in here as the sibling CI-cost change.

## Why two PRs

The branch bundled the runner answer with the Pando ontology glossary work. Separating them lets this change merge and reach the four private consumers (session/decision/evidence-memory, meta) via `copier update` first; the ontology docs land in #170 (now #174) after, independent of the runner rollout.

CLOSES #172

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789749605&installation_model_id=432661&pr_number=175&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F175&signature=b3513cc76b6e579530a5fbf5fac279913f07727ba81b7d5e9ba9e25acbe4a84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->