### PR TITLE
feat(ci): merge-approval gate — ci-ok requires a current human Approve review

### DIFF
--- a/.github/merge-approvers.json
+++ b/.github/merge-approvers.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Humans whose Approve review satisfies the merge-approval gate (agentic-engineering-template#187). A PR AUTHORED by one of them passes without a review — an author cannot approve their own PR, and authorship is approval by the same party. Bots never belong here.",
+  "approvers": ["pando-genet"]
+}

--- a/.github/workflows/ci-ok.yml
+++ b/.github/workflows/ci-ok.yml
@@ -77,6 +77,24 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
+  approval:
+    name: "merge approval"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # An allowlisted human's latest review must APPROVE the current
+      # head commit (stale approvals name the commit gap), or the PR is
+      # authored by an approver — authorship is approval by the same
+      # party, since GitHub forbids approving one's own PR. The
+      # `automated`-label + bot-author escape matches the ticket gate,
+      # so release and template-update PRs do not wait on a click (#187).
+      - name: A current human approval covers this head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_APPROVERS: .github/merge-approvers.json
+        run: python3 scripts/ci/check_gate.py approval
+
   ci-ok:
     name: "ci-ok"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
             --data agentic_project_name="Snake Farm"
             --data agentic_project_description="A sample."
             --data agentic_repo_owner=actions-user
+            --data agentic_merge_approvers=actions-user
           )
 
           uv run copier copy --trust --defaults --vcs-ref ci-conflict-check \

--- a/copier.yml
+++ b/copier.yml
@@ -89,6 +89,27 @@ agentic_actions_runner:
     without that runner provider's app installed.
   default: "ubuntu-latest"
 
+agentic_merge_approval_gate:
+  type: bool
+  help: >-
+    Require a current human Approve review before merge, as a ci-ok gate
+    job (agentic-engineering-template#187). A PR authored by an
+    allowlisted approver passes without a review — the author cannot
+    approve their own PR, and authorship is approval by the same party.
+  default: true
+  when: "{{ agentic_subtemplate == 'template' }}"
+
+agentic_merge_approvers:
+  type: str
+  help: >-
+    Comma-separated GitHub logins whose Approve review satisfies the
+    merge-approval gate (humans, never bots). Rendered into
+    .github/merge-approvers.json. The repo owner may be an org, so this
+    cannot be defaulted from it.
+  default: ""
+  validator: "{% if agentic_subtemplate == 'template' and agentic_merge_approval_gate and not agentic_merge_approvers %}Required while agentic_merge_approval_gate is true — name at least one human login{% endif %}"
+  when: "{{ agentic_subtemplate == 'template' and agentic_merge_approval_gate }}"
+
 agentic_tracker_cli:
   type: str
   help: "Tracker CLI agents must use for repository interaction (issues/PRs/CI)."

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """The uniform CI gate (agentic-engineering-template#137, #143).
 
-Three subcommands, one per job in ci-ok.yml:
+One subcommand per job in ci-ok.yml:
 
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
              `no_commit_marker`, or resolved by the reviewer
+  approval   an allowlisted human's latest review APPROVES the current
+             head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -435,6 +437,119 @@ def run_reviews():
     return 1 if problems else 0
 
 
+# ----------------------------------------------------------- approval
+
+
+def latest_reviews(reviews):
+    """Each reviewer's latest state-bearing review, in submission order.
+
+    COMMENTED reviews carry no verdict and are skipped; everything else
+    (APPROVED, CHANGES_REQUESTED, DISMISSED) overwrites the reviewer's
+    earlier entry — GitHub returns reviews chronologically, so the last
+    one standing is the reviewer's current word.
+    """
+    current = {}
+    for review in reviews:
+        if review.get("state") == "COMMENTED":
+            continue
+        user = (review.get("user") or {}).get("login")
+        if user:
+            current[user] = review
+    return current
+
+
+def approval_violations(reviews, approvers, author, labels, head_sha):
+    """Why the PR lacks a current human approval, and whether the
+    escape held.
+
+    The pass conditions, in order:
+    - `automated` label on a bot-authored PR — the same escape as the
+      ticket gate, so release and template-update PRs do not wait on a
+      human click (#187 records this as a deliberate hole).
+    - the PR's AUTHOR is an allowlisted approver — an author cannot
+      approve their own PR, and authorship is approval by the same
+      party.
+    - some approver's latest review is APPROVED on the current head
+      commit. An approval on an older commit is stale and named as
+      such: whatever was approved is not what would merge.
+
+    A CHANGES_REQUESTED from an approver is named explicitly — it is
+    not merely "no approval", it is a standing objection.
+    """
+    if "automated" in labels and str(author).endswith("[bot]"):
+        return [], True
+    if author in approvers:
+        return [], False
+
+    problems = []
+    stale = []
+    for user, review in latest_reviews(reviews).items():
+        if user not in approvers:
+            continue
+        state = review.get("state")
+        if state == "APPROVED":
+            if review.get("commit_id") == head_sha:
+                return [], False
+            stale.append(
+                f"approval by {user} is stale — it approved "
+                f"{str(review.get('commit_id'))[:7]}, the head is now "
+                f"{str(head_sha)[:7]}; re-approve the current state"
+            )
+        elif state == "CHANGES_REQUESTED":
+            problems.append(
+                f"{user} requested changes — address them or have the review dismissed"
+            )
+    problems.extend(stale)
+    if not problems:
+        problems.append(
+            "no approving review from an allowlisted human "
+            f"({'/'.join(sorted(approvers)) or 'none configured'}) — "
+            "an approver clicks Approve, or authors the PR"
+        )
+    return problems, False
+
+
+def approvers_config():
+    """The central approvers file — required, never defaulted (#144).
+
+    An empty list is as loud as a missing file: a gate that waved
+    through every PR because nobody was listed would read absence as
+    approval.
+    """
+    with open(os.environ["MERGE_APPROVERS"], encoding="utf-8") as handle:
+        approvers = json.load(handle)["approvers"]
+    if not approvers or not all(isinstance(a, str) and a for a in approvers):
+        raise ValueError(
+            f"{os.environ['MERGE_APPROVERS']} lists no approvers — "
+            "name at least one human login"
+        )
+    return approvers
+
+
+def run_approval():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    reviews = paginate(f"/repos/{repo}/pulls/{pr['number']}/reviews", token)
+    problems, escaped = approval_violations(
+        reviews,
+        approvers_config(),
+        pr["user"]["login"],
+        [label["name"] for label in pr.get("labels", [])],
+        pr["head"]["sha"],
+    )
+    if escaped:
+        print("automated escape: bot-authored PR carries the automated label.")
+        return 0
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("A current human approval covers this head.")
+    return 1 if problems else 0
+
+
 # ---------------------------------------------------------- aggregate
 
 
@@ -581,7 +696,12 @@ def run_aggregate():
 
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
-    runners = {"ticket": run_ticket, "reviews": run_reviews, "aggregate": run_aggregate}
+    runners = {
+        "ticket": run_ticket,
+        "reviews": run_reviews,
+        "approval": run_approval,
+        "aggregate": run_aggregate,
+    }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)
         return 2

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """The uniform CI gate (agentic-engineering-template#137, #143).
 
-Three subcommands, one per job in ci-ok.yml:
+One subcommand per job in ci-ok.yml:
 
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
              `no_commit_marker`, or resolved by the reviewer
+  approval   an allowlisted human's latest review APPROVES the current
+             head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -435,6 +437,119 @@ def run_reviews():
     return 1 if problems else 0
 
 
+# ----------------------------------------------------------- approval
+
+
+def latest_reviews(reviews):
+    """Each reviewer's latest state-bearing review, in submission order.
+
+    COMMENTED reviews carry no verdict and are skipped; everything else
+    (APPROVED, CHANGES_REQUESTED, DISMISSED) overwrites the reviewer's
+    earlier entry — GitHub returns reviews chronologically, so the last
+    one standing is the reviewer's current word.
+    """
+    current = {}
+    for review in reviews:
+        if review.get("state") == "COMMENTED":
+            continue
+        user = (review.get("user") or {}).get("login")
+        if user:
+            current[user] = review
+    return current
+
+
+def approval_violations(reviews, approvers, author, labels, head_sha):
+    """Why the PR lacks a current human approval, and whether the
+    escape held.
+
+    The pass conditions, in order:
+    - `automated` label on a bot-authored PR — the same escape as the
+      ticket gate, so release and template-update PRs do not wait on a
+      human click (#187 records this as a deliberate hole).
+    - the PR's AUTHOR is an allowlisted approver — an author cannot
+      approve their own PR, and authorship is approval by the same
+      party.
+    - some approver's latest review is APPROVED on the current head
+      commit. An approval on an older commit is stale and named as
+      such: whatever was approved is not what would merge.
+
+    A CHANGES_REQUESTED from an approver is named explicitly — it is
+    not merely "no approval", it is a standing objection.
+    """
+    if "automated" in labels and str(author).endswith("[bot]"):
+        return [], True
+    if author in approvers:
+        return [], False
+
+    problems = []
+    stale = []
+    for user, review in latest_reviews(reviews).items():
+        if user not in approvers:
+            continue
+        state = review.get("state")
+        if state == "APPROVED":
+            if review.get("commit_id") == head_sha:
+                return [], False
+            stale.append(
+                f"approval by {user} is stale — it approved "
+                f"{str(review.get('commit_id'))[:7]}, the head is now "
+                f"{str(head_sha)[:7]}; re-approve the current state"
+            )
+        elif state == "CHANGES_REQUESTED":
+            problems.append(
+                f"{user} requested changes — address them or have the review dismissed"
+            )
+    problems.extend(stale)
+    if not problems:
+        problems.append(
+            "no approving review from an allowlisted human "
+            f"({'/'.join(sorted(approvers)) or 'none configured'}) — "
+            "an approver clicks Approve, or authors the PR"
+        )
+    return problems, False
+
+
+def approvers_config():
+    """The central approvers file — required, never defaulted (#144).
+
+    An empty list is as loud as a missing file: a gate that waved
+    through every PR because nobody was listed would read absence as
+    approval.
+    """
+    with open(os.environ["MERGE_APPROVERS"], encoding="utf-8") as handle:
+        approvers = json.load(handle)["approvers"]
+    if not approvers or not all(isinstance(a, str) and a for a in approvers):
+        raise ValueError(
+            f"{os.environ['MERGE_APPROVERS']} lists no approvers — "
+            "name at least one human login"
+        )
+    return approvers
+
+
+def run_approval():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    reviews = paginate(f"/repos/{repo}/pulls/{pr['number']}/reviews", token)
+    problems, escaped = approval_violations(
+        reviews,
+        approvers_config(),
+        pr["user"]["login"],
+        [label["name"] for label in pr.get("labels", [])],
+        pr["head"]["sha"],
+    )
+    if escaped:
+        print("automated escape: bot-authored PR carries the automated label.")
+        return 0
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("A current human approval covers this head.")
+    return 1 if problems else 0
+
+
 # ---------------------------------------------------------- aggregate
 
 
@@ -581,7 +696,12 @@ def run_aggregate():
 
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
-    runners = {"ticket": run_ticket, "reviews": run_reviews, "aggregate": run_aggregate}
+    runners = {
+        "ticket": run_ticket,
+        "reviews": run_reviews,
+        "approval": run_approval,
+        "aggregate": run_aggregate,
+    }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)
         return 2

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """The uniform CI gate (agentic-engineering-template#137, #143).
 
-Three subcommands, one per job in ci-ok.yml:
+One subcommand per job in ci-ok.yml:
 
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
              `no_commit_marker`, or resolved by the reviewer
+  approval   an allowlisted human's latest review APPROVES the current
+             head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -435,6 +437,119 @@ def run_reviews():
     return 1 if problems else 0
 
 
+# ----------------------------------------------------------- approval
+
+
+def latest_reviews(reviews):
+    """Each reviewer's latest state-bearing review, in submission order.
+
+    COMMENTED reviews carry no verdict and are skipped; everything else
+    (APPROVED, CHANGES_REQUESTED, DISMISSED) overwrites the reviewer's
+    earlier entry — GitHub returns reviews chronologically, so the last
+    one standing is the reviewer's current word.
+    """
+    current = {}
+    for review in reviews:
+        if review.get("state") == "COMMENTED":
+            continue
+        user = (review.get("user") or {}).get("login")
+        if user:
+            current[user] = review
+    return current
+
+
+def approval_violations(reviews, approvers, author, labels, head_sha):
+    """Why the PR lacks a current human approval, and whether the
+    escape held.
+
+    The pass conditions, in order:
+    - `automated` label on a bot-authored PR — the same escape as the
+      ticket gate, so release and template-update PRs do not wait on a
+      human click (#187 records this as a deliberate hole).
+    - the PR's AUTHOR is an allowlisted approver — an author cannot
+      approve their own PR, and authorship is approval by the same
+      party.
+    - some approver's latest review is APPROVED on the current head
+      commit. An approval on an older commit is stale and named as
+      such: whatever was approved is not what would merge.
+
+    A CHANGES_REQUESTED from an approver is named explicitly — it is
+    not merely "no approval", it is a standing objection.
+    """
+    if "automated" in labels and str(author).endswith("[bot]"):
+        return [], True
+    if author in approvers:
+        return [], False
+
+    problems = []
+    stale = []
+    for user, review in latest_reviews(reviews).items():
+        if user not in approvers:
+            continue
+        state = review.get("state")
+        if state == "APPROVED":
+            if review.get("commit_id") == head_sha:
+                return [], False
+            stale.append(
+                f"approval by {user} is stale — it approved "
+                f"{str(review.get('commit_id'))[:7]}, the head is now "
+                f"{str(head_sha)[:7]}; re-approve the current state"
+            )
+        elif state == "CHANGES_REQUESTED":
+            problems.append(
+                f"{user} requested changes — address them or have the review dismissed"
+            )
+    problems.extend(stale)
+    if not problems:
+        problems.append(
+            "no approving review from an allowlisted human "
+            f"({'/'.join(sorted(approvers)) or 'none configured'}) — "
+            "an approver clicks Approve, or authors the PR"
+        )
+    return problems, False
+
+
+def approvers_config():
+    """The central approvers file — required, never defaulted (#144).
+
+    An empty list is as loud as a missing file: a gate that waved
+    through every PR because nobody was listed would read absence as
+    approval.
+    """
+    with open(os.environ["MERGE_APPROVERS"], encoding="utf-8") as handle:
+        approvers = json.load(handle)["approvers"]
+    if not approvers or not all(isinstance(a, str) and a for a in approvers):
+        raise ValueError(
+            f"{os.environ['MERGE_APPROVERS']} lists no approvers — "
+            "name at least one human login"
+        )
+    return approvers
+
+
+def run_approval():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    reviews = paginate(f"/repos/{repo}/pulls/{pr['number']}/reviews", token)
+    problems, escaped = approval_violations(
+        reviews,
+        approvers_config(),
+        pr["user"]["login"],
+        [label["name"] for label in pr.get("labels", [])],
+        pr["head"]["sha"],
+    )
+    if escaped:
+        print("automated escape: bot-authored PR carries the automated label.")
+        return 0
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("A current human approval covers this head.")
+    return 1 if problems else 0
+
+
 # ---------------------------------------------------------- aggregate
 
 
@@ -581,7 +696,12 @@ def run_aggregate():
 
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
-    runners = {"ticket": run_ticket, "reviews": run_reviews, "aggregate": run_aggregate}
+    runners = {
+        "ticket": run_ticket,
+        "reviews": run_reviews,
+        "approval": run_approval,
+        "aggregate": run_aggregate,
+    }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)
         return 2

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """The uniform CI gate (agentic-engineering-template#137, #143).
 
-Three subcommands, one per job in ci-ok.yml:
+One subcommand per job in ci-ok.yml:
 
   ticket     the PR names its tickets in the canonical ALL-CAPS form
   reviews    every human review thread is answered with a verified
              commit URL or a line starting with the central file's
              `no_commit_marker`, or resolved by the reviewer
+  approval   an allowlisted human's latest review APPROVES the current
+             head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
 
@@ -435,6 +437,119 @@ def run_reviews():
     return 1 if problems else 0
 
 
+# ----------------------------------------------------------- approval
+
+
+def latest_reviews(reviews):
+    """Each reviewer's latest state-bearing review, in submission order.
+
+    COMMENTED reviews carry no verdict and are skipped; everything else
+    (APPROVED, CHANGES_REQUESTED, DISMISSED) overwrites the reviewer's
+    earlier entry — GitHub returns reviews chronologically, so the last
+    one standing is the reviewer's current word.
+    """
+    current = {}
+    for review in reviews:
+        if review.get("state") == "COMMENTED":
+            continue
+        user = (review.get("user") or {}).get("login")
+        if user:
+            current[user] = review
+    return current
+
+
+def approval_violations(reviews, approvers, author, labels, head_sha):
+    """Why the PR lacks a current human approval, and whether the
+    escape held.
+
+    The pass conditions, in order:
+    - `automated` label on a bot-authored PR — the same escape as the
+      ticket gate, so release and template-update PRs do not wait on a
+      human click (#187 records this as a deliberate hole).
+    - the PR's AUTHOR is an allowlisted approver — an author cannot
+      approve their own PR, and authorship is approval by the same
+      party.
+    - some approver's latest review is APPROVED on the current head
+      commit. An approval on an older commit is stale and named as
+      such: whatever was approved is not what would merge.
+
+    A CHANGES_REQUESTED from an approver is named explicitly — it is
+    not merely "no approval", it is a standing objection.
+    """
+    if "automated" in labels and str(author).endswith("[bot]"):
+        return [], True
+    if author in approvers:
+        return [], False
+
+    problems = []
+    stale = []
+    for user, review in latest_reviews(reviews).items():
+        if user not in approvers:
+            continue
+        state = review.get("state")
+        if state == "APPROVED":
+            if review.get("commit_id") == head_sha:
+                return [], False
+            stale.append(
+                f"approval by {user} is stale — it approved "
+                f"{str(review.get('commit_id'))[:7]}, the head is now "
+                f"{str(head_sha)[:7]}; re-approve the current state"
+            )
+        elif state == "CHANGES_REQUESTED":
+            problems.append(
+                f"{user} requested changes — address them or have the review dismissed"
+            )
+    problems.extend(stale)
+    if not problems:
+        problems.append(
+            "no approving review from an allowlisted human "
+            f"({'/'.join(sorted(approvers)) or 'none configured'}) — "
+            "an approver clicks Approve, or authors the PR"
+        )
+    return problems, False
+
+
+def approvers_config():
+    """The central approvers file — required, never defaulted (#144).
+
+    An empty list is as loud as a missing file: a gate that waved
+    through every PR because nobody was listed would read absence as
+    approval.
+    """
+    with open(os.environ["MERGE_APPROVERS"], encoding="utf-8") as handle:
+        approvers = json.load(handle)["approvers"]
+    if not approvers or not all(isinstance(a, str) and a for a in approvers):
+        raise ValueError(
+            f"{os.environ['MERGE_APPROVERS']} lists no approvers — "
+            "name at least one human login"
+        )
+    return approvers
+
+
+def run_approval():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    reviews = paginate(f"/repos/{repo}/pulls/{pr['number']}/reviews", token)
+    problems, escaped = approval_violations(
+        reviews,
+        approvers_config(),
+        pr["user"]["login"],
+        [label["name"] for label in pr.get("labels", [])],
+        pr["head"]["sha"],
+    )
+    if escaped:
+        print("automated escape: bot-authored PR carries the automated label.")
+        return 0
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("A current human approval covers this head.")
+    return 1 if problems else 0
+
+
 # ---------------------------------------------------------- aggregate
 
 
@@ -581,7 +696,12 @@ def run_aggregate():
 
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
-    runners = {"ticket": run_ticket, "reviews": run_reviews, "aggregate": run_aggregate}
+    runners = {
+        "ticket": run_ticket,
+        "reviews": run_reviews,
+        "approval": run_approval,
+        "aggregate": run_aggregate,
+    }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)
         return 2

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/merge-approvers.json.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/merge-approvers.json.jinja
@@ -1,0 +1,4 @@
+{
+  "comment": "Humans whose Approve review satisfies the merge-approval gate (agentic-engineering-template#187). A PR AUTHORED by one of them passes without a review — an author cannot approve their own PR, and authorship is approval by the same party. Bots never belong here.",
+  "approvers": [{{ agentic_merge_approvers.split(',') | map('trim') | select | map('tojson') | join(', ') }}]
+}

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -79,7 +79,25 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
-  ci-ok:
+{% if agentic_merge_approval_gate %}  approval:
+    name: "merge approval"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # An allowlisted human's latest review must APPROVE the current
+      # head commit (stale approvals name the commit gap), or the PR is
+      # authored by an approver — authorship is approval by the same
+      # party, since GitHub forbids approving one's own PR. The
+      # `automated`-label + bot-author escape matches the ticket gate,
+      # so release and template-update PRs do not wait on a click (#187).
+      - name: A current human approval covers this head
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          MERGE_APPROVERS: .github/merge-approvers.json
+        run: python3 scripts/ci/check_gate.py approval
+
+{% endif %}  ci-ok:
     name: "ci-ok"
     runs-on: {{ agentic_actions_runner }}
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def base_answers() -> dict[str, str]:
         "agentic_precommit": "prek",
         "agentic_forge": "github",
         "agentic_repo_owner": "actions-user",
+        "agentic_merge_approvers": "actions-user",
     }
 
 

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -386,6 +386,83 @@ def test_own_workflow_path_is_static_never_listed():
     assert gate.own_workflow_path(ref, "o/r") == ".github/workflows/ci-ok.yml"
 
 
+# ----------------------------------------------------------- approval
+
+
+def review(user, state, commit="headsha", when=1):
+    return {"user": {"login": user}, "state": state, "commit_id": commit, "when": when}
+
+
+def test_current_approval_from_an_approver_passes():
+    problems, escaped = gate.approval_violations(
+        [review("approver", "APPROVED")], ["approver"], "bot[bot]", [], "headsha"
+    )
+    assert problems == [] and not escaped
+
+
+def test_stale_approval_names_both_commits():
+    problems, _ = gate.approval_violations(
+        [review("approver", "APPROVED", commit="oldsha1")],
+        ["approver"],
+        "x",
+        [],
+        "headsha1",
+    )
+    assert len(problems) == 1
+    assert "stale" in problems[0]
+    assert "oldsha1" in problems[0] and "headsha" in problems[0]
+
+
+def test_latest_review_wins_and_comments_do_not_overwrite():
+    reviews = [
+        review("approver", "APPROVED", commit="oldsha"),
+        review("approver", "CHANGES_REQUESTED"),
+        review("approver", "COMMENTED"),
+    ]
+    problems, _ = gate.approval_violations(reviews, ["approver"], "x", [], "headsha")
+    assert any("requested changes" in p for p in problems)
+    reviews.append(review("approver", "APPROVED"))
+    problems, _ = gate.approval_violations(reviews, ["approver"], "x", [], "headsha")
+    assert problems == []
+
+
+def test_non_approver_reviews_do_not_count():
+    problems, _ = gate.approval_violations(
+        [review("stranger", "APPROVED")], ["approver"], "x", [], "headsha"
+    )
+    assert any("no approving review" in p for p in problems)
+
+
+def test_approver_author_passes_without_a_review():
+    problems, escaped = gate.approval_violations(
+        [], ["approver"], "approver", [], "headsha"
+    )
+    assert problems == [] and not escaped
+
+
+def test_automated_escape_is_bot_only_for_approval_too():
+    _, escaped = gate.approval_violations(
+        [], ["approver"], "updater[bot]", ["automated"], "headsha"
+    )
+    assert escaped
+    problems, escaped = gate.approval_violations(
+        [], ["approver"], "human", ["automated"], "headsha"
+    )
+    assert problems and not escaped
+
+
+def test_empty_approver_list_is_loud(tmp_path, monkeypatch):
+    config = tmp_path / "merge-approvers.json"
+    config.write_text('{"approvers": []}')
+    monkeypatch.setenv("MERGE_APPROVERS", str(config))
+    try:
+        gate.approvers_config()
+    except ValueError as err:
+        assert "no approvers" in str(err)
+    else:
+        raise AssertionError("an empty approver list must refuse, not pass")
+
+
 # ------------------------------------------------- copies stay pinned
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -72,6 +72,9 @@ GITHUB_ONLY_FILES = frozenset(
         # keyword file its checks read.
         ".github/workflows/ci-ok.yml",
         ".github/reference-keywords.json",
+        # The merge-approval gate (#187): the approver allowlist its
+        # check reads.
+        ".github/merge-approvers.json",
     }
 )
 

--- a/tests/test_self_application.py
+++ b/tests/test_self_application.py
@@ -65,6 +65,7 @@ def test_repo_root_matches_the_rendered_template(tmp_path: Path) -> None:
             ),
             "agentic_project_slug": "agentic-engineering-template",
             "agentic_repo_owner": "frankify-app",
+            "agentic_merge_approvers": "pando-genet",
         },
         defaults=True,
         unsafe=True,

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -145,6 +145,7 @@ def test_default_render_carries_no_store_rules(tmp_path: Path) -> None:
             "agentic_project_description": "A consumer repo",
             "agentic_project_slug": "consumer",
             "agentic_repo_owner": "example",
+            "agentic_merge_approvers": "example",
         },
         defaults=True,
         unsafe=True,


### PR DESCRIPTION
CLOSES #187 — the parked required-approvals decision, ruled and machine-checked.

## What lands

- **`check_gate.py approval`** (new subcommand, pure `approval_violations` + `latest_reviews`): passes when an allowlisted human's latest state-bearing review is `APPROVED` **on the current head commit**. Stale approvals name both commits and ask for a re-approve; `CHANGES_REQUESTED` from an approver is reported as a standing objection. A PR **authored** by an approver passes without a review (GitHub forbids self-approval; authorship is approval by the same party — the single-human-org case). The `automated`-label + bot-author escape matches the ticket gate, so release/template-update PRs don't wait on a click.
- **`ci-ok.yml` job "merge approval"**, templated behind the new `agentic_merge_approval_gate` copier bool (default true) — rides the existing vehicle, which already re-runs on `pull_request_review: submitted/dismissed`, so an Approve click flips the gate without re-running the test matrix. The required context stays `ci-ok` alone.
- **`.github/merge-approvers.json`**, rendered from the new required `agentic_merge_approvers` question (comma-separated logins of the org's reviewing identities — `agentic_repo_owner` may be an org, so it can't default this; personal identities do not belong in repos). An empty or missing list refuses loudly (#144 philosophy).
- **Self-application**: this repo carries the job and the approvers file (seeded with the org's reviewing identity); gate-script copies stay byte-pinned to the template (pin test still enforces it).
- 7 new tests in `test_ci_gate.py`; the self-application and subtemplate renders carry the new answer.

## Exemptions, by design

- session-memory: direct pushes, no `ci-ok`, exempt by construction.
- `automated` + bot-author PRs: deliberate hole, same trust model as the ticket gate's escape.
- Repos opting out set `agentic_merge_approval_gate: false` at stamp/update time.

## Rollout

Stamped repos receive the gate via the normal template-update release; each update PR asks the new `agentic_merge_approvers` question. Until then, nothing changes in consumers. Flipping `required_approving_review_count` to 1 in the rulesets stays out of scope until GitHub enforces rulesets on these repos — the gate is the enforcement in the meantime.

**Note:** this PR runs the gate it introduces — it is bot-authored, so it needs an Approve from the configured reviewing identity before `ci-ok` goes green.

## Verification

- Full test suite green: 268 passed, 1 skipped (e2e deselected locally, runs in CI)
- Root `ci-ok.yml`/`merge-approvers.json` verified byte-identical to the render by the self-application test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa