### PR TITLE
fix(decision-memory): exempt the doc-field migration from the carve-out guard

### DIFF
--- a/decision-memory/.github/store/preferences_guard.py
+++ b/decision-memory/.github/store/preferences_guard.py
@@ -101,6 +101,12 @@ def classify_pref_commits(commits: list[dict]) -> tuple[bool, list[str]]:
         if kind == "bump-exempt":
             notes.append(f"{short}: mechanical pref-confirm counter bump — exempt")
             continue
+        if kind == "migration":
+            # The one-time doc-field backfill is meaning-preserving — the
+            # commit guard already accepts it, and the two must never
+            # disagree — so it needs no carve-out label or replay report.
+            notes.append(f"{short}: one-time doc-field backfill migration — exempt")
+            continue
         required = True
         if kind == "invalid":
             notes.append(

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -702,6 +702,24 @@ class CarveOutTests(unittest.TestCase):
         self.assertFalse(required)
         self.assertTrue(any("exempt" in note for note in notes))
 
+    def test_doc_backfill_migration_needs_no_label(self):
+        # The one-time doc-field backfill is meaning-preserving: the
+        # commit guard accepts it as a migration, so the carve-out must
+        # not disagree by demanding a label or a replay report.
+        pre_doc = make_rule()
+        del pre_doc["doc"]
+        required, notes = guard.classify_pref_commits(
+            [
+                self.commit(
+                    "chore: update agentic template",
+                    old=json.dumps({"rules": [pre_doc]}),
+                    new=source_text(make_rule(doc=None)),
+                )
+            ]
+        )
+        self.assertFalse(required)
+        self.assertTrue(any("migration" in note for note in notes))
+
     def test_counter_bump_that_rewrites_the_rule_needs_the_label(self):
         required, _ = guard.classify_pref_commits(
             [


### PR DESCRIPTION
Completes [AET!177](https://github.com/pandoscope/agentic-engineering-template/pull/177). That PR taught the **commit** guard (`classify_preferences_change`) a `migration` kind for the one-time `doc: null` backfill, but left the **carve-out** guard (`preferences_guard.py`) untouched — so the two disagreed, which the classifier's docstring says must never happen. A store crossing the `doc` boundary passed `guards.py` and then failed `preferences_guard.py`:

```
GUARD FAIL: preferences.json: existing rules were rewritten without the
'preferences-carve-out' label — only a labelled compaction PR may rewrite
the active set (counter bumps via pref-confirm are exempt)
```

## Fix

`classify_pref_commits` now exempts `migration` exactly as it exempts `bump-exempt` — the backfill is meaning-preserving, so it needs no `preferences-carve-out` label and no replay report. One new `CarveOutTests` case asserts a doc-backfill commit is not carve-out-required; full subtemplate suite 182 pass, and the whole `prek run --all-files` gate is green locally (ruff, codespell, actionlint, djlint, route guard included).

Surfaced completing decision-memory's update to v4.3.1 — it's the last consumer in the [#172](https://github.com/pandoscope/agentic-engineering-template/issues/172) runner fan-out.

FIXES #178

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789766804&installation_model_id=432661&pr_number=179&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F179&signature=a0b016e1e2bed8f27769f674c874707f08e279e0ca27ea87b386fa568f799b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->