### PR TITLE
docs(glossary): Reinset — the org's tests, checks and rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ what makes them lintable here.
 - [preference set](docs/glossary/preference-set.md)
 - [principal](docs/glossary/principal.md)
 - [record contract](docs/glossary/record-contract.md)
+- [reinset](docs/glossary/reinset.md)
 - [agent session](docs/glossary/agent-session.md)
 - [session-memory](docs/glossary/session-memory.md)
 - [template stamp](docs/glossary/template-stamp.md)

--- a/docs/glossary/reinset.md
+++ b/docs/glossary/reinset.md
@@ -1,0 +1,15 @@
+## Reinset
+
+<!-- d10e: auto-prune -->
+<!-- Copier-vendored from the agentic-engineering-template — do NOT edit
+     here; change it in the template and pull via `copier update`. The
+     auto-prune marker above lets `disambiguate prune` remove this term
+     from a repo that never links it. -->
+
+The [org](org.md)'s set of reins on its agents: the tests, checks, and
+rules that govern the energy harnessed from the LLM. Where a violation
+is machine-fixable, the reinset repairs and reports rather than merely
+rejecting — it supplies the auto-formatters. A rein enters the reinset
+only on evidence — an incident that showed the need, cited beside it.
+
+_Avoid_: Gauntlet, guardrail set, harness

--- a/template/docs/glossary/reinset.md
+++ b/template/docs/glossary/reinset.md
@@ -1,0 +1,15 @@
+## Reinset
+
+<!-- d10e: auto-prune -->
+<!-- Copier-vendored from the agentic-engineering-template — do NOT edit
+     here; change it in the template and pull via `copier update`. The
+     auto-prune marker above lets `disambiguate prune` remove this term
+     from a repo that never links it. -->
+
+The [org](org.md)'s set of reins on its agents: the tests, checks, and
+rules that govern the energy harnessed from the LLM. Where a violation
+is machine-fixable, the reinset repairs and reports rather than merely
+rejecting — it supplies the auto-formatters. A rein enters the reinset
+only on evidence — an incident that showed the need, cited beside it.
+
+_Avoid_: Gauntlet, guardrail set, harness

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -34,6 +34,7 @@ COMMON_FILES = frozenset(
         "scripts/doctor.sh",
         # Shared glossary terms, stamped into every generated repo (#52).
         "docs/glossary/decision-memory.md",
+        "docs/glossary/reinset.md",
         "docs/glossary/decision-record.md",
         "docs/glossary/pando-cell.md",
         "docs/glossary/evidence-memory.md",

--- a/tests/test_shared_glossary.py
+++ b/tests/test_shared_glossary.py
@@ -26,6 +26,7 @@ SOURCE_DIR = PROJECT_ROOT / "template" / "docs" / "glossary"
 SHARED_TERMS = frozenset(
     {
         "decision-memory",
+        "reinset",
         "decision-record",
         "grilling",
         "org",


### PR DESCRIPTION
CLOSES #184.

Principal ruling: the set of tests, checks and rules Pandoscope uses to govern the energy harnessed from the LLM is the **Reinset**, not the Gauntlet.

The distinction the word carries: a gauntlet is an ordeal run once at a gate, and these checks, katas and standing rules steer continuously — the org's reins on the energy the model supplies. "Gauntlet" is listed under `_Avoid_` so the old word resolves rather than lingering as a synonym.

- `template/docs/glossary/reinset.md` — the shared set, so every stamped repo inherits the term via `copier update`.
- `docs/glossary/reinset.md` — this repo's stamped mirror, which is what makes it lintable here.
- `README.md` — added to the glossary index; the README is this repo's lint root, and without a link the term is an orphan (`disambiguate --lint` fails, as it did on the first attempt here).

The entry links [org](https://github.com/pandoscope/agentic-engineering-template/blob/main/docs/glossary/org.md) and states the evidence rule already in force in the probe skills: a rein enters the reinset only with an incident that showed the need, cited beside it.

`uvx disambiguate --lint` clean.

Obstacles/deviations: none.

Out of scope, noted on the ticket: `original/run-probe` in the skills repo still uses "gauntlet" as a trigger phrase and should gain "reinset" alongside it; the dojo tree ([skills#165](https://github.com/pandoscope/skills/issues/165)) adopts the word when that work resumes.

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790285824&installation_model_id=432661&pr_number=185&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F185&signature=78ada26c61f8ece9195dbddece1249079073f97208ed619e9fb57f7e988f97ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
