### PR TITLE
Vendor notify-sessions-manifest workflow; lint guards vendored-file drift

### DIFF
--- a/.github/workflows/notify-sessions-manifest.yml
+++ b/.github/workflows/notify-sessions-manifest.yml
@@ -5,6 +5,10 @@ name: Notify sessions manifest
 # tell meta to regenerate environment/repos.manifest — no cron, no
 # waiting. meta re-enumerates the whole org on every dispatch, so this
 # event also prunes entries for repos that vanished since the last run.
+#
+# Vendored unconditionally: the paths filter makes it inert in any
+# repo without a `.pandoscope-sessions` marker. The marker itself is a
+# per-repo opt-in the template never stamps.
 on:
   push:
     branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,9 @@ Code-specific skills:
 - Never push to `main`
 - Create PR immediately on branch creation
 - Commits: conventional commits
+- **Merge commits only on `main`** — feature branches rebase onto
+  `main`, never merge it in; the `commitlint` job rejects `Merge`
+  headers on PR commits.
 - **Ticket references in PR bodies are ALL CAPS, from the central list**
   (`.github/reference-keywords.json`, enforced by the `ticket` job):
   `CLOSES #n` / `FIXES #n` close on merge,

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,14 +2,13 @@ export default {
   extends: ["@commitlint/config-conventional"],
   // commitlint's defaultIgnores silently exempts fixup!/squash!
   // headers (measured: a fixup! commit passed the PR gate unparsed),
-  // which hollows out "the type enum IS the allow-list". Off, with
-  // only two explicit exemptions: PR branches legitimately merge main
-  // in, and git-generated revert headers are not conventional.
+  // which hollows out "the type enum IS the allow-list". Off, with one
+  // explicit exemption: git-generated revert headers are not
+  // conventional. Merge headers get none — merge commits are allowed
+  // only on main (feature branches rebase), and since this gate lints
+  // only feature-branch commits, a Merge header here IS the violation.
   defaultIgnores: false,
-  ignores: [
-    (message) => message.startsWith("Merge "),
-    (message) => message.startsWith('Revert "'),
-  ],
+  ignores: [(message) => message.startsWith('Revert "')],
   rules: {
     "header-max-length": [0, "always", Infinity],
     "body-max-line-length": [0, "always", Infinity],

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,5 +1,15 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  // commitlint's defaultIgnores silently exempts fixup!/squash!
+  // headers (measured: a fixup! commit passed the PR gate unparsed),
+  // which hollows out "the type enum IS the allow-list". Off, with
+  // only two explicit exemptions: PR branches legitimately merge main
+  // in, and git-generated revert headers are not conventional.
+  defaultIgnores: false,
+  ignores: [
+    (message) => message.startsWith("Merge "),
+    (message) => message.startsWith('Revert "'),
+  ],
   rules: {
     "header-max-length": [0, "always", Infinity],
     "body-max-line-length": [0, "always", Infinity],

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -142,6 +142,9 @@ Code-specific skills:
 - Never push to `main`
 - Create PR immediately on branch creation
 - Commits: conventional commits
+- **Merge commits only on `main`** — feature branches rebase onto
+  `main`, never merge it in; the `commitlint` job rejects `Merge`
+  headers on PR commits.
 {%- set refkw = reference_keywords() %}
 {%- set closing = refkw.allowed | dictsort | selectattr("1", "equalto", "closing") | map(attribute="0") | list %}
 {%- set nonclosing = refkw.allowed | dictsort | rejectattr("1", "equalto", "closing") | map(attribute="0") | list %}

--- a/template/commitlint.config.mjs
+++ b/template/commitlint.config.mjs
@@ -2,14 +2,13 @@ export default {
   extends: ["@commitlint/config-conventional"],
   // commitlint's defaultIgnores silently exempts fixup!/squash!
   // headers (measured: a fixup! commit passed the PR gate unparsed),
-  // which hollows out "the type enum IS the allow-list". Off, with
-  // only two explicit exemptions: PR branches legitimately merge main
-  // in, and git-generated revert headers are not conventional.
+  // which hollows out "the type enum IS the allow-list". Off, with one
+  // explicit exemption: git-generated revert headers are not
+  // conventional. Merge headers get none — merge commits are allowed
+  // only on main (feature branches rebase), and since this gate lints
+  // only feature-branch commits, a Merge header here IS the violation.
   defaultIgnores: false,
-  ignores: [
-    (message) => message.startsWith("Merge "),
-    (message) => message.startsWith('Revert "'),
-  ],
+  ignores: [(message) => message.startsWith('Revert "')],
   rules: {
     "header-max-length": [0, "always", Infinity],
     "body-max-line-length": [0, "always", Infinity],

--- a/template/commitlint.config.mjs
+++ b/template/commitlint.config.mjs
@@ -1,5 +1,15 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  // commitlint's defaultIgnores silently exempts fixup!/squash!
+  // headers (measured: a fixup! commit passed the PR gate unparsed),
+  // which hollows out "the type enum IS the allow-list". Off, with
+  // only two explicit exemptions: PR branches legitimately merge main
+  // in, and git-generated revert headers are not conventional.
+  defaultIgnores: false,
+  ignores: [
+    (message) => message.startsWith("Merge "),
+    (message) => message.startsWith('Revert "'),
+  ],
   rules: {
     "header-max-length": [0, "always", Infinity],
     "body-max-line-length": [0, "always", Infinity],

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -32,6 +32,44 @@ jobs:
             exit 1
           fi
 
+  # Rendered even when agentic_precommit is 'none' for the same reason
+  # as the marker check: vendored files are template-owned (#196), and
+  # a hand-edit to one must go red here rather than drift silently —
+  # that is how hand-copied workflows went unnoticed. Recopying the
+  # STAMPED ref makes this a local-modification check only; being
+  # behind the template is the template-update weekly audit's job.
+  template-drift:
+    name: "vendored files match the stamped template"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Recopy the stamped template version and diff
+        run: |
+          set -euo pipefail
+          answers_file=".copier-answers.agentic.yml"
+          if [ ! -f "$answers_file" ]; then
+            echo "No $answers_file — not a stamped repo; nothing to check."
+            exit 0
+          fi
+          stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
+
+          # Seeded (_skip_if_exists) files already exist, so recopy
+          # leaves them alone — they stay exempt structurally.
+          uvx --with copier-template-extensions copier recopy \
+            --answers-file "$answers_file" \
+            --defaults --trust --skip-tasks --vcs-ref "$stamped"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --porcelain
+            git diff
+            echo "::error::Vendored files differ from the stamped template ($stamped). These files are template-owned: change them in the template repo and let the release fan-out deliver the update, or revert the local edit."
+            exit 1
+          fi
+          echo "Vendored files match the stamped template ($stamped)."
+
   # Full conventional commits on every PR commit (#137): the type enum
   # IS the allow-list — `fixup!`/`squash!` fail header parsing and
   # `wip` is not a type, so "unsquashed history" stays safe to require.

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -71,8 +71,10 @@ jobs:
           echo "Vendored files match the stamped template ($stamped)."
 
   # Full conventional commits on every PR commit (#137): the type enum
-  # IS the allow-list — `fixup!`/`squash!` fail header parsing and
-  # `wip` is not a type, so "unsquashed history" stays safe to require.
+  # IS the allow-list — `wip` is not a type, and the config turns
+  # commitlint's defaultIgnores off so `fixup!`/`squash!` headers are
+  # parsed (and fail) instead of silently skipped (#196). That keeps
+  # "unsquashed history" safe to require.
   commitlint:
     name: "commitlint (PR commits)"
     if: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/notify-sessions-manifest.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/notify-sessions-manifest.yml.jinja
@@ -1,0 +1,41 @@
+name: Notify sessions manifest
+
+# The event side of meta's regenerate-repos-manifest workflow: the
+# moment this repo's session marker changes on the default branch,
+# tell meta to regenerate environment/repos.manifest — no cron, no
+# waiting. meta re-enumerates the whole org on every dispatch, so this
+# event also prunes entries for repos that vanished since the last run.
+#
+# Vendored unconditionally: the paths filter makes it inert in any
+# repo without a `.pandoscope-sessions` marker. The marker itself is a
+# per-repo opt-in the template never stamps.
+on:
+  push:
+    branches: [main]
+    paths: [".pandoscope-sessions"]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: "dispatch sessions-marker-changed to meta"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - name: Mint release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: {% raw %}${{ vars.RELEASE_BOT_CLIENT_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.RELEASE_BOT_PRIVATE_KEY }}{% endraw %}
+          owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+
+      - name: Tell meta the marker changed
+        env:
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          OWNER: {% raw %}${{ github.repository_owner }}{% endraw %}
+          REPO: {% raw %}${{ github.repository }}{% endraw %}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$OWNER/meta/dispatches" \
+            -f event_type=sessions-marker-changed \
+            -f "client_payload[repo]=$REPO"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -67,6 +67,9 @@ GITHUB_ONLY_FILES = frozenset(
         ".github/workflows/add-to-project.yml",
         ".github/workflows/labels.yml",
         ".github/workflows/lint.yml",
+        # Inert without a `.pandoscope-sessions` marker (paths filter);
+        # the marker is a per-repo opt-in the template never stamps.
+        ".github/workflows/notify-sessions-manifest.yml",
         ".github/workflows/ticket-closed.yml",
         # The uniform CI gate (#137): the one required context and the
         # keyword file its checks read.

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -558,6 +558,31 @@ def test_lint_workflow_guards_vendored_template_drift(
         )
 
 
+def test_commitlint_config_rejects_fixup_and_squash_commits(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """commitlint must parse fixup!/squash! headers, not skip them.
+
+    commitlint's defaultIgnores silently exempts fixup!/squash!
+    commits (measured: a fixup! commit sailed through the PR gate), so
+    "the type enum IS the allow-list" only holds with defaultIgnores
+    off. Merge and revert commits keep an explicit exemption: PR
+    branches legitimately merge main in, and git-generated revert
+    headers are not conventional.
+    """
+    dst_path = _render(tmp_path, base_answers, "commitlint-ignores")
+
+    _check_file_contents(
+        dst_path / "commitlint.config.mjs",
+        [
+            "defaultIgnores: false",
+            'startsWith("Merge ")',
+            "startsWith('Revert \"')",
+        ],
+    )
+
+
 def test_grilling_pinned_to_frankify_derivation(
     tmp_path: Path,
     base_answers: dict[str, str],

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -498,6 +498,66 @@ def test_forgejo_forge_ships_no_github_workflow(
     assert not (dst_path / ".github").exists()
 
 
+def test_github_forge_ships_notify_sessions_manifest_workflow(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """GitHub forge: the sessions-marker notify workflow is vendored.
+
+    Vendored unconditionally because its path filter makes it inert in
+    any repo without a `.pandoscope-sessions` marker; the marker itself
+    stays a per-repo opt-in the template never stamps.
+    """
+    dst_path = _render(tmp_path, base_answers, "notify-github")
+
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "notify-sessions-manifest.yml",
+        [
+            'paths: [".pandoscope-sessions"]',
+            "event_type=sessions-marker-changed",
+            "runs-on: ubuntu-latest",
+            # GitHub expressions must survive rendering (file is not Jinja).
+            "${{ vars.RELEASE_BOT_CLIENT_ID }}",
+            "${{ secrets.RELEASE_BOT_PRIVATE_KEY }}",
+        ],
+    )
+    assert not (dst_path / ".pandoscope-sessions").exists(), (
+        "the marker is a per-repo opt-in, never stamped by the template"
+    )
+
+
+def test_lint_workflow_guards_vendored_template_drift(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """Hand-editing a template-vendored file must turn CI red.
+
+    The lint workflow recopies the STAMPED template version (the
+    `_commit` in the answers file) and fails on any diff — a
+    local-modification check, orthogonal to the being-behind drift the
+    template-update weekly audit covers. Rendered even without prek,
+    like the conflict-marker job: both guard the template contract. The
+    template repo itself carries no answers file, so the job skips
+    cleanly there.
+    """
+    for precommit in ("prek", "none"):
+        answers = {**base_answers, "agentic_precommit": precommit}
+        dst_path = _render(tmp_path, answers, f"lint-drift-{precommit}")
+
+        _check_file_contents(
+            dst_path / ".github" / "workflows" / "lint.yml",
+            [
+                "copier recopy",
+                '--defaults --trust --skip-tasks --vcs-ref "$stamped"',
+                "copier-template-extensions",
+                'awk \'$1 == "_commit:" {print $2}\'',
+                "not a stamped repo",
+                "git status --porcelain",
+                "template-owned",
+            ],
+        )
+
+
 def test_grilling_pinned_to_frankify_derivation(
     tmp_path: Path,
     base_answers: dict[str, str],

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -550,7 +550,7 @@ def test_lint_workflow_guards_vendored_template_drift(
                 "copier recopy",
                 '--defaults --trust --skip-tasks --vcs-ref "$stamped"',
                 "copier-template-extensions",
-                'awk \'$1 == "_commit:" {print $2}\'',
+                "awk '$1 == \"_commit:\" {print $2}'",
                 "not a stamped repo",
                 "git status --porcelain",
                 "template-owned",

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -567,9 +567,11 @@ def test_commitlint_config_rejects_fixup_and_squash_commits(
     commitlint's defaultIgnores silently exempts fixup!/squash!
     commits (measured: a fixup! commit sailed through the PR gate), so
     "the type enum IS the allow-list" only holds with defaultIgnores
-    off. Merge and revert commits keep an explicit exemption: PR
-    branches legitimately merge main in, and git-generated revert
-    headers are not conventional.
+    off. Merge headers get NO exemption — merge commits are allowed
+    only on main (ruled), and this gate lints only feature-branch
+    commits, so a Merge header in its range is itself the violation.
+    Only git-generated revert headers stay exempt: they are not
+    conventional, and reverts are legitimate anywhere.
     """
     dst_path = _render(tmp_path, base_answers, "commitlint-ignores")
 
@@ -577,9 +579,9 @@ def test_commitlint_config_rejects_fixup_and_squash_commits(
         dst_path / "commitlint.config.mjs",
         [
             "defaultIgnores: false",
-            'startsWith("Merge ")',
             "startsWith('Revert \"')",
         ],
+        unexpect_strs=['startsWith("Merge'],
     )
 
 


### PR DESCRIPTION
CLOSES #196

The sessions-marker rollout hand-copied `.github/workflows/notify-sessions-manifest.yml` into four repos instead of distributing it through this template, and nothing would have turned CI red over that kind of hand-edit. Two changes, TDD:

**Vendor the notify workflow.** `template/.../workflows/notify-sessions-manifest.yml.jinja` ships the workflow to every GitHub-forge repo, `runs-on` parameterized like the other rendered workflows. Vendored unconditionally on purpose: its `paths: [".pandoscope-sessions"]` filter makes it inert in any repo without a marker, and the marker itself stays a per-repo opt-in the template never stamps (asserted in the render test). The template repo's own copy is adopted via the restamp commit per the template-first route.

**Guard vendored files in CI.** The vendored lint workflow gains a `template-drift` job: `copier recopy` at the repo's **stamped** template version (`_commit` from `.copier-answers.agentic.yml`), then red on any resulting working-tree diff, naming the files and the fix (change it in the template, or revert). Pinning to the stamped ref keeps this a pure local-modification check — being *behind* the template remains the template-update weekly audit's finding, so the two guards never double-report. Seeded `_skip_if_exists` files are exempt structurally (recopy never overwrites an existing seeded file), and a repo without an answers file (this template itself) skips cleanly.

Full suite green locally: 298 passed. Downstream repos pick both up on the next release fan-out — at which point the four hand-copies become template-managed, and any future hand-edit to a vendored file fails lint.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790804254&installation_model_id=432661&pr_number=197&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F197&signature=de56f2786b45db089144ef7a4af07a12ecf2f6b91cf841296ca505c3ab6cc798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->