### PR TITLE
feat: leak prevention layers 1+2 — gitleaks in prek, leaks job in the CI gate

### DIFF
--- a/.github/workflows/ci-ok.yml
+++ b/.github/workflows/ci-ok.yml
@@ -77,6 +77,39 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
+  leaks:
+    name: "leaks"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # gitleaks walks the PR's own commits, not just the merge ref.
+          fetch-depth: 0
+
+      # Credential class (#189): the pinned gitleaks binary scans every
+      # PR commit's content. Pinned by version AND checksum — a moving
+      # release tag could swap the scanner under every repo's CI at
+      # once. --redact keeps whatever it finds out of this public log.
+      - name: gitleaks finds no credential in any PR commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          ./gitleaks git --redact --no-banner --exit-code 1 \
+            --log-opts "$BASE_SHA..$HEAD_SHA"
+
+      # Identity class (#189): known strings, matched verbatim against
+      # every surface this PR publishes. The org secret carries values
+      # only — the repo commits nothing but this variable's name.
+      - name: No blocklisted string on any surface this PR publishes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUSH_BLOCKLIST: ${{ secrets.PUSH_BLOCKLIST }}
+        run: python3 scripts/ci/check_gate.py leaks
+
   approval:
     name: "merge approval"
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,13 @@ repos:
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
       # `-l` prints only the offending FILE, never the matched line;
-      # unset env means the layer is off and the hook passes.
+      # unset env means the layer is off and the hook passes. The
+      # pattern is normalized first (CR/LF and stray pipes stripped):
+      # an editor-saved trailing newline would otherwise put an empty
+      # alternative into the pattern, matching every file.
       - id: push-blocklist
         name: no blocklisted string in staged files
-        entry: bash -c '[ -z "${PUSH_BLOCKLIST:-}" ] || ! grep -IilE -- "$PUSH_BLOCKLIST" "$@"' --
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,14 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
+      # in env, never committed — exactly grep's alternation syntax.
+      # `-l` prints only the offending FILE, never the matched line;
+      # unset env means the layer is off and the hook passes.
+      - id: push-blocklist
+        name: no blocklisted string in staged files
+        entry: bash -c '[ -z "${PUSH_BLOCKLIST:-}" ] || ! grep -IilE -- "$PUSH_BLOCKLIST" "$@"' --
+        language: system
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0
     hooks:
@@ -70,6 +78,11 @@ repos:
       # (yamllint can't parse Jinja).
       - id: yamllint
         args: [--strict]
+  # Credential class (#189): stock rules over the staged diff, offline.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,14 @@ repos:
         name: no blocklisted string in staged files
         entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
+      # The same gate at the commit-msg stage: messages auto-publish
+      # on push with no approval step, and the pre-commit stage fires
+      # before a message exists. Git hands this hook the message file.
+      - id: push-blocklist-msg
+        name: no blocklisted string in the commit message
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
+        language: system
+        stages: [commit-msg]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ repos:
         always_run: true
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
+      # An entry may name its placeholder (`value=pb:name`); labels
+      # are metadata and are stripped before the pattern is built.
       # `-l` prints only the offending FILE, never the matched line;
       # unset env means the layer is off and the hook passes. The
       # pattern is normalized first (CR/LF and stray pipes stripped):
@@ -31,7 +33,7 @@ repos:
       # alternative into the pattern, matching every file.
       - id: push-blocklist
         name: no blocklisted string in staged files
-        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0

--- a/decision-memory/.github/workflows/ci-ok.yml.jinja
+++ b/decision-memory/.github/workflows/ci-ok.yml.jinja
@@ -58,6 +58,39 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
+  leaks:
+    name: "leaks"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # gitleaks walks the PR's own commits, not just the merge ref.
+          fetch-depth: 0
+
+      # Credential class (#189): the pinned gitleaks binary scans every
+      # PR commit's content. Pinned by version AND checksum — a moving
+      # release tag could swap the scanner under every repo's CI at
+      # once. --redact keeps whatever it finds out of this public log.
+      - name: gitleaks finds no credential in any PR commit
+        env:
+          BASE_SHA: {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}
+          HEAD_SHA: {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+        run: |
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          ./gitleaks git --redact --no-banner --exit-code 1 \
+            --log-opts "$BASE_SHA..$HEAD_SHA"
+
+      # Identity class (#189): known strings, matched verbatim against
+      # every surface this PR publishes. The org secret carries values
+      # only — the repo commits nothing but this variable's name.
+      - name: No blocklisted string on any surface this PR publishes
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          PUSH_BLOCKLIST: {% raw %}${{ secrets.PUSH_BLOCKLIST }}{% endraw %}
+        run: python3 scripts/ci/check_gate.py leaks
+
   ci-ok:
     name: "ci-ok"
     runs-on: {{ agentic_actions_runner }}

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -14,6 +14,9 @@ One subcommand per job in ci-ok.yml:
   rerun      stale non-green gate runs on this head SHA are re-run in
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
+  leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+             publishes: title, body, commit messages, commit author
+             and committer names/emails, and the diff (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -803,6 +806,87 @@ def run_rerun():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- leaks
+
+
+def parse_blocklist(value):
+    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+
+    Values-only and `|`-separated (pandoscope/skills#46): the variable
+    carries WHAT to block and nothing else, so the committed side of
+    the contract is just this parser and the variable's name.
+    """
+    if not value:
+        return []
+    return [entry.strip() for entry in value.split("|") if entry.strip()]
+
+
+def leak_violations(surfaces, values):
+    """Denylist hits over (label, text) surfaces — value-silent.
+
+    Case-insensitive substring match, one violation per (surface,
+    entry) pair. The violation names WHERE and WHICH entry, never
+    WHAT: the values are the identifying material this gate keeps off
+    public surfaces, and this gate's own log on a public repo is such
+    a surface (#189).
+    """
+    problems = []
+    for label, text in surfaces:
+        lowered = (text or "").lower()
+        for position, value in enumerate(values, start=1):
+            if value.lower() in lowered:
+                problems.append(
+                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    "scrub it and rewrite the offending commit or text"
+                )
+    return problems
+
+
+def pr_surfaces(pr, commits, files):
+    """Every text surface this PR publishes, labeled for the verdict.
+
+    Commit metadata is listed explicitly because no established
+    scanner covers author/committer name and email (#189) — an agent's
+    misconfigured git identity auto-publishes on merge with no
+    approval step in between.
+    """
+    surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    for entry in commits:
+        sha = entry["sha"][:7]
+        commit = entry["commit"]
+        surfaces.append((f"commit {sha} message", commit.get("message")))
+        for role in ("author", "committer"):
+            who = commit.get(role) or {}
+            surfaces.append((f"commit {sha} {role} name", who.get("name")))
+            surfaces.append((f"commit {sha} {role} email", who.get("email")))
+    for changed in files:
+        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    return surfaces
+
+
+def run_leaks():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        # An unset org secret must not fail every fork and fresh
+        # consumer, but silence would hide that the layer is off.
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    number = pr["number"]
+    commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
+    files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string on any surface this PR publishes.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -811,6 +895,7 @@ def main():
         "approval": run_approval,
         "aggregate": run_aggregate,
         "rerun": run_rerun,
+        "leaks": run_leaks,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -810,33 +810,44 @@ def run_rerun():
 
 
 def parse_blocklist(value):
-    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+    """PUSH_BLOCKLIST env → (value, name) pairs, blanks dropped.
 
-    Values-only and `|`-separated (pandoscope/skills#46): the variable
-    carries WHAT to block and nothing else, so the committed side of
-    the contract is just this parser and the variable's name.
+    `|`-separated values (pandoscope/skills#46); the variable carries
+    WHAT to block and nothing else, so the committed side of the
+    contract is just this parser and the variable's name. An entry may
+    name its own placeholder (`value=pb:name`, `=` and `|` reserved):
+    the name is what violations and scrub placeholders say, and it
+    survives list edits where a positional index would drift. An
+    unlabeled entry falls back to its raw field position.
     """
     if not value:
         return []
-    return [entry.strip() for entry in value.split("|") if entry.strip()]
+    pairs = []
+    for position, entry in enumerate(value.split("|"), start=1):
+        term, _, name = entry.partition("=")
+        term = term.strip()
+        if term:
+            pairs.append((term, name.strip() or f"entry {position}"))
+    return pairs
 
 
 def leak_violations(surfaces, values):
     """Denylist hits over (label, text) surfaces — value-silent.
 
     Case-insensitive substring match, one violation per (surface,
-    entry) pair. The violation names WHERE and WHICH entry, never
-    WHAT: the values are the identifying material this gate keeps off
-    public surfaces, and this gate's own log on a public repo is such
-    a surface (#189).
+    entry) pair; `values` is parse_blocklist output. The violation
+    names WHERE and WHICH entry — by the entry's own placeholder name
+    when it carries one — never WHAT: the values are the identifying
+    material this gate keeps off public surfaces, and this gate's own
+    log on a public repo is such a surface (#189).
     """
     problems = []
     for label, text in surfaces:
         lowered = (text or "").lower()
-        for position, value in enumerate(values, start=1):
-            if value.lower() in lowered:
+        for term, name in values:
+            if term.lower() in lowered:
                 problems.append(
-                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    f"{label} carries PUSH_BLOCKLIST {name} — "
                     "scrub it and rewrite the offending commit or text"
                 )
     return problems

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -16,8 +16,9 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, the diff, and the PR's own
-             comment and review threads (#189)
+             and committer names/emails, the branch name, the diff,
+             the PR's own comment and review threads, and the bodies
+             and comments of every ticket the body references (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -854,18 +855,43 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
+def referenced_tickets(body, repo):
+    """Every ticket the body mentions, keyword or not, as owner/repo#n.
+
+    Broader than closing_refs on purpose: a see-also reference leaks
+    exactly like a CLOSES, so any `#n` / `owner/repo#n` occurrence
+    puts that ticket's surfaces under the scan.
+    """
+    refs = set()
+    for match in re.finditer(REF, body or ""):
+        ref = match.group(0)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def pr_surfaces(
+    pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
+):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between. The PR's own comment threads are scanned
-    too: a comment publishes the instant it is posted, so this cannot
-    prevent, but the gate re-runs on exactly those events — a hit
+    approval step in between. The PR's own comment threads and the
+    tickets it references (`tickets` is (ref, body, comments) tuples)
+    are scanned too: those publish the instant they are posted, so
+    this cannot prevent — but the gate re-runs on PR events, and a hit
     blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    if pr.get("head"):
+        surfaces.append(("branch name", pr["head"].get("ref")))
+    for ref, body, ticket_comments in tickets:
+        surfaces.append((f"ticket {ref} body", body))
+        for comment in ticket_comments:
+            surfaces.append(
+                (f"ticket {ref} comment {comment['id']}", comment.get("body"))
+            )
     for entry in commits:
         sha = entry["sha"][:7]
         commit = entry["commit"]
@@ -903,6 +929,20 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    tickets = []
+    for ref in referenced_tickets(pr.get("body"), repo):
+        ticket_repo, _, ticket_number = ref.rpartition("#")
+        try:
+            issue = fetch(f"/repos/{ticket_repo}/issues/{ticket_number}", token)
+            ticket_comments = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/comments", token
+            )
+        except (OSError, ValueError) as error:
+            # A ref the token cannot read (foreign or private repo) is
+            # not this gate's to judge — say so and move on.
+            print(f"::notice::could not scan referenced ticket {ref}: {error}")
+            continue
+        tickets.append((ref, issue.get("body"), ticket_comments))
     problems = leak_violations(
         pr_surfaces(
             pr,
@@ -911,6 +951,7 @@ def run_leaks():
             comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
             reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
             review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+            tickets=tickets,
         ),
         values,
     )

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -16,7 +16,8 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, and the diff (#189)
+             and committer names/emails, the diff, and the PR's own
+             comment and review threads (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -853,13 +854,16 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files):
+def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between.
+    approval step in between. The PR's own comment threads are scanned
+    too: a comment publishes the instant it is posted, so this cannot
+    prevent, but the gate re-runs on exactly those events — a hit
+    blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
     for entry in commits:
@@ -872,6 +876,15 @@ def pr_surfaces(pr, commits, files):
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
         surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    for comment in comments:
+        surfaces.append((f"comment {comment['id']}", comment.get("body")))
+    for review in reviews:
+        surfaces.append((f"review {review['id']}", review.get("body")))
+    for comment in review_comments:
+        where = comment.get("path") or "(general)"
+        surfaces.append(
+            (f"review comment {comment['id']} on {where}", comment.get("body"))
+        )
     return surfaces
 
 
@@ -890,7 +903,17 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
-    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    problems = leak_violations(
+        pr_surfaces(
+            pr,
+            commits,
+            files,
+            comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
+            reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
+            review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+        ),
+        values,
+    )
     for problem in problems:
         print(f"::error::{problem}")
     if not problems:

--- a/evidence-memory/.github/workflows/ci-ok.yml.jinja
+++ b/evidence-memory/.github/workflows/ci-ok.yml.jinja
@@ -58,6 +58,39 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
+  leaks:
+    name: "leaks"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # gitleaks walks the PR's own commits, not just the merge ref.
+          fetch-depth: 0
+
+      # Credential class (#189): the pinned gitleaks binary scans every
+      # PR commit's content. Pinned by version AND checksum — a moving
+      # release tag could swap the scanner under every repo's CI at
+      # once. --redact keeps whatever it finds out of this public log.
+      - name: gitleaks finds no credential in any PR commit
+        env:
+          BASE_SHA: {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}
+          HEAD_SHA: {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+        run: |
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          ./gitleaks git --redact --no-banner --exit-code 1 \
+            --log-opts "$BASE_SHA..$HEAD_SHA"
+
+      # Identity class (#189): known strings, matched verbatim against
+      # every surface this PR publishes. The org secret carries values
+      # only — the repo commits nothing but this variable's name.
+      - name: No blocklisted string on any surface this PR publishes
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          PUSH_BLOCKLIST: {% raw %}${{ secrets.PUSH_BLOCKLIST }}{% endraw %}
+        run: python3 scripts/ci/check_gate.py leaks
+
   ci-ok:
     name: "ci-ok"
     runs-on: {{ agentic_actions_runner }}

--- a/evidence-memory/AGENTS.md
+++ b/evidence-memory/AGENTS.md
@@ -66,6 +66,11 @@ If you leak anything — even low-risk, even by accident — that is
 itself a detection. File it. Prevention here is built from observed
 weak spots, not imagined ones.
 
+The prek and CI leak scans (gitleaks + the PUSH_BLOCKLIST denylist)
+catch **verbatim** strings only — paraphrase sails through. A green
+scan is a narrowed surface, never clearance; the re-read above stays
+mandatory.
+
 ## Filing
 
 ```bash

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -14,6 +14,9 @@ One subcommand per job in ci-ok.yml:
   rerun      stale non-green gate runs on this head SHA are re-run in
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
+  leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+             publishes: title, body, commit messages, commit author
+             and committer names/emails, and the diff (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -803,6 +806,87 @@ def run_rerun():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- leaks
+
+
+def parse_blocklist(value):
+    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+
+    Values-only and `|`-separated (pandoscope/skills#46): the variable
+    carries WHAT to block and nothing else, so the committed side of
+    the contract is just this parser and the variable's name.
+    """
+    if not value:
+        return []
+    return [entry.strip() for entry in value.split("|") if entry.strip()]
+
+
+def leak_violations(surfaces, values):
+    """Denylist hits over (label, text) surfaces — value-silent.
+
+    Case-insensitive substring match, one violation per (surface,
+    entry) pair. The violation names WHERE and WHICH entry, never
+    WHAT: the values are the identifying material this gate keeps off
+    public surfaces, and this gate's own log on a public repo is such
+    a surface (#189).
+    """
+    problems = []
+    for label, text in surfaces:
+        lowered = (text or "").lower()
+        for position, value in enumerate(values, start=1):
+            if value.lower() in lowered:
+                problems.append(
+                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    "scrub it and rewrite the offending commit or text"
+                )
+    return problems
+
+
+def pr_surfaces(pr, commits, files):
+    """Every text surface this PR publishes, labeled for the verdict.
+
+    Commit metadata is listed explicitly because no established
+    scanner covers author/committer name and email (#189) — an agent's
+    misconfigured git identity auto-publishes on merge with no
+    approval step in between.
+    """
+    surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    for entry in commits:
+        sha = entry["sha"][:7]
+        commit = entry["commit"]
+        surfaces.append((f"commit {sha} message", commit.get("message")))
+        for role in ("author", "committer"):
+            who = commit.get(role) or {}
+            surfaces.append((f"commit {sha} {role} name", who.get("name")))
+            surfaces.append((f"commit {sha} {role} email", who.get("email")))
+    for changed in files:
+        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    return surfaces
+
+
+def run_leaks():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        # An unset org secret must not fail every fork and fresh
+        # consumer, but silence would hide that the layer is off.
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    number = pr["number"]
+    commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
+    files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string on any surface this PR publishes.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -811,6 +895,7 @@ def main():
         "approval": run_approval,
         "aggregate": run_aggregate,
         "rerun": run_rerun,
+        "leaks": run_leaks,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -810,33 +810,44 @@ def run_rerun():
 
 
 def parse_blocklist(value):
-    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+    """PUSH_BLOCKLIST env → (value, name) pairs, blanks dropped.
 
-    Values-only and `|`-separated (pandoscope/skills#46): the variable
-    carries WHAT to block and nothing else, so the committed side of
-    the contract is just this parser and the variable's name.
+    `|`-separated values (pandoscope/skills#46); the variable carries
+    WHAT to block and nothing else, so the committed side of the
+    contract is just this parser and the variable's name. An entry may
+    name its own placeholder (`value=pb:name`, `=` and `|` reserved):
+    the name is what violations and scrub placeholders say, and it
+    survives list edits where a positional index would drift. An
+    unlabeled entry falls back to its raw field position.
     """
     if not value:
         return []
-    return [entry.strip() for entry in value.split("|") if entry.strip()]
+    pairs = []
+    for position, entry in enumerate(value.split("|"), start=1):
+        term, _, name = entry.partition("=")
+        term = term.strip()
+        if term:
+            pairs.append((term, name.strip() or f"entry {position}"))
+    return pairs
 
 
 def leak_violations(surfaces, values):
     """Denylist hits over (label, text) surfaces — value-silent.
 
     Case-insensitive substring match, one violation per (surface,
-    entry) pair. The violation names WHERE and WHICH entry, never
-    WHAT: the values are the identifying material this gate keeps off
-    public surfaces, and this gate's own log on a public repo is such
-    a surface (#189).
+    entry) pair; `values` is parse_blocklist output. The violation
+    names WHERE and WHICH entry — by the entry's own placeholder name
+    when it carries one — never WHAT: the values are the identifying
+    material this gate keeps off public surfaces, and this gate's own
+    log on a public repo is such a surface (#189).
     """
     problems = []
     for label, text in surfaces:
         lowered = (text or "").lower()
-        for position, value in enumerate(values, start=1):
-            if value.lower() in lowered:
+        for term, name in values:
+            if term.lower() in lowered:
                 problems.append(
-                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    f"{label} carries PUSH_BLOCKLIST {name} — "
                     "scrub it and rewrite the offending commit or text"
                 )
     return problems

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -16,8 +16,9 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, the diff, and the PR's own
-             comment and review threads (#189)
+             and committer names/emails, the branch name, the diff,
+             the PR's own comment and review threads, and the bodies
+             and comments of every ticket the body references (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -854,18 +855,43 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
+def referenced_tickets(body, repo):
+    """Every ticket the body mentions, keyword or not, as owner/repo#n.
+
+    Broader than closing_refs on purpose: a see-also reference leaks
+    exactly like a CLOSES, so any `#n` / `owner/repo#n` occurrence
+    puts that ticket's surfaces under the scan.
+    """
+    refs = set()
+    for match in re.finditer(REF, body or ""):
+        ref = match.group(0)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def pr_surfaces(
+    pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
+):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between. The PR's own comment threads are scanned
-    too: a comment publishes the instant it is posted, so this cannot
-    prevent, but the gate re-runs on exactly those events — a hit
+    approval step in between. The PR's own comment threads and the
+    tickets it references (`tickets` is (ref, body, comments) tuples)
+    are scanned too: those publish the instant they are posted, so
+    this cannot prevent — but the gate re-runs on PR events, and a hit
     blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    if pr.get("head"):
+        surfaces.append(("branch name", pr["head"].get("ref")))
+    for ref, body, ticket_comments in tickets:
+        surfaces.append((f"ticket {ref} body", body))
+        for comment in ticket_comments:
+            surfaces.append(
+                (f"ticket {ref} comment {comment['id']}", comment.get("body"))
+            )
     for entry in commits:
         sha = entry["sha"][:7]
         commit = entry["commit"]
@@ -903,6 +929,20 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    tickets = []
+    for ref in referenced_tickets(pr.get("body"), repo):
+        ticket_repo, _, ticket_number = ref.rpartition("#")
+        try:
+            issue = fetch(f"/repos/{ticket_repo}/issues/{ticket_number}", token)
+            ticket_comments = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/comments", token
+            )
+        except (OSError, ValueError) as error:
+            # A ref the token cannot read (foreign or private repo) is
+            # not this gate's to judge — say so and move on.
+            print(f"::notice::could not scan referenced ticket {ref}: {error}")
+            continue
+        tickets.append((ref, issue.get("body"), ticket_comments))
     problems = leak_violations(
         pr_surfaces(
             pr,
@@ -911,6 +951,7 @@ def run_leaks():
             comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
             reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
             review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+            tickets=tickets,
         ),
         values,
     )

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -16,7 +16,8 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, and the diff (#189)
+             and committer names/emails, the diff, and the PR's own
+             comment and review threads (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -853,13 +854,16 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files):
+def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between.
+    approval step in between. The PR's own comment threads are scanned
+    too: a comment publishes the instant it is posted, so this cannot
+    prevent, but the gate re-runs on exactly those events — a hit
+    blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
     for entry in commits:
@@ -872,6 +876,15 @@ def pr_surfaces(pr, commits, files):
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
         surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    for comment in comments:
+        surfaces.append((f"comment {comment['id']}", comment.get("body")))
+    for review in reviews:
+        surfaces.append((f"review {review['id']}", review.get("body")))
+    for comment in review_comments:
+        where = comment.get("path") or "(general)"
+        surfaces.append(
+            (f"review comment {comment['id']} on {where}", comment.get("body"))
+        )
     return surfaces
 
 
@@ -890,7 +903,17 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
-    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    problems = leak_violations(
+        pr_surfaces(
+            pr,
+            commits,
+            files,
+            comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
+            reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
+            review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+        ),
+        values,
+    )
     for problem in problems:
         print(f"::error::{problem}")
     if not problems:

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -14,6 +14,9 @@ One subcommand per job in ci-ok.yml:
   rerun      stale non-green gate runs on this head SHA are re-run in
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
+  leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+             publishes: title, body, commit messages, commit author
+             and committer names/emails, and the diff (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -803,6 +806,87 @@ def run_rerun():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- leaks
+
+
+def parse_blocklist(value):
+    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+
+    Values-only and `|`-separated (pandoscope/skills#46): the variable
+    carries WHAT to block and nothing else, so the committed side of
+    the contract is just this parser and the variable's name.
+    """
+    if not value:
+        return []
+    return [entry.strip() for entry in value.split("|") if entry.strip()]
+
+
+def leak_violations(surfaces, values):
+    """Denylist hits over (label, text) surfaces — value-silent.
+
+    Case-insensitive substring match, one violation per (surface,
+    entry) pair. The violation names WHERE and WHICH entry, never
+    WHAT: the values are the identifying material this gate keeps off
+    public surfaces, and this gate's own log on a public repo is such
+    a surface (#189).
+    """
+    problems = []
+    for label, text in surfaces:
+        lowered = (text or "").lower()
+        for position, value in enumerate(values, start=1):
+            if value.lower() in lowered:
+                problems.append(
+                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    "scrub it and rewrite the offending commit or text"
+                )
+    return problems
+
+
+def pr_surfaces(pr, commits, files):
+    """Every text surface this PR publishes, labeled for the verdict.
+
+    Commit metadata is listed explicitly because no established
+    scanner covers author/committer name and email (#189) — an agent's
+    misconfigured git identity auto-publishes on merge with no
+    approval step in between.
+    """
+    surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    for entry in commits:
+        sha = entry["sha"][:7]
+        commit = entry["commit"]
+        surfaces.append((f"commit {sha} message", commit.get("message")))
+        for role in ("author", "committer"):
+            who = commit.get(role) or {}
+            surfaces.append((f"commit {sha} {role} name", who.get("name")))
+            surfaces.append((f"commit {sha} {role} email", who.get("email")))
+    for changed in files:
+        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    return surfaces
+
+
+def run_leaks():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        # An unset org secret must not fail every fork and fresh
+        # consumer, but silence would hide that the layer is off.
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    number = pr["number"]
+    commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
+    files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string on any surface this PR publishes.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -811,6 +895,7 @@ def main():
         "approval": run_approval,
         "aggregate": run_aggregate,
         "rerun": run_rerun,
+        "leaks": run_leaks,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -810,33 +810,44 @@ def run_rerun():
 
 
 def parse_blocklist(value):
-    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+    """PUSH_BLOCKLIST env → (value, name) pairs, blanks dropped.
 
-    Values-only and `|`-separated (pandoscope/skills#46): the variable
-    carries WHAT to block and nothing else, so the committed side of
-    the contract is just this parser and the variable's name.
+    `|`-separated values (pandoscope/skills#46); the variable carries
+    WHAT to block and nothing else, so the committed side of the
+    contract is just this parser and the variable's name. An entry may
+    name its own placeholder (`value=pb:name`, `=` and `|` reserved):
+    the name is what violations and scrub placeholders say, and it
+    survives list edits where a positional index would drift. An
+    unlabeled entry falls back to its raw field position.
     """
     if not value:
         return []
-    return [entry.strip() for entry in value.split("|") if entry.strip()]
+    pairs = []
+    for position, entry in enumerate(value.split("|"), start=1):
+        term, _, name = entry.partition("=")
+        term = term.strip()
+        if term:
+            pairs.append((term, name.strip() or f"entry {position}"))
+    return pairs
 
 
 def leak_violations(surfaces, values):
     """Denylist hits over (label, text) surfaces — value-silent.
 
     Case-insensitive substring match, one violation per (surface,
-    entry) pair. The violation names WHERE and WHICH entry, never
-    WHAT: the values are the identifying material this gate keeps off
-    public surfaces, and this gate's own log on a public repo is such
-    a surface (#189).
+    entry) pair; `values` is parse_blocklist output. The violation
+    names WHERE and WHICH entry — by the entry's own placeholder name
+    when it carries one — never WHAT: the values are the identifying
+    material this gate keeps off public surfaces, and this gate's own
+    log on a public repo is such a surface (#189).
     """
     problems = []
     for label, text in surfaces:
         lowered = (text or "").lower()
-        for position, value in enumerate(values, start=1):
-            if value.lower() in lowered:
+        for term, name in values:
+            if term.lower() in lowered:
                 problems.append(
-                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    f"{label} carries PUSH_BLOCKLIST {name} — "
                     "scrub it and rewrite the offending commit or text"
                 )
     return problems

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -16,8 +16,9 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, the diff, and the PR's own
-             comment and review threads (#189)
+             and committer names/emails, the branch name, the diff,
+             the PR's own comment and review threads, and the bodies
+             and comments of every ticket the body references (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -854,18 +855,43 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
+def referenced_tickets(body, repo):
+    """Every ticket the body mentions, keyword or not, as owner/repo#n.
+
+    Broader than closing_refs on purpose: a see-also reference leaks
+    exactly like a CLOSES, so any `#n` / `owner/repo#n` occurrence
+    puts that ticket's surfaces under the scan.
+    """
+    refs = set()
+    for match in re.finditer(REF, body or ""):
+        ref = match.group(0)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def pr_surfaces(
+    pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
+):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between. The PR's own comment threads are scanned
-    too: a comment publishes the instant it is posted, so this cannot
-    prevent, but the gate re-runs on exactly those events — a hit
+    approval step in between. The PR's own comment threads and the
+    tickets it references (`tickets` is (ref, body, comments) tuples)
+    are scanned too: those publish the instant they are posted, so
+    this cannot prevent — but the gate re-runs on PR events, and a hit
     blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    if pr.get("head"):
+        surfaces.append(("branch name", pr["head"].get("ref")))
+    for ref, body, ticket_comments in tickets:
+        surfaces.append((f"ticket {ref} body", body))
+        for comment in ticket_comments:
+            surfaces.append(
+                (f"ticket {ref} comment {comment['id']}", comment.get("body"))
+            )
     for entry in commits:
         sha = entry["sha"][:7]
         commit = entry["commit"]
@@ -903,6 +929,20 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    tickets = []
+    for ref in referenced_tickets(pr.get("body"), repo):
+        ticket_repo, _, ticket_number = ref.rpartition("#")
+        try:
+            issue = fetch(f"/repos/{ticket_repo}/issues/{ticket_number}", token)
+            ticket_comments = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/comments", token
+            )
+        except (OSError, ValueError) as error:
+            # A ref the token cannot read (foreign or private repo) is
+            # not this gate's to judge — say so and move on.
+            print(f"::notice::could not scan referenced ticket {ref}: {error}")
+            continue
+        tickets.append((ref, issue.get("body"), ticket_comments))
     problems = leak_violations(
         pr_surfaces(
             pr,
@@ -911,6 +951,7 @@ def run_leaks():
             comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
             reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
             review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+            tickets=tickets,
         ),
         values,
     )

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -16,7 +16,8 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, and the diff (#189)
+             and committer names/emails, the diff, and the PR's own
+             comment and review threads (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -853,13 +854,16 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files):
+def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between.
+    approval step in between. The PR's own comment threads are scanned
+    too: a comment publishes the instant it is posted, so this cannot
+    prevent, but the gate re-runs on exactly those events — a hit
+    blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
     for entry in commits:
@@ -872,6 +876,15 @@ def pr_surfaces(pr, commits, files):
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
         surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    for comment in comments:
+        surfaces.append((f"comment {comment['id']}", comment.get("body")))
+    for review in reviews:
+        surfaces.append((f"review {review['id']}", review.get("body")))
+    for comment in review_comments:
+        where = comment.get("path") or "(general)"
+        surfaces.append(
+            (f"review comment {comment['id']} on {where}", comment.get("body"))
+        )
     return surfaces
 
 
@@ -890,7 +903,17 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
-    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    problems = leak_violations(
+        pr_surfaces(
+            pr,
+            commits,
+            files,
+            comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
+            reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
+            review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+        ),
+        values,
+    )
     for problem in problems:
         print(f"::error::{problem}")
     if not problems:

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -14,6 +14,9 @@ One subcommand per job in ci-ok.yml:
   rerun      stale non-green gate runs on this head SHA are re-run in
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
+  leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+             publishes: title, body, commit messages, commit author
+             and committer names/emails, and the diff (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -803,6 +806,87 @@ def run_rerun():
         time.sleep(15)
 
 
+# -------------------------------------------------------------- leaks
+
+
+def parse_blocklist(value):
+    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+
+    Values-only and `|`-separated (pandoscope/skills#46): the variable
+    carries WHAT to block and nothing else, so the committed side of
+    the contract is just this parser and the variable's name.
+    """
+    if not value:
+        return []
+    return [entry.strip() for entry in value.split("|") if entry.strip()]
+
+
+def leak_violations(surfaces, values):
+    """Denylist hits over (label, text) surfaces — value-silent.
+
+    Case-insensitive substring match, one violation per (surface,
+    entry) pair. The violation names WHERE and WHICH entry, never
+    WHAT: the values are the identifying material this gate keeps off
+    public surfaces, and this gate's own log on a public repo is such
+    a surface (#189).
+    """
+    problems = []
+    for label, text in surfaces:
+        lowered = (text or "").lower()
+        for position, value in enumerate(values, start=1):
+            if value.lower() in lowered:
+                problems.append(
+                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    "scrub it and rewrite the offending commit or text"
+                )
+    return problems
+
+
+def pr_surfaces(pr, commits, files):
+    """Every text surface this PR publishes, labeled for the verdict.
+
+    Commit metadata is listed explicitly because no established
+    scanner covers author/committer name and email (#189) — an agent's
+    misconfigured git identity auto-publishes on merge with no
+    approval step in between.
+    """
+    surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    for entry in commits:
+        sha = entry["sha"][:7]
+        commit = entry["commit"]
+        surfaces.append((f"commit {sha} message", commit.get("message")))
+        for role in ("author", "committer"):
+            who = commit.get(role) or {}
+            surfaces.append((f"commit {sha} {role} name", who.get("name")))
+            surfaces.append((f"commit {sha} {role} email", who.get("email")))
+    for changed in files:
+        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    return surfaces
+
+
+def run_leaks():
+    token = os.environ["GH_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        # An unset org secret must not fail every fork and fresh
+        # consumer, but silence would hide that the layer is off.
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    pr = live_pr(event["pull_request"], token)
+    number = pr["number"]
+    commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
+    files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string on any surface this PR publishes.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -811,6 +895,7 @@ def main():
         "approval": run_approval,
         "aggregate": run_aggregate,
         "rerun": run_rerun,
+        "leaks": run_leaks,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -810,33 +810,44 @@ def run_rerun():
 
 
 def parse_blocklist(value):
-    """PUSH_BLOCKLIST env → the denylist values, blanks dropped.
+    """PUSH_BLOCKLIST env → (value, name) pairs, blanks dropped.
 
-    Values-only and `|`-separated (pandoscope/skills#46): the variable
-    carries WHAT to block and nothing else, so the committed side of
-    the contract is just this parser and the variable's name.
+    `|`-separated values (pandoscope/skills#46); the variable carries
+    WHAT to block and nothing else, so the committed side of the
+    contract is just this parser and the variable's name. An entry may
+    name its own placeholder (`value=pb:name`, `=` and `|` reserved):
+    the name is what violations and scrub placeholders say, and it
+    survives list edits where a positional index would drift. An
+    unlabeled entry falls back to its raw field position.
     """
     if not value:
         return []
-    return [entry.strip() for entry in value.split("|") if entry.strip()]
+    pairs = []
+    for position, entry in enumerate(value.split("|"), start=1):
+        term, _, name = entry.partition("=")
+        term = term.strip()
+        if term:
+            pairs.append((term, name.strip() or f"entry {position}"))
+    return pairs
 
 
 def leak_violations(surfaces, values):
     """Denylist hits over (label, text) surfaces — value-silent.
 
     Case-insensitive substring match, one violation per (surface,
-    entry) pair. The violation names WHERE and WHICH entry, never
-    WHAT: the values are the identifying material this gate keeps off
-    public surfaces, and this gate's own log on a public repo is such
-    a surface (#189).
+    entry) pair; `values` is parse_blocklist output. The violation
+    names WHERE and WHICH entry — by the entry's own placeholder name
+    when it carries one — never WHAT: the values are the identifying
+    material this gate keeps off public surfaces, and this gate's own
+    log on a public repo is such a surface (#189).
     """
     problems = []
     for label, text in surfaces:
         lowered = (text or "").lower()
-        for position, value in enumerate(values, start=1):
-            if value.lower() in lowered:
+        for term, name in values:
+            if term.lower() in lowered:
                 problems.append(
-                    f"{label} carries PUSH_BLOCKLIST entry {position} — "
+                    f"{label} carries PUSH_BLOCKLIST {name} — "
                     "scrub it and rewrite the offending commit or text"
                 )
     return problems

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -16,8 +16,9 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, the diff, and the PR's own
-             comment and review threads (#189)
+             and committer names/emails, the branch name, the diff,
+             the PR's own comment and review threads, and the bodies
+             and comments of every ticket the body references (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -854,18 +855,43 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
+def referenced_tickets(body, repo):
+    """Every ticket the body mentions, keyword or not, as owner/repo#n.
+
+    Broader than closing_refs on purpose: a see-also reference leaks
+    exactly like a CLOSES, so any `#n` / `owner/repo#n` occurrence
+    puts that ticket's surfaces under the scan.
+    """
+    refs = set()
+    for match in re.finditer(REF, body or ""):
+        ref = match.group(0)
+        refs.add(ref if "/" in ref else f"{repo}{ref}")
+    return sorted(refs)
+
+
+def pr_surfaces(
+    pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
+):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between. The PR's own comment threads are scanned
-    too: a comment publishes the instant it is posted, so this cannot
-    prevent, but the gate re-runs on exactly those events — a hit
+    approval step in between. The PR's own comment threads and the
+    tickets it references (`tickets` is (ref, body, comments) tuples)
+    are scanned too: those publish the instant they are posted, so
+    this cannot prevent — but the gate re-runs on PR events, and a hit
     blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
+    if pr.get("head"):
+        surfaces.append(("branch name", pr["head"].get("ref")))
+    for ref, body, ticket_comments in tickets:
+        surfaces.append((f"ticket {ref} body", body))
+        for comment in ticket_comments:
+            surfaces.append(
+                (f"ticket {ref} comment {comment['id']}", comment.get("body"))
+            )
     for entry in commits:
         sha = entry["sha"][:7]
         commit = entry["commit"]
@@ -903,6 +929,20 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
+    tickets = []
+    for ref in referenced_tickets(pr.get("body"), repo):
+        ticket_repo, _, ticket_number = ref.rpartition("#")
+        try:
+            issue = fetch(f"/repos/{ticket_repo}/issues/{ticket_number}", token)
+            ticket_comments = paginate(
+                f"/repos/{ticket_repo}/issues/{ticket_number}/comments", token
+            )
+        except (OSError, ValueError) as error:
+            # A ref the token cannot read (foreign or private repo) is
+            # not this gate's to judge — say so and move on.
+            print(f"::notice::could not scan referenced ticket {ref}: {error}")
+            continue
+        tickets.append((ref, issue.get("body"), ticket_comments))
     problems = leak_violations(
         pr_surfaces(
             pr,
@@ -911,6 +951,7 @@ def run_leaks():
             comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
             reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
             review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+            tickets=tickets,
         ),
         values,
     )

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -16,7 +16,8 @@ One subcommand per job in ci-ok.yml:
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
              publishes: title, body, commit messages, commit author
-             and committer names/emails, and the diff (#189)
+             and committer names/emails, the diff, and the PR's own
+             comment and review threads (#189)
 
 Decision logic lives in pure functions over plain data so the tests
 exercise it without a network; `fetch` is the only door to the API.
@@ -853,13 +854,16 @@ def leak_violations(surfaces, values):
     return problems
 
 
-def pr_surfaces(pr, commits, files):
+def pr_surfaces(pr, commits, files, comments=(), reviews=(), review_comments=()):
     """Every text surface this PR publishes, labeled for the verdict.
 
     Commit metadata is listed explicitly because no established
     scanner covers author/committer name and email (#189) — an agent's
     misconfigured git identity auto-publishes on merge with no
-    approval step in between.
+    approval step in between. The PR's own comment threads are scanned
+    too: a comment publishes the instant it is posted, so this cannot
+    prevent, but the gate re-runs on exactly those events — a hit
+    blocks merge and goes loud instead of lingering quietly.
     """
     surfaces = [("PR title", pr.get("title")), ("PR body", pr.get("body"))]
     for entry in commits:
@@ -872,6 +876,15 @@ def pr_surfaces(pr, commits, files):
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
         surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+    for comment in comments:
+        surfaces.append((f"comment {comment['id']}", comment.get("body")))
+    for review in reviews:
+        surfaces.append((f"review {review['id']}", review.get("body")))
+    for comment in review_comments:
+        where = comment.get("path") or "(general)"
+        surfaces.append(
+            (f"review comment {comment['id']} on {where}", comment.get("body"))
+        )
     return surfaces
 
 
@@ -890,7 +903,17 @@ def run_leaks():
     number = pr["number"]
     commits = paginate(f"/repos/{repo}/pulls/{number}/commits", token)
     files = paginate(f"/repos/{repo}/pulls/{number}/files", token)
-    problems = leak_violations(pr_surfaces(pr, commits, files), values)
+    problems = leak_violations(
+        pr_surfaces(
+            pr,
+            commits,
+            files,
+            comments=paginate(f"/repos/{repo}/issues/{number}/comments", token),
+            reviews=paginate(f"/repos/{repo}/pulls/{number}/reviews", token),
+            review_comments=paginate(f"/repos/{repo}/pulls/{number}/comments", token),
+        ),
+        values,
+    )
     for problem in problems:
         print(f"::error::{problem}")
     if not problems:

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -79,6 +79,39 @@ jobs:
           REFERENCE_KEYWORDS: .github/reference-keywords.json
         run: python3 scripts/ci/check_gate.py reviews
 
+  leaks:
+    name: "leaks"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # gitleaks walks the PR's own commits, not just the merge ref.
+          fetch-depth: 0
+
+      # Credential class (#189): the pinned gitleaks binary scans every
+      # PR commit's content. Pinned by version AND checksum — a moving
+      # release tag could swap the scanner under every repo's CI at
+      # once. --redact keeps whatever it finds out of this public log.
+      - name: gitleaks finds no credential in any PR commit
+        env:
+          BASE_SHA: {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %}
+          HEAD_SHA: {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+        run: |
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          ./gitleaks git --redact --no-banner --exit-code 1 \
+            --log-opts "$BASE_SHA..$HEAD_SHA"
+
+      # Identity class (#189): known strings, matched verbatim against
+      # every surface this PR publishes. The org secret carries values
+      # only — the repo commits nothing but this variable's name.
+      - name: No blocklisted string on any surface this PR publishes
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          PUSH_BLOCKLIST: {% raw %}${{ secrets.PUSH_BLOCKLIST }}{% endraw %}
+        run: python3 scripts/ci/check_gate.py leaks
+
 {% if agentic_merge_approval_gate %}  approval:
     name: "merge approval"
     runs-on: {{ agentic_actions_runner }}

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -62,10 +62,13 @@ repos:
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
       # `-l` prints only the offending FILE, never the matched line;
-      # unset env means the layer is off and the hook passes.
+      # unset env means the layer is off and the hook passes. The
+      # pattern is normalized first (CR/LF and stray pipes stripped):
+      # an editor-saved trailing newline would otherwise put an empty
+      # alternative into the pattern, matching every file.
       - id: push-blocklist
         name: no blocklisted string in staged files
-        entry: bash -c '[ -z "${PUSH_BLOCKLIST:-}" ] || ! grep -IilE -- "$PUSH_BLOCKLIST" "$@"' --
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
       - id: disambiguate-lint
         name: disambiguate --lint

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -72,6 +72,14 @@ repos:
         name: no blocklisted string in staged files
         entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
+      # The same gate at the commit-msg stage: messages auto-publish
+      # on push with no approval step, and the pre-commit stage fires
+      # before a message exists. Git hands this hook the message file.
+      - id: push-blocklist-msg
+        name: no blocklisted string in the commit message
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
+        language: system
+        stages: [commit-msg]
       - id: disambiguate-lint
         name: disambiguate --lint
         entry: uvx disambiguate=={{ agentic_disambiguate_version }} --lint{% if agentic_disambiguate_roots %} {{ agentic_disambiguate_roots }}{% endif %}

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -33,6 +33,11 @@ repos:
     hooks:
       - id: yamllint
         args: [--strict]
+  # Credential class (#189): stock rules over the staged diff, offline.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
@@ -54,6 +59,14 @@ repos:
       # Roots come from the agentic_disambiguate_roots answer: prek has no
       # repo-owned env file to feed DISAMBIGUATE_ROOTS through, so answer
       # data is the only place roots survive `copier update` unpatched.
+      # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
+      # in env, never committed — exactly grep's alternation syntax.
+      # `-l` prints only the offending FILE, never the matched line;
+      # unset env means the layer is off and the hook passes.
+      - id: push-blocklist
+        name: no blocklisted string in staged files
+        entry: bash -c '[ -z "${PUSH_BLOCKLIST:-}" ] || ! grep -IilE -- "$PUSH_BLOCKLIST" "$@"' --
+        language: system
       - id: disambiguate-lint
         name: disambiguate --lint
         entry: uvx disambiguate=={{ agentic_disambiguate_version }} --lint{% if agentic_disambiguate_roots %} {{ agentic_disambiguate_roots }}{% endif %}

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -61,6 +61,8 @@ repos:
       # data is the only place roots survive `copier update` unpatched.
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
+      # An entry may name its placeholder (`value=pb:name`); labels
+      # are metadata and are stripped before the pattern is built.
       # `-l` prints only the offending FILE, never the matched line;
       # unset env means the layer is off and the hook passes. The
       # pattern is normalized first (CR/LF and stray pipes stripped):
@@ -68,7 +70,7 @@ repos:
       # alternative into the pattern, matching every file.
       - id: push-blocklist
         name: no blocklisted string in staged files
-        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
+        entry: bash -c 'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\r\n" | sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); [ -z "$p" ] || ! grep -IilE -- "$p" "$@"' --
         language: system
       - id: disambiguate-lint
         name: disambiguate --lint

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -512,12 +512,23 @@ def test_an_in_flight_gate_run_is_not_stale_and_reports_as_busy():
 
 def test_parse_blocklist_splits_on_pipes_and_drops_blanks():
     assert gate.parse_blocklist("alice|Bob Example| |bob@example.org|") == [
-        "alice",
-        "Bob Example",
-        "bob@example.org",
+        ("alice", "entry 1"),
+        ("Bob Example", "entry 2"),
+        ("bob@example.org", "entry 4"),
     ]
     assert gate.parse_blocklist("") == []
     assert gate.parse_blocklist(None) == []
+
+
+def test_parse_blocklist_reads_explicit_placeholder_labels():
+    """An entry may name its own placeholder (`value=pb:name`), so the
+    label survives list edits — a positional 'entry N' drifts the
+    moment a term is inserted above it."""
+    assert gate.parse_blocklist("alice=pb:old-account|bob|carol=pb:nickname") == [
+        ("alice", "pb:old-account"),
+        ("bob", "entry 2"),
+        ("carol", "pb:nickname"),
+    ]
 
 
 def test_leak_violations_name_surface_and_entry_never_the_value():
@@ -525,21 +536,25 @@ def test_leak_violations_name_surface_and_entry_never_the_value():
     a CI log on a public repo is a public surface — so a violation names
     WHERE and WHICH entry, never WHAT (#189)."""
     surfaces = [("PR title", "ship it"), ("commit 3f2a1b0 message", "by alice")]
-    problems = gate.leak_violations(surfaces, ["alice", "bob"])
+    values = gate.parse_blocklist("alice=pb:old-account|bob")
+    problems = gate.leak_violations(surfaces, values)
     assert len(problems) == 1
     assert "commit 3f2a1b0 message" in problems[0]
-    assert "entry 1" in problems[0]
+    assert "pb:old-account" in problems[0]
     assert "alice" not in problems[0]
 
 
 def test_leak_violations_match_case_insensitively():
-    problems = gate.leak_violations([("PR body", "Mail ALICE@example.org")], ["alice"])
+    problems = gate.leak_violations(
+        [("PR body", "Mail ALICE@example.org")], gate.parse_blocklist("alice")
+    )
     assert len(problems) == 1
+    assert "entry 1" in problems[0]
 
 
 def test_leak_violations_report_every_hit_pair_once():
     surfaces = [("PR title", "alice and bob"), ("PR body", "bob, bob, bob")]
-    problems = gate.leak_violations(surfaces, ["alice", "bob"])
+    problems = gate.leak_violations(surfaces, gate.parse_blocklist("alice|bob"))
     assert len(problems) == 3
 
 
@@ -573,7 +588,7 @@ def test_leaks_job_rides_the_gate_everywhere():
 
 BLOCKLIST_HOOK_ENTRY = (
     'bash -c \'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\\r\\n" | '
-    'sed "s/||*/|/g;s/^|//;s/|$//"); '
+    'sed "s/=[^|]*//g;s/||*/|/g;s/^|//;s/|$//"); '
     '[ -z "$p" ] || ! grep -IilE -- "$p" "$@"\' --'
 )
 
@@ -633,6 +648,17 @@ def test_blocklist_hook_tolerates_editor_added_newlines_and_stray_pipes(tmp_path
         assert hit.returncode == 1, f"blocklist {messy!r} missed a real hit"
     only_noise = run_blocklist_hook(tmp_path, "anything", "|\n")
     assert only_noise.returncode == 0
+
+
+def test_blocklist_hook_matches_the_value_not_its_placeholder_label(tmp_path):
+    """`value=pb:name` entries: the label is metadata, never a pattern —
+    a file merely MENTIONING the placeholder must pass, and the value
+    still fails."""
+    labeled = "alice=pb:old-account|bob"
+    hit = run_blocklist_hook(tmp_path, "alice was here", labeled)
+    assert hit.returncode == 1
+    mention = run_blocklist_hook(tmp_path, "scrubbed to pb:old-account", labeled)
+    assert mention.returncode == 0
 
 
 # ------------------------------------------------- copies stay pinned

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -587,6 +587,27 @@ def test_pr_surfaces_include_the_prs_own_comment_threads():
     assert surfaces["review comment 7 on a.py"] == "inline note"
 
 
+def test_referenced_tickets_come_from_any_ref_in_the_body():
+    """Every `#n` / `owner/repo#n` the body mentions, keyword or not:
+    a see-also leaks exactly like a CLOSES."""
+    body = "CLOSES #7, see also pandoscope/skills#9 and #7 again"
+    refs = gate.referenced_tickets(body, "pandoscope/meta")
+    assert refs == ["pandoscope/meta#7", "pandoscope/skills#9"]
+    assert gate.referenced_tickets(None, "pandoscope/meta") == []
+
+
+def test_pr_surfaces_include_branch_name_and_referenced_tickets():
+    """The branch name publishes with the PR; referenced tickets are
+    already public, so a hit there is red-and-loud at the gate rather
+    than prevention — the principal fixes the ticket, the PR unblocks."""
+    pr = {"title": "t", "body": "b", "head": {"ref": "claude/7-thing"}}
+    tickets = [("o/r#5", "ticket body", [{"id": 3, "body": "a comment"}])]
+    surfaces = dict(gate.pr_surfaces(pr, [], [], tickets=tickets))
+    assert surfaces["branch name"] == "claude/7-thing"
+    assert surfaces["ticket o/r#5 body"] == "ticket body"
+    assert surfaces["ticket o/r#5 comment 3"] == "a comment"
+
+
 def test_leaks_job_rides_the_gate_everywhere():
     """Layer 2 of #189: the leaks job rides ci-ok in the template AND
     both store variants, so the one required context enforces it. The

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -8,6 +8,8 @@ template-first, like every other multi-copy file here.
 
 import importlib.util
 import json
+import os
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -543,6 +545,78 @@ def test_leak_violations_report_every_hit_pair_once():
 
 def test_empty_blocklist_finds_nothing():
     assert gate.leak_violations([("PR body", "anything at all")], []) == []
+
+
+def test_leaks_job_rides_the_gate_everywhere():
+    """Layer 2 of #189: the leaks job rides ci-ok in the template AND
+    both store variants, so the one required context enforces it. The
+    gitleaks binary is pinned by version and checksum — a moving 'latest'
+    would let a compromised release into every repo's CI at once."""
+    paths = [
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "ci-ok.yml.jinja",
+        ROOT / "decision-memory" / ".github" / "workflows" / "ci-ok.yml.jinja",
+        ROOT / "evidence-memory" / ".github" / "workflows" / "ci-ok.yml.jinja",
+    ]
+    for path in paths:
+        text = path.read_text()
+        assert "check_gate.py leaks" in text, path
+        assert "secrets.PUSH_BLOCKLIST" in text, path
+        assert "gitleaks_8.30.1_linux_x64.tar.gz" in text, path
+        assert (
+            "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb" in text
+        ), path
+
+
+BLOCKLIST_HOOK_ENTRY = (
+    'bash -c \'[ -z "${PUSH_BLOCKLIST:-}" ] || '
+    '! grep -IilE -- "$PUSH_BLOCKLIST" "$@"\' --'
+)
+
+
+def test_prek_carries_gitleaks_and_the_blocklist_hook():
+    """Layer 1 of #189: the local gate in every rendered repo, and in
+    this repo's own (deliberately divergent) config too."""
+    template = (
+        ROOT
+        / "template"
+        / "{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja"
+    ).read_text()
+    own = (ROOT / ".pre-commit-config.yaml").read_text()
+    for config in (template, own):
+        assert "https://github.com/gitleaks/gitleaks" in config
+        assert "rev: v8.30.1" in config
+        assert BLOCKLIST_HOOK_ENTRY in config
+
+
+def run_blocklist_hook(tmp_path, content, blocklist):
+    """The push-blocklist hook's script, invoked as prek invokes it."""
+    script = BLOCKLIST_HOOK_ENTRY[len("bash -c '") : -len("' --")]
+    target = tmp_path / "staged.md"
+    target.write_text(content)
+    return subprocess.run(
+        ["bash", "-c", script, "--", str(target)],
+        env={"PATH": os.environ["PATH"], "PUSH_BLOCKLIST": blocklist},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_blocklist_hook_catches_a_planted_value_and_passes_clean(tmp_path):
+    """#104 acceptance: a planted fixture value is caught; the hook
+    prints only the offending FILENAME (grep -l), never the matched
+    line — the terminal transcript may itself be shared."""
+    hit = run_blocklist_hook(tmp_path, "contact ALICE@example.org", "alice|bob")
+    assert hit.returncode == 1
+    assert hit.stdout.strip() == str(tmp_path / "staged.md")
+    clean = run_blocklist_hook(tmp_path, "nothing to see", "alice|bob")
+    assert clean.returncode == 0
+    unset = run_blocklist_hook(tmp_path, "alice everywhere", "")
+    assert unset.returncode == 0
 
 
 # ------------------------------------------------- copies stay pinned

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -562,6 +562,31 @@ def test_empty_blocklist_finds_nothing():
     assert gate.leak_violations([("PR body", "anything at all")], []) == []
 
 
+def test_pr_surfaces_include_the_prs_own_comment_threads():
+    """Comments publish the instant they are posted, so scanning them
+    cannot prevent — but the gate re-runs on exactly these events, and
+    a hit blocks merge and goes loud instead of lingering quietly."""
+    pr = {"title": "t", "body": "b"}
+    comments = [{"id": 9, "user": {"login": "x"}, "body": "general remark"}]
+    reviews = [{"id": 4, "user": {"login": "x"}, "body": "review summary"}]
+    review_comments = [
+        {"id": 7, "user": {"login": "x"}, "body": "inline note", "path": "a.py"}
+    ]
+    surfaces = dict(
+        gate.pr_surfaces(
+            pr,
+            [],
+            [],
+            comments=comments,
+            reviews=reviews,
+            review_comments=review_comments,
+        )
+    )
+    assert surfaces["comment 9"] == "general remark"
+    assert surfaces["review 4"] == "review summary"
+    assert surfaces["review comment 7 on a.py"] == "inline note"
+
+
 def test_leaks_job_rides_the_gate_everywhere():
     """Layer 2 of #189: the leaks job rides ci-ok in the template AND
     both store variants, so the one required context enforces it. The

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -650,6 +650,24 @@ def test_blocklist_hook_tolerates_editor_added_newlines_and_stray_pipes(tmp_path
     assert only_noise.returncode == 0
 
 
+def test_blocklist_hook_also_gates_the_commit_message(tmp_path):
+    """Commit messages auto-publish on push with no approval step, so
+    the local gate covers them too: a second hook with the same entry
+    at the commit-msg stage, where git hands it the message file. The
+    functional path is the same entry already proven above; this pins
+    the wiring in both prek configs."""
+    template = (
+        ROOT
+        / "template"
+        / "{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja"
+    ).read_text()
+    own = (ROOT / ".pre-commit-config.yaml").read_text()
+    for config in (template, own):
+        _, tail = config.split("id: push-blocklist-msg", 1)
+        assert "stages: [commit-msg]" in tail.split("- id:")[0]
+        assert config.count(BLOCKLIST_HOOK_ENTRY) == 2
+
+
 def test_blocklist_hook_matches_the_value_not_its_placeholder_label(tmp_path):
     """`value=pb:name` entries: the label is metadata, never a pattern —
     a file merely MENTIONING the placeholder must pass, and the value

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -505,6 +505,46 @@ def test_an_in_flight_gate_run_is_not_stale_and_reports_as_busy():
     assert not gate.gate_busy([gate_run(1)] + runs[2:], ".github/workflows/ci-ok.yml")
 
 
+# -------------------------------------------------------------- leaks
+
+
+def test_parse_blocklist_splits_on_pipes_and_drops_blanks():
+    assert gate.parse_blocklist("alice|Bob Example| |bob@example.org|") == [
+        "alice",
+        "Bob Example",
+        "bob@example.org",
+    ]
+    assert gate.parse_blocklist("") == []
+    assert gate.parse_blocklist(None) == []
+
+
+def test_leak_violations_name_surface_and_entry_never_the_value():
+    """The denylist values are themselves the identifying material, and
+    a CI log on a public repo is a public surface — so a violation names
+    WHERE and WHICH entry, never WHAT (#189)."""
+    surfaces = [("PR title", "ship it"), ("commit 3f2a1b0 message", "by alice")]
+    problems = gate.leak_violations(surfaces, ["alice", "bob"])
+    assert len(problems) == 1
+    assert "commit 3f2a1b0 message" in problems[0]
+    assert "entry 1" in problems[0]
+    assert "alice" not in problems[0]
+
+
+def test_leak_violations_match_case_insensitively():
+    problems = gate.leak_violations([("PR body", "Mail ALICE@example.org")], ["alice"])
+    assert len(problems) == 1
+
+
+def test_leak_violations_report_every_hit_pair_once():
+    surfaces = [("PR title", "alice and bob"), ("PR body", "bob, bob, bob")]
+    problems = gate.leak_violations(surfaces, ["alice", "bob"])
+    assert len(problems) == 3
+
+
+def test_empty_blocklist_finds_nothing():
+    assert gate.leak_violations([("PR body", "anything at all")], []) == []
+
+
 # ------------------------------------------------- copies stay pinned
 
 

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -572,8 +572,9 @@ def test_leaks_job_rides_the_gate_everywhere():
 
 
 BLOCKLIST_HOOK_ENTRY = (
-    'bash -c \'[ -z "${PUSH_BLOCKLIST:-}" ] || '
-    '! grep -IilE -- "$PUSH_BLOCKLIST" "$@"\' --'
+    'bash -c \'p=$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d "\\r\\n" | '
+    'sed "s/||*/|/g;s/^|//;s/|$//"); '
+    '[ -z "$p" ] || ! grep -IilE -- "$p" "$@"\' --'
 )
 
 
@@ -617,6 +618,21 @@ def test_blocklist_hook_catches_a_planted_value_and_passes_clean(tmp_path):
     assert clean.returncode == 0
     unset = run_blocklist_hook(tmp_path, "alice everywhere", "")
     assert unset.returncode == 0
+
+
+def test_blocklist_hook_tolerates_editor_added_newlines_and_stray_pipes(tmp_path):
+    """The secret material comes from an editor-saved file, and editors
+    add a final newline for good reason. A raw newline (or a doubled or
+    dangling pipe) would put an EMPTY alternative into the grep pattern,
+    which matches every file — so the hook normalizes the pattern
+    instead of demanding a newline-free file."""
+    for messy in ("alice|bob\n", "alice||bob", "|alice|bob|", "alice|bob\r\n"):
+        clean = run_blocklist_hook(tmp_path, "nothing to see", messy)
+        assert clean.returncode == 0, f"blocklist {messy!r} false-positived"
+        hit = run_blocklist_hook(tmp_path, "contact alice today", messy)
+        assert hit.returncode == 1, f"blocklist {messy!r} missed a real hit"
+    only_noise = run_blocklist_hook(tmp_path, "anything", "|\n")
+    assert only_noise.returncode == 0
 
 
 # ------------------------------------------------- copies stay pinned


### PR DESCRIPTION
ADVANCES #189
ADVANCES #104

Two leak classes, two mechanisms, both riding existing vehicles:

**Layer 1 — local gate (prek).** gitleaks v8.30.1 as a stock prek hook (offline, credential class), plus a `push-blocklist` local hook: `PUSH_BLOCKLIST` carries `|`-separated values in env — never committed — which is exactly grep's alternation syntax, so the whole committed mechanism is one bash line. `grep -l` prints only the offending filename, never the matched line. Both hooks land in the rendered config and this repo's own (deliberately divergent) config.

**Layer 2 — CI gate.** A `leaks` job rides `ci-ok` in the template and both store variants, so the one required context enforces it with no ruleset change. Two steps: the gitleaks binary — pinned by version AND sha256, since a moving release tag could swap the scanner under every repo's CI at once — scans every PR commit's content with `--redact`; and a new `check_gate.py leaks` subcommand scans PR title, body, commit messages, commit author/committer names and emails, and the diff against the denylist (`PUSH_BLOCKLIST` as an org Actions secret). Commit metadata is scanned by the custom subcommand because no established scanner covers it, and it auto-publishes on merge with no approval step.

Design decisions, also in the commit messages:

- Violations are value-silent — they name the surface and the 1-based entry, never the value: the gate's own log on a public repo is one of the surfaces the gate protects.
- An empty/unset `PUSH_BLOCKLIST` warns and passes: failing every fork and fresh consumer over an unset org secret would be wrong, but silence would hide that the layer is off.
- The evidence store's AGENTS.md now states plainly that both layers catch verbatim strings only — a green scan narrows the surface, never grants clearance (#104's honesty clause).

Testing: red-first TDD on the pure decision logic (`parse_blocklist`, `leak_violations`) and on the wiring; the push-blocklist entry is proven against a planted fixture value (catch, clean pass, unset-env pass); full suite 289 passed incl. e2e renders and self-application; prek green on every commit.

Remaining #189 layers (TruffleHog scheduled org audit, `run_secret_scanning`) follow in later PRs. Setup note for the principal: create the org Actions secret `PUSH_BLOCKLIST` (values only, `|`-separated) and export the same variable in local agent environments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790716781&installation_model_id=432661&pr_number=192&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F192&signature=1b5ae000e666500d8b03712b865adfae58a718b528d40861ddc25fc552306fea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->