### PR TITLE
test: leak-gate canary drill (never merges)

### DIFF
--- a/canary-drill.txt
+++ b/canary-drill.txt
@@ -1,0 +1,1 @@
+canary payload: aif0saeB


### PR DESCRIPTION
ADVANCES #189

Canary drill for the leaks gate — one surface per round, expecting a value-silent red for each. The single commit plants the test nonce in the file content, the commit message, and the author name; the scratch ticket #193 carries it in a comment. Round E planted it in a plain comment below; this edit is the re-judge poke that should catch it. Truth table lands here when the drill completes; this PR is then closed and the branch deleted.