### PR TITLE
feat(ci): auto-rerun stale red gate runs in place (gate-rerun.yml)

### DIFF
--- a/.github/workflows/gate-rerun.yml
+++ b/.github/workflows/gate-rerun.yml
@@ -1,0 +1,46 @@
+# The stale-red janitor for the CI gate (agentic-engineering-template#190).
+#
+# A re-judge event spawns a FRESH `CI gate` run; the prior red run's
+# check runs stay `failure` on the same head SHA, and required-check
+# evaluation counts that stale red over the newer green — a PR whose
+# gate is genuinely green stays unmergeable until the old run is re-run
+# IN PLACE. This workflow does exactly that, and nothing else: it waits
+# until no gate run on the head is in flight, then re-runs each
+# completed non-green gate run's failed jobs, once each.
+#
+# It never fabricates green — a rerun re-executes the gate's own jobs,
+# which judge live data, so a still-unmet condition reruns red and
+# keeps blocking. It is deliberately NOT part of ci-ok.yml: a rerun
+# queued into the `ci-ok-<pr>` concurrency group would cancel the
+# in-flight fresh run via cancel-in-progress, so this rides its own
+# group. No `synchronize` trigger, so the aggregate never awaits it.
+name: Gate rerun
+
+on:
+  pull_request:
+    types: [edited, labeled, unlabeled, review_requested, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  actions: write
+
+concurrency:
+  group: gate-rerun-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rerun:
+    name: "rerun stale gate runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Stale non-green gate runs on this head are re-run in place
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GATE_WORKFLOW: .github/workflows/ci-ok.yml
+        run: python3 scripts/ci/check_gate.py rerun

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -11,6 +11,9 @@ One subcommand per job in ci-ok.yml:
              head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
+  rerun      stale non-green gate runs on this head SHA are re-run in
+             place, so a superseded red stops blocking merge (#190) —
+             gate-rerun.yml's job, not ci-ok.yml's
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -22,6 +25,7 @@ import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.request
 
 import yaml
@@ -64,8 +68,8 @@ def graphql(query, variables, token):
     """POST one GraphQL query — the read for what REST does not expose.
 
     Review-thread resolution exists only in the GraphQL schema, so this
-    is the file's second and last network door: a POST to the fixed
-    /graphql path, under the same scheme guard as `fetch`.
+    is the file's second network door: a POST to the fixed /graphql
+    path, under the same scheme guard as `fetch`.
     """
     body = json.dumps({"query": query, "variables": variables}).encode()
     req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
@@ -83,6 +87,28 @@ def graphql(query, variables, token):
     if payload.get("errors"):
         raise RuntimeError(f"GraphQL errors: {payload['errors']}")
     return payload["data"]
+
+
+def post(path, token):
+    """POST one empty-bodied API path — the file's one write door.
+
+    Exists solely for `rerun-failed-jobs` (#190): superseding a stale
+    red check run takes a write, where everything the gate JUDGES stays
+    behind the two read doors above. Same scheme guard; returns the
+    HTTP status, since the endpoint answers 201 with no body.
+    """
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
+        data=b"",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        return response.status
 
 
 def paginate(path, token, key=None):
@@ -694,6 +720,89 @@ def run_aggregate():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- rerun
+
+
+def stale_gate_runs(runs, gate_path):
+    """Completed non-green runs of the gate workflow, oldest first.
+
+    A re-judge event spawns a FRESH gate run; the prior red run's check
+    runs stay `failure` on the same head SHA, and required-check
+    evaluation counts that stale red over the newer green (#190 —
+    observed blocking #188's merge). Only re-running the old run in
+    place supersedes its verdict. `skipped` already passes evaluation,
+    so it is not stale; anything else non-success is.
+    """
+    return [
+        run
+        for run in sorted(runs, key=lambda run: run["id"])
+        if run["path"] == gate_path
+        and run["status"] == "completed"
+        and run["conclusion"] not in ("success", "skipped")
+    ]
+
+
+def gate_busy(runs, gate_path):
+    """Is any run of the gate workflow still queued or in flight?
+
+    Re-running an old run while a fresh one is in progress queues into
+    the same `ci-ok-<pr>` concurrency group and cancel-in-progress
+    kills the fresh run — trading one stale red for another. The rerun
+    therefore waits for quiet first, which is also why it lives in its
+    own workflow with its own group.
+    """
+    return any(
+        run["path"] == gate_path and run["status"] != "completed" for run in runs
+    )
+
+
+def run_rerun():
+    """Re-run each stale red gate run once, serially, then stop.
+
+    This job SYNCS old runs with the gate's current verdict; it never
+    judges. A rerun re-executes the gate's own jobs, which read live
+    data (#159), so a red flips green only when the condition genuinely
+    holds now — a still-unmet condition reruns red and keeps blocking,
+    which is correct and not this job's failure. Hence exit 0 on every
+    orderly path; each run is attempted at most once so a legitimately
+    red gate cannot loop.
+    """
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["HEAD_SHA"]
+    gate_path = os.environ["GATE_WORKFLOW"]
+    deadline = time.monotonic() + int(os.environ.get("GATE_RERUN_TIMEOUT", "1500"))
+
+    attempted = set()
+    while True:
+        runs = paginate(
+            f"/repos/{repo}/actions/runs?head_sha={sha}", token, "workflow_runs"
+        )
+        if not gate_busy(runs, gate_path):
+            stale = [
+                run
+                for run in stale_gate_runs(runs, gate_path)
+                if run["id"] not in attempted
+            ]
+            if not stale:
+                done = f"re-ran {sorted(attempted)}" if attempted else "none found"
+                print(f"No stale non-green gate runs left on {sha} ({done}).")
+                return 0
+            run = stale[0]
+            attempted.add(run["id"])
+            print(f"re-running failed jobs of run {run['id']} ({run['conclusion']})")
+            try:
+                post(f"/repos/{repo}/actions/runs/{run['id']}/rerun-failed-jobs", token)
+            except urllib.error.HTTPError as err:
+                # E.g. a cancelled run with nothing rerunnable (409) —
+                # note it and move on; syncing must not go red itself.
+                print(f"::warning::rerun of {run['id']} refused: {err}")
+        if time.monotonic() > deadline:
+            print("::warning::gate runs still in flight at the rerun timeout.")
+            return 0
+        time.sleep(15)
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -701,6 +810,7 @@ def main():
         "reviews": run_reviews,
         "approval": run_approval,
         "aggregate": run_aggregate,
+        "rerun": run_rerun,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -11,6 +11,9 @@ One subcommand per job in ci-ok.yml:
              head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
+  rerun      stale non-green gate runs on this head SHA are re-run in
+             place, so a superseded red stops blocking merge (#190) —
+             gate-rerun.yml's job, not ci-ok.yml's
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -22,6 +25,7 @@ import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.request
 
 import yaml
@@ -64,8 +68,8 @@ def graphql(query, variables, token):
     """POST one GraphQL query — the read for what REST does not expose.
 
     Review-thread resolution exists only in the GraphQL schema, so this
-    is the file's second and last network door: a POST to the fixed
-    /graphql path, under the same scheme guard as `fetch`.
+    is the file's second network door: a POST to the fixed /graphql
+    path, under the same scheme guard as `fetch`.
     """
     body = json.dumps({"query": query, "variables": variables}).encode()
     req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
@@ -83,6 +87,28 @@ def graphql(query, variables, token):
     if payload.get("errors"):
         raise RuntimeError(f"GraphQL errors: {payload['errors']}")
     return payload["data"]
+
+
+def post(path, token):
+    """POST one empty-bodied API path — the file's one write door.
+
+    Exists solely for `rerun-failed-jobs` (#190): superseding a stale
+    red check run takes a write, where everything the gate JUDGES stays
+    behind the two read doors above. Same scheme guard; returns the
+    HTTP status, since the endpoint answers 201 with no body.
+    """
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
+        data=b"",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        return response.status
 
 
 def paginate(path, token, key=None):
@@ -694,6 +720,89 @@ def run_aggregate():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- rerun
+
+
+def stale_gate_runs(runs, gate_path):
+    """Completed non-green runs of the gate workflow, oldest first.
+
+    A re-judge event spawns a FRESH gate run; the prior red run's check
+    runs stay `failure` on the same head SHA, and required-check
+    evaluation counts that stale red over the newer green (#190 —
+    observed blocking #188's merge). Only re-running the old run in
+    place supersedes its verdict. `skipped` already passes evaluation,
+    so it is not stale; anything else non-success is.
+    """
+    return [
+        run
+        for run in sorted(runs, key=lambda run: run["id"])
+        if run["path"] == gate_path
+        and run["status"] == "completed"
+        and run["conclusion"] not in ("success", "skipped")
+    ]
+
+
+def gate_busy(runs, gate_path):
+    """Is any run of the gate workflow still queued or in flight?
+
+    Re-running an old run while a fresh one is in progress queues into
+    the same `ci-ok-<pr>` concurrency group and cancel-in-progress
+    kills the fresh run — trading one stale red for another. The rerun
+    therefore waits for quiet first, which is also why it lives in its
+    own workflow with its own group.
+    """
+    return any(
+        run["path"] == gate_path and run["status"] != "completed" for run in runs
+    )
+
+
+def run_rerun():
+    """Re-run each stale red gate run once, serially, then stop.
+
+    This job SYNCS old runs with the gate's current verdict; it never
+    judges. A rerun re-executes the gate's own jobs, which read live
+    data (#159), so a red flips green only when the condition genuinely
+    holds now — a still-unmet condition reruns red and keeps blocking,
+    which is correct and not this job's failure. Hence exit 0 on every
+    orderly path; each run is attempted at most once so a legitimately
+    red gate cannot loop.
+    """
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["HEAD_SHA"]
+    gate_path = os.environ["GATE_WORKFLOW"]
+    deadline = time.monotonic() + int(os.environ.get("GATE_RERUN_TIMEOUT", "1500"))
+
+    attempted = set()
+    while True:
+        runs = paginate(
+            f"/repos/{repo}/actions/runs?head_sha={sha}", token, "workflow_runs"
+        )
+        if not gate_busy(runs, gate_path):
+            stale = [
+                run
+                for run in stale_gate_runs(runs, gate_path)
+                if run["id"] not in attempted
+            ]
+            if not stale:
+                done = f"re-ran {sorted(attempted)}" if attempted else "none found"
+                print(f"No stale non-green gate runs left on {sha} ({done}).")
+                return 0
+            run = stale[0]
+            attempted.add(run["id"])
+            print(f"re-running failed jobs of run {run['id']} ({run['conclusion']})")
+            try:
+                post(f"/repos/{repo}/actions/runs/{run['id']}/rerun-failed-jobs", token)
+            except urllib.error.HTTPError as err:
+                # E.g. a cancelled run with nothing rerunnable (409) —
+                # note it and move on; syncing must not go red itself.
+                print(f"::warning::rerun of {run['id']} refused: {err}")
+        if time.monotonic() > deadline:
+            print("::warning::gate runs still in flight at the rerun timeout.")
+            return 0
+        time.sleep(15)
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -701,6 +810,7 @@ def main():
         "reviews": run_reviews,
         "approval": run_approval,
         "aggregate": run_aggregate,
+        "rerun": run_rerun,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -11,6 +11,9 @@ One subcommand per job in ci-ok.yml:
              head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
+  rerun      stale non-green gate runs on this head SHA are re-run in
+             place, so a superseded red stops blocking merge (#190) —
+             gate-rerun.yml's job, not ci-ok.yml's
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -22,6 +25,7 @@ import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.request
 
 import yaml
@@ -64,8 +68,8 @@ def graphql(query, variables, token):
     """POST one GraphQL query — the read for what REST does not expose.
 
     Review-thread resolution exists only in the GraphQL schema, so this
-    is the file's second and last network door: a POST to the fixed
-    /graphql path, under the same scheme guard as `fetch`.
+    is the file's second network door: a POST to the fixed /graphql
+    path, under the same scheme guard as `fetch`.
     """
     body = json.dumps({"query": query, "variables": variables}).encode()
     req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
@@ -83,6 +87,28 @@ def graphql(query, variables, token):
     if payload.get("errors"):
         raise RuntimeError(f"GraphQL errors: {payload['errors']}")
     return payload["data"]
+
+
+def post(path, token):
+    """POST one empty-bodied API path — the file's one write door.
+
+    Exists solely for `rerun-failed-jobs` (#190): superseding a stale
+    red check run takes a write, where everything the gate JUDGES stays
+    behind the two read doors above. Same scheme guard; returns the
+    HTTP status, since the endpoint answers 201 with no body.
+    """
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
+        data=b"",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        return response.status
 
 
 def paginate(path, token, key=None):
@@ -694,6 +720,89 @@ def run_aggregate():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- rerun
+
+
+def stale_gate_runs(runs, gate_path):
+    """Completed non-green runs of the gate workflow, oldest first.
+
+    A re-judge event spawns a FRESH gate run; the prior red run's check
+    runs stay `failure` on the same head SHA, and required-check
+    evaluation counts that stale red over the newer green (#190 —
+    observed blocking #188's merge). Only re-running the old run in
+    place supersedes its verdict. `skipped` already passes evaluation,
+    so it is not stale; anything else non-success is.
+    """
+    return [
+        run
+        for run in sorted(runs, key=lambda run: run["id"])
+        if run["path"] == gate_path
+        and run["status"] == "completed"
+        and run["conclusion"] not in ("success", "skipped")
+    ]
+
+
+def gate_busy(runs, gate_path):
+    """Is any run of the gate workflow still queued or in flight?
+
+    Re-running an old run while a fresh one is in progress queues into
+    the same `ci-ok-<pr>` concurrency group and cancel-in-progress
+    kills the fresh run — trading one stale red for another. The rerun
+    therefore waits for quiet first, which is also why it lives in its
+    own workflow with its own group.
+    """
+    return any(
+        run["path"] == gate_path and run["status"] != "completed" for run in runs
+    )
+
+
+def run_rerun():
+    """Re-run each stale red gate run once, serially, then stop.
+
+    This job SYNCS old runs with the gate's current verdict; it never
+    judges. A rerun re-executes the gate's own jobs, which read live
+    data (#159), so a red flips green only when the condition genuinely
+    holds now — a still-unmet condition reruns red and keeps blocking,
+    which is correct and not this job's failure. Hence exit 0 on every
+    orderly path; each run is attempted at most once so a legitimately
+    red gate cannot loop.
+    """
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["HEAD_SHA"]
+    gate_path = os.environ["GATE_WORKFLOW"]
+    deadline = time.monotonic() + int(os.environ.get("GATE_RERUN_TIMEOUT", "1500"))
+
+    attempted = set()
+    while True:
+        runs = paginate(
+            f"/repos/{repo}/actions/runs?head_sha={sha}", token, "workflow_runs"
+        )
+        if not gate_busy(runs, gate_path):
+            stale = [
+                run
+                for run in stale_gate_runs(runs, gate_path)
+                if run["id"] not in attempted
+            ]
+            if not stale:
+                done = f"re-ran {sorted(attempted)}" if attempted else "none found"
+                print(f"No stale non-green gate runs left on {sha} ({done}).")
+                return 0
+            run = stale[0]
+            attempted.add(run["id"])
+            print(f"re-running failed jobs of run {run['id']} ({run['conclusion']})")
+            try:
+                post(f"/repos/{repo}/actions/runs/{run['id']}/rerun-failed-jobs", token)
+            except urllib.error.HTTPError as err:
+                # E.g. a cancelled run with nothing rerunnable (409) —
+                # note it and move on; syncing must not go red itself.
+                print(f"::warning::rerun of {run['id']} refused: {err}")
+        if time.monotonic() > deadline:
+            print("::warning::gate runs still in flight at the rerun timeout.")
+            return 0
+        time.sleep(15)
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -701,6 +810,7 @@ def main():
         "reviews": run_reviews,
         "approval": run_approval,
         "aggregate": run_aggregate,
+        "rerun": run_rerun,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -11,6 +11,9 @@ One subcommand per job in ci-ok.yml:
              head commit — or the PR is authored by one (#187)
   aggregate  every job of every pull_request-triggered workflow on
              this head SHA succeeded — the one required context
+  rerun      stale non-green gate runs on this head SHA are re-run in
+             place, so a superseded red stops blocking merge (#190) —
+             gate-rerun.yml's job, not ci-ok.yml's
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -22,6 +25,7 @@ import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.request
 
 import yaml
@@ -64,8 +68,8 @@ def graphql(query, variables, token):
     """POST one GraphQL query — the read for what REST does not expose.
 
     Review-thread resolution exists only in the GraphQL schema, so this
-    is the file's second and last network door: a POST to the fixed
-    /graphql path, under the same scheme guard as `fetch`.
+    is the file's second network door: a POST to the fixed /graphql
+    path, under the same scheme guard as `fetch`.
     """
     body = json.dumps({"query": query, "variables": variables}).encode()
     req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
@@ -83,6 +87,28 @@ def graphql(query, variables, token):
     if payload.get("errors"):
         raise RuntimeError(f"GraphQL errors: {payload['errors']}")
     return payload["data"]
+
+
+def post(path, token):
+    """POST one empty-bodied API path — the file's one write door.
+
+    Exists solely for `rerun-failed-jobs` (#190): superseding a stale
+    red check run takes a write, where everything the gate JUDGES stays
+    behind the two read doors above. Same scheme guard; returns the
+    HTTP status, since the endpoint answers 201 with no body.
+    """
+    req = urllib.request.Request(  # noqa: S310 — api_url rejects every other scheme
+        api_url(path),
+        data=b"",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as response:  # noqa: S310 — checked above
+        return response.status
 
 
 def paginate(path, token, key=None):
@@ -694,6 +720,89 @@ def run_aggregate():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- rerun
+
+
+def stale_gate_runs(runs, gate_path):
+    """Completed non-green runs of the gate workflow, oldest first.
+
+    A re-judge event spawns a FRESH gate run; the prior red run's check
+    runs stay `failure` on the same head SHA, and required-check
+    evaluation counts that stale red over the newer green (#190 —
+    observed blocking #188's merge). Only re-running the old run in
+    place supersedes its verdict. `skipped` already passes evaluation,
+    so it is not stale; anything else non-success is.
+    """
+    return [
+        run
+        for run in sorted(runs, key=lambda run: run["id"])
+        if run["path"] == gate_path
+        and run["status"] == "completed"
+        and run["conclusion"] not in ("success", "skipped")
+    ]
+
+
+def gate_busy(runs, gate_path):
+    """Is any run of the gate workflow still queued or in flight?
+
+    Re-running an old run while a fresh one is in progress queues into
+    the same `ci-ok-<pr>` concurrency group and cancel-in-progress
+    kills the fresh run — trading one stale red for another. The rerun
+    therefore waits for quiet first, which is also why it lives in its
+    own workflow with its own group.
+    """
+    return any(
+        run["path"] == gate_path and run["status"] != "completed" for run in runs
+    )
+
+
+def run_rerun():
+    """Re-run each stale red gate run once, serially, then stop.
+
+    This job SYNCS old runs with the gate's current verdict; it never
+    judges. A rerun re-executes the gate's own jobs, which read live
+    data (#159), so a red flips green only when the condition genuinely
+    holds now — a still-unmet condition reruns red and keeps blocking,
+    which is correct and not this job's failure. Hence exit 0 on every
+    orderly path; each run is attempted at most once so a legitimately
+    red gate cannot loop.
+    """
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["HEAD_SHA"]
+    gate_path = os.environ["GATE_WORKFLOW"]
+    deadline = time.monotonic() + int(os.environ.get("GATE_RERUN_TIMEOUT", "1500"))
+
+    attempted = set()
+    while True:
+        runs = paginate(
+            f"/repos/{repo}/actions/runs?head_sha={sha}", token, "workflow_runs"
+        )
+        if not gate_busy(runs, gate_path):
+            stale = [
+                run
+                for run in stale_gate_runs(runs, gate_path)
+                if run["id"] not in attempted
+            ]
+            if not stale:
+                done = f"re-ran {sorted(attempted)}" if attempted else "none found"
+                print(f"No stale non-green gate runs left on {sha} ({done}).")
+                return 0
+            run = stale[0]
+            attempted.add(run["id"])
+            print(f"re-running failed jobs of run {run['id']} ({run['conclusion']})")
+            try:
+                post(f"/repos/{repo}/actions/runs/{run['id']}/rerun-failed-jobs", token)
+            except urllib.error.HTTPError as err:
+                # E.g. a cancelled run with nothing rerunnable (409) —
+                # note it and move on; syncing must not go red itself.
+                print(f"::warning::rerun of {run['id']} refused: {err}")
+        if time.monotonic() > deadline:
+            print("::warning::gate runs still in flight at the rerun timeout.")
+            return 0
+        time.sleep(15)
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -701,6 +810,7 @@ def main():
         "reviews": run_reviews,
         "approval": run_approval,
         "aggregate": run_aggregate,
+        "rerun": run_rerun,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/gate-rerun.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/gate-rerun.yml
@@ -1,0 +1,46 @@
+# The stale-red janitor for the CI gate (agentic-engineering-template#190).
+#
+# A re-judge event spawns a FRESH `CI gate` run; the prior red run's
+# check runs stay `failure` on the same head SHA, and required-check
+# evaluation counts that stale red over the newer green — a PR whose
+# gate is genuinely green stays unmergeable until the old run is re-run
+# IN PLACE. This workflow does exactly that, and nothing else: it waits
+# until no gate run on the head is in flight, then re-runs each
+# completed non-green gate run's failed jobs, once each.
+#
+# It never fabricates green — a rerun re-executes the gate's own jobs,
+# which judge live data, so a still-unmet condition reruns red and
+# keeps blocking. It is deliberately NOT part of ci-ok.yml: a rerun
+# queued into the `ci-ok-<pr>` concurrency group would cancel the
+# in-flight fresh run via cancel-in-progress, so this rides its own
+# group. No `synchronize` trigger, so the aggregate never awaits it.
+name: Gate rerun
+
+on:
+  pull_request:
+    types: [edited, labeled, unlabeled, review_requested, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  actions: write
+
+concurrency:
+  group: gate-rerun-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rerun:
+    name: "rerun stale gate runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Stale non-green gate runs on this head are re-run in place
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GATE_WORKFLOW: .github/workflows/ci-ok.yml
+        run: python3 scripts/ci/check_gate.py rerun

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -463,6 +463,48 @@ def test_empty_approver_list_is_loud(tmp_path, monkeypatch):
         raise AssertionError("an empty approver list must refuse, not pass")
 
 
+# -------------------------------------------------------------- rerun
+
+
+def gate_run(run_id, path=".github/workflows/ci-ok.yml", **overrides):
+    run = {"id": run_id, "path": path, "status": "completed", "conclusion": "failure"}
+    run.update(overrides)
+    return run
+
+
+def test_stale_gate_runs_are_completed_non_green_gate_runs_oldest_first():
+    runs = [
+        gate_run(3, conclusion="success"),
+        gate_run(2, conclusion="cancelled"),
+        gate_run(5),
+        gate_run(4, path=".github/workflows/ci.yml"),
+    ]
+    stale = gate.stale_gate_runs(runs, ".github/workflows/ci-ok.yml")
+    assert [run["id"] for run in stale] == [2, 5]
+
+
+def test_a_skipped_gate_run_is_not_stale():
+    """`skipped` passes required-check evaluation, so there is no red
+    to supersede — re-running it would only spend Actions minutes."""
+    runs = [gate_run(1, conclusion="skipped")]
+    assert gate.stale_gate_runs(runs, ".github/workflows/ci-ok.yml") == []
+
+
+def test_an_in_flight_gate_run_is_not_stale_and_reports_as_busy():
+    """A queued or running gate run is about to publish the current
+    verdict — re-running under it would race the concurrency group and
+    cancel it, which is the failure mode the separate workflow exists
+    to avoid (#190)."""
+    runs = [
+        gate_run(1, status="in_progress", conclusion=None),
+        gate_run(2, status="queued", conclusion=None),
+        gate_run(3, path=".github/workflows/ci.yml", status="queued", conclusion=None),
+    ]
+    assert gate.stale_gate_runs(runs, ".github/workflows/ci-ok.yml") == []
+    assert gate.gate_busy(runs, ".github/workflows/ci-ok.yml")
+    assert not gate.gate_busy([gate_run(1)] + runs[2:], ".github/workflows/ci-ok.yml")
+
+
 # ------------------------------------------------- copies stay pinned
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -75,6 +75,9 @@ GITHUB_ONLY_FILES = frozenset(
         # The merge-approval gate (#187): the approver allowlist its
         # check reads.
         ".github/merge-approvers.json",
+        # The stale-red janitor (#190): re-runs superseded red gate
+        # runs in place so they stop blocking merge.
+        ".github/workflows/gate-rerun.yml",
     }
 )
 


### PR DESCRIPTION
CLOSES #190 — the stale-red follow-up to the #187/#188 merge-approval gate, observed blocking #188's own merge.

## The failure this fixes

The CI gate re-judges by spawning a **fresh run** on re-judge events. The prior red run's check runs stay `failure` on the same head SHA, and GitHub's required-check evaluation counted that stale red over two newer green `ci-ok` runs — #188 merged only after its stale run's failed jobs were re-run **in place** by hand.

## What lands

- **`check_gate.py rerun`** (new subcommand): waits until no gate run on the head SHA is queued or in flight, then re-runs each completed non-green gate run's failed jobs, at most once each, oldest first. Selection is pure (`stale_gate_runs`, `gate_busy`, 3 new tests); `post` is the file's one write door (`rerun-failed-jobs` only). Always exits 0 on orderly paths — it syncs old runs with the gate's current verdict, it never judges.
- **`gate-rerun.yml`** vehicle on the gate's re-judge events, with its **own concurrency group** — a rerun queued into `ci-ok-<pr>` would cancel the in-flight fresh run via cancel-in-progress, which is why this cannot be a job inside `ci-ok.yml`. No `synchronize` trigger, so the aggregate never awaits it and it is not a required context.

## Fail-closed by construction

A rerun re-executes the gate's own jobs, which judge live data (#159): a stale red flips green only when the condition genuinely holds now; a still-unmet condition reruns red and keeps blocking. The rejected alternative — concluding the approval job `neutral` while unapproved — counts as *passing* for required checks and would let an unapproved PR merge.

## Scope

Main template + self-application. Store subtemplates carry no approval job and have not exhibited the path; extend later if bitten.

## Verification

- Full suite green locally: 281 passed (e2e and self-application included)
- Two-commit template-first shape (feat + restamp); gate-script copies byte-pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790696466&installation_model_id=432661&pr_number=191&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F191&signature=d26865993fbca1c28a235010000bf124f2c799abf28e2dc44f3cd8a580d916a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->