### PR TITLE
fix(decision-memory): accept the one-time doc-field backfill migration

### DIFF
--- a/decision-memory/.github/guards/guards.py
+++ b/decision-memory/.github/guards/guards.py
@@ -151,6 +151,61 @@ def _parse_side(text: str | None, side: str) -> tuple[dict, list[str]]:
     return data, []
 
 
+# The keys a rule carried before `doc` became required, in order. A file
+# from a store that predates the field parses under no current schema, so
+# the classifier below recognizes exactly its backfill rather than reading
+# every unparsable old side as tampering.
+_PRE_DOC_RULE_KEYS = tuple(k for k in decision_validator.RULE_KEYS if k != "doc")
+
+
+def is_doc_backfill(old_text: str | None, new_text: str | None) -> bool:
+    """True when the change is exactly the one-time `doc`-field backfill.
+
+    A store crossing the release that made `doc` required converts its
+    legacy set by hand: every rule gains ``doc`` and nothing else moves.
+    The old side cannot parse under the current schema (that is the whole
+    reason it needs converting), so this reads raw JSON and accepts the
+    change only when it is precisely that migration — each pre-`doc` rule
+    reappears with ``doc`` appended as a null, its other keys, values and
+    order untouched, no rule added, removed or reordered, and the file's
+    non-rule content (the `_comment`) unchanged. Any rule already holding
+    ``doc`` must be identical on both sides. Anything else is not a
+    backfill, so a real rewrite hiding behind a schema bump stays caught.
+    """
+    try:
+        old = json.loads(old_text or "")
+        new = json.loads(new_text or "")
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        return False
+    old_rules, new_rules = old.get("rules"), new.get("rules")
+    if not isinstance(old_rules, list) or not isinstance(new_rules, list):
+        return False
+    if len(old_rules) != len(new_rules) or old_rules == new_rules:
+        return False
+    if {k: v for k, v in old.items() if k != "rules"} != {
+        k: v for k, v in new.items() if k != "rules"
+    }:
+        return False
+    for old_rule, new_rule in zip(old_rules, new_rules):
+        if not isinstance(old_rule, dict) or not isinstance(new_rule, dict):
+            return False
+        if "doc" in old_rule:
+            if old_rule != new_rule:
+                return False
+            continue
+        if tuple(old_rule) != _PRE_DOC_RULE_KEYS:
+            return False
+        if tuple(new_rule) != decision_validator.RULE_KEYS:
+            return False
+        if new_rule["doc"] is not None:
+            return False
+        if {k: new_rule[k] for k in old_rule} != old_rule:
+            return False
+    return True
+
+
 def classify_preferences_change(
     old_text: str | None, new_text: str | None, subject: str
 ) -> tuple[str, list[str]]:
@@ -158,14 +213,21 @@ def classify_preferences_change(
 
     Returns ``(kind, errors)`` with kind one of ``none`` (rules
     identical), ``addition`` (existing rules untouched), ``bump-exempt``
-    (a pref-confirm commit whose math validates), ``rewrite`` (anything
-    else touching an existing rule), or ``invalid`` (either side does
-    not parse). One classifier feeds both the commit guard and the
-    carve-out, so the two can never disagree about what a commit did.
+    (a pref-confirm commit whose math validates), ``migration`` (the
+    one-time `doc`-field backfill — see ``is_doc_backfill``), ``rewrite``
+    (anything else touching an existing rule), or ``invalid`` (either
+    side does not parse). One classifier feeds both the commit guard and
+    the carve-out, so the two can never disagree about what a commit did.
     """
     old_data, old_errors = _parse_side(old_text, "old")
     new_data, new_errors = _parse_side(new_text, "new")
     if old_errors or new_errors:
+        # The old side of the `doc` backfill predates the required key,
+        # so it cannot parse under this schema. Accept it only when the
+        # new side is valid and the change is exactly that migration;
+        # every other unparsable side stays a hard failure.
+        if not new_errors and is_doc_backfill(old_text, new_text):
+            return "migration", []
         return "invalid", old_errors + new_errors
     old_rules = old_data.get("rules", [])
     new_rules = new_data.get("rules", [])

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -443,6 +443,64 @@ class PreferencesChangeClassificationTests(unittest.TestCase):
             ("none", []),
         )
 
+    @staticmethod
+    def _pre_doc(**kwargs):
+        rule = make_rule(**kwargs)
+        del rule["doc"]
+        return rule
+
+    def test_doc_backfill_migration_is_accepted(self):
+        # A store crossing the release that made `doc` required: every
+        # rule gains doc: null by hand, nothing else moves. The old side
+        # cannot parse under this schema, yet the change is accepted.
+        old = json.dumps(
+            {"rules": [self._pre_doc(text="a."), self._pre_doc(text="b.")]}
+        )
+        new = source_text(
+            make_rule(text="a.", doc=None), make_rule(text="b.", doc=None)
+        )
+        kind, errors = guards.classify_preferences_change(
+            old, new, "chore: update agentic template"
+        )
+        self.assertEqual((kind, errors), ("migration", []))
+
+    def test_doc_backfill_of_a_partially_migrated_set(self):
+        # One rule already carries doc; the other is backfilled. Still a
+        # migration as long as the already-migrated rule is untouched.
+        old = json.dumps(
+            {"rules": [make_rule(text="a.", doc=None), self._pre_doc(text="b.")]}
+        )
+        new = source_text(
+            make_rule(text="a.", doc=None), make_rule(text="b.", doc=None)
+        )
+        kind, errors = guards.classify_preferences_change(old, new, "chore: finish it")
+        self.assertEqual((kind, errors), ("migration", []))
+
+    def test_doc_backfill_rejects_a_smuggled_counter_change(self):
+        # Adding doc AND bumping a counter is not a pure backfill, and the
+        # old side does not parse — so a rewrite hiding behind the schema
+        # bump stays a hard failure rather than sliding through.
+        old = json.dumps({"rules": [self._pre_doc(confirmed=3)]})
+        new = source_text(make_rule(confirmed=4, doc=None))
+        kind, _ = guards.classify_preferences_change(old, new, "chore: sneaky")
+        self.assertEqual(kind, "invalid")
+
+    def test_doc_backfill_rejects_inventing_provenance(self):
+        # A backfill declares absence (null); minting a doc URL for a
+        # legacy rule is a claim, not a migration.
+        old = json.dumps({"rules": [self._pre_doc()]})
+        new = source_text(make_rule(doc="https://example.com/x.md"))
+        kind, _ = guards.classify_preferences_change(old, new, "chore: invent")
+        self.assertEqual(kind, "invalid")
+
+    def test_doc_backfill_rejects_an_added_rule(self):
+        old = json.dumps({"rules": [self._pre_doc(text="a.")]})
+        new = source_text(
+            make_rule(text="a.", doc=None), make_rule(text="b.", doc=None)
+        )
+        kind, _ = guards.classify_preferences_change(old, new, "chore: plus one")
+        self.assertEqual(kind, "invalid")
+
 
 def contest_record(record_id, chosen_slot, slot_rules):
     """A record whose options cite rules — a decided contest fixture.


### PR DESCRIPTION
## Problem

v4.2.0 made `doc` a required key on every preference rule and dropped the one-shot migrate tool (73554fa), on the premise that "a store converts its legacy set by hand, the guards verify." The guard couldn't verify it.

`classify_preferences_change` runs from HEAD and parses **both** sides of a `preferences.json` change with HEAD's strict validator. The first commit to cross the `doc` boundary has a pre-`doc` parent that no longer parses, so the classifier returns `invalid` and the guard fails — for any commit arrangement, because the parent is always the pre-migration set.

Surfaced converting decision-memory (v4.1.0 → v4.3.0) for the Blacksmith runner answer: it's the one consumer in the [#172](https://github.com/pandoscope/agentic-engineering-template/issues/172) fan-out still blocked.

## Fix

A new `is_doc_backfill` recognizes exactly the one-time migration from raw JSON: each pre-`doc` rule reappears with `doc` appended as **null**, every other key/value/order untouched, no rule added/removed/reordered, and the file's non-rule content (`_comment`) unchanged; a rule that already has `doc` must be identical on both sides. When the old side fails to parse **only** for this reason and the new side is valid, the change classifies as `migration` (accepted).

Anything else stays a hard failure — a smuggled counter/text change, an invented non-null `doc`, a reorder, or an added rule — so a real rewrite cannot ride in behind the schema bump.

## Tests

Five cases added to `PreferencesChangeClassificationTests`: the accepted backfill, a partially-migrated set, and rejection of a smuggled counter change, invented provenance, and an added rule. Full subtemplate suite: 181 passed, 1 skipped. Verified end-to-end against decision-memory's real migration commit — `guards.py --base origin/main` goes from red to `All guards passed.`

FIXES #176

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789757365&installation_model_id=432661&pr_number=177&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F177&signature=e8fbbff6adcaaa3637a9c40514afd33b9160f57823635ab3d87ad56273b6953a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->