### PR TITLE
docs: forbid scheduled self check-ins in the Forge Budget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ including `AGENTS.md`.
 
 API budget per-account, shared by all sessions.
 
-- No PR subscriptions unless the principal asks.
+- No PR subscriptions and no scheduled self check-ins unless the
+  principal asks; report state when asked and stop.
 - Git before REST. Clone answers: file contents, diffs, history,
   branch state. API only for: check runs, job logs, comments,
   reviews, labels, PR/issue state.

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -15,7 +15,8 @@ including `AGENTS.md`.
 
 API budget per-account, shared by all sessions.
 
-- No PR subscriptions unless the principal asks.
+- No PR subscriptions and no scheduled self check-ins unless the
+  principal asks; report state when asked and stop.
 - Git before REST. Clone answers: file contents, diffs, history,
   branch state. API only for: check runs, job logs, comments,
   reviews, labels, PR/issue state.


### PR DESCRIPTION
Extends the Forge Budget rule "No PR subscriptions unless the principal asks" to also forbid scheduled `send_later` self check-ins:

> No PR subscriptions and no scheduled self check-ins unless the principal asks; report state when asked and stop.

The old rule covered `subscribe_pr_activity` only; the managed environment's harness separately instructs agents to arm hourly self check-ins on any PR they own, and nothing countermanded it — observed as recurring hourly API reads against the shared budget on a PR waiting for a principal-only merge.

Template-first: source commit touches `template/CLAUDE.md.jinja`, the restamp of the repo's own `CLAUDE.md` is a separate commit; route guard verified clean on the range.

Note: docs-typed, so per #180 this cuts no release and reaches consumers only via manual `copier update --vcs-ref` (or direct edits) until that gap is fixed.

CLOSES #181

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789819204&installation_model_id=432661&pr_number=182&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F182&signature=1a575d48a6e5a7280d2e2bb353b0249668fe9f81b085a51d8bb161d6d07f1a34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->