### PR TITLE
chore: declare this repo cloned in standard sessions

### DIFF
--- a/.github/workflows/notify-sessions-manifest.yml
+++ b/.github/workflows/notify-sessions-manifest.yml
@@ -1,0 +1,37 @@
+name: Notify sessions manifest
+
+# The event side of meta's regenerate-repos-manifest workflow: the
+# moment this repo's session marker changes on the default branch,
+# tell meta to regenerate environment/repos.manifest — no cron, no
+# waiting. meta re-enumerates the whole org on every dispatch, so this
+# event also prunes entries for repos that vanished since the last run.
+on:
+  push:
+    branches: [main]
+    paths: [".pandoscope-sessions"]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: "dispatch sessions-marker-changed to meta"
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Tell meta the marker changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$OWNER/meta/dispatches" \
+            -f event_type=sessions-marker-changed \
+            -f "client_payload[repo]=$REPO"

--- a/.github/workflows/notify-sessions-manifest.yml
+++ b/.github/workflows/notify-sessions-manifest.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   dispatch:
     name: "dispatch sessions-marker-changed to meta"
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Mint release-bot installation token
         id: app-token

--- a/.pandoscope-sessions
+++ b/.pandoscope-sessions
@@ -1,0 +1,1 @@
+standard


### PR DESCRIPTION
ADVANCES pandoscope/meta#99 — this repo declares itself into the session manifest that meta's ensure-repos hook clones from.

Adds the `.pandoscope-sessions` marker (`standard`) plus the `notify-sessions-manifest` workflow: a push touching the marker on the default branch dispatches meta's regenerate-repos-manifest workflow ([meta!105](https://github.com/pandoscope/meta/pull/105)) the moment it lands — event-driven, no cron. The workflow enumerates the org in Actions (the one place that's possible; the agent proxy 403s org enumeration from sessions) and commits the generated `environment/repos.manifest`. A repo controls its own membership; the manifest is a build artifact nobody hand-edits, and every dispatch also prunes repos that vanished since the last run.

Repo-root config only — nothing under `template/`, so rendered projects are untouched.