### PR TITLE
feat(audit): daily per-repo trufflehog self-scan — leak layer 3

### DIFF
--- a/.github/workflows/trufflehog-audit.yml
+++ b/.github/workflows/trufflehog-audit.yml
@@ -1,0 +1,110 @@
+name: TruffleHog audit
+
+# Layer 3 of the leak-prevention stack
+# (agentic-engineering-template#189): a daily retroactive scan of THIS
+# repo's surfaces no hook can gate — issue and PR descriptions and
+# comments, plus full git history — with TruffleHog's stock credential
+# rules AND the PUSH_BLOCKLIST identity denylist as custom detectors.
+# One job per repo, responsible only for the repo it lives on: the
+# scan runs on the repo's own token (no org enumeration, no app
+# credential) and is free on public repos. A finding turns the run
+# red — the red run is the alert. Layers 1–2 gate what agents push;
+# this net catches what publishes without a gate (a comment posted by
+# hand, content that predates the gates, a denylist entry added after
+# the fact).
+on:
+  schedule:
+    - cron: "26 5 * * *"
+  workflow_dispatch:
+    inputs:
+      scan_private:
+        description: >-
+          Scan even though this repo is private — the
+          scan-before-going-public check.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: trufflehog-audit
+
+jobs:
+  audit:
+    name: "trufflehog self-scan"
+    runs-on: ubuntu-latest
+    steps:
+      # Private repos are not exposed, so their daily run stops here
+      # for free instead of billing a scan nobody needs. The dispatch
+      # input overrides for the moment before a repo goes public.
+      - name: Skip private repos unless explicitly overridden
+        id: visibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERRIDE: ${{ inputs.scan_private }}
+        run: |
+          set -euo pipefail
+          private="$(gh api "repos/$GITHUB_REPOSITORY" --jq .private)"
+          if [ "$private" = "true" ] && [ "$OVERRIDE" != "true" ]; then
+            echo "::notice::private repo — not exposed, audit skipped (dispatch with scan_private to override)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.visibility.outputs.skip == 'false'
+
+      # Pinned by version AND sha256 (the ci-ok gitleaks convention):
+      # a moving release tag must not swap the scanner under the audit.
+      - name: Install trufflehog 3.97.1 (pinned by sha256)
+        if: steps.visibility.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          curl -sSfL -o trufflehog.tar.gz \
+            https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_linux_amd64.tar.gz
+          echo "f863ea3a8d786f7d097870496c977944cce7372a2fe1e56707d965016e543ece  trufflehog.tar.gz" | sha256sum -c
+          tar -xzf trufflehog.tar.gz trufflehog
+
+      # The denylist values live only in the org secret and the config
+      # file generated here; the generator's own output is value-silent
+      # and GitHub additionally masks the secret in logs. An empty
+      # blocklist is loud but not fatal: stock rules still scan.
+      - name: Generate denylist detectors from PUSH_BLOCKLIST
+        if: steps.visibility.outputs.skip == 'false'
+        env:
+          PUSH_BLOCKLIST: ${{ secrets.PUSH_BLOCKLIST }}
+        run: |
+          set -euo pipefail
+          scripts/ci/trufflehog-detectors.sh "$RUNNER_TEMP/detectors.yaml"
+          if [ ! -e "$RUNNER_TEMP/detectors.yaml" ]; then
+            echo "::warning::PUSH_BLOCKLIST is empty — the scan runs with stock credential rules only (identity layer off)."
+            printf 'detectors: []\n' > "$RUNNER_TEMP/detectors.yaml"
+          fi
+
+      # --json so findings can be reduced to value-silent lines: the
+      # raw stream carries the matched secret (Raw/RawV2), so it is
+      # never printed — only detector label and location.
+      - name: Scan this repo — git history, issues, PRs, comments
+        if: steps.visibility.outputs.skip == 'false'
+        env:
+          GH_AUDIT_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ./trufflehog github "--repo=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --issue-comments --pr-comments \
+            --config "$RUNNER_TEMP/detectors.yaml" \
+            --token "$GH_AUDIT_TOKEN" \
+            --json --no-update --fail --log-level=-1 \
+            > "$RUNNER_TEMP/findings.jsonl" && rc=0 || rc=$?
+          # trufflehog --fail exits 183 on findings (the reporter turns
+          # those red itself); any other nonzero exit is a scan failure
+          # and must not pass silently.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 183 ]; then
+            echo "::error::trufflehog exited $rc (scan failure, not findings)"
+            exit "$rc"
+          fi
+          scripts/ci/trufflehog-report.sh "$RUNNER_TEMP/findings.jsonl"

--- a/decision-memory/scripts/ci/trufflehog-detectors.sh
+++ b/decision-memory/scripts/ci/trufflehog-detectors.sh
@@ -41,10 +41,13 @@ for entry in $list; do
     escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
     # Single-quoted YAML scalars: only ' is special (doubled below);
     # double quotes would treat the regex backslashes as YAML escapes
-    # and trufflehog rejects the whole config.
-    yq_value="${value//\'/\'\'}"
-    yq_escaped="${escaped//\'/\'\'}"
-    yq_label="${label//\'/\'\'}"
+    # and trufflehog rejects the whole config. The quote lives in a
+    # variable because bash 3.2 (macOS) keeps the backslashes of an
+    # escaped-quote replacement string literal.
+    q="'"
+    yq_value="${value//"$q"/$q$q}"
+    yq_escaped="${escaped//"$q"/$q$q}"
+    yq_label="${label//"$q"/$q$q}"
     {
         printf "  - name: '%s'\n" "$yq_label"
         printf '    keywords:\n'

--- a/decision-memory/scripts/ci/trufflehog-detectors.sh
+++ b/decision-memory/scripts/ci/trufflehog-detectors.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Turn PUSH_BLOCKLIST into a TruffleHog custom-detector config — the
+# layer-3 audit's denylist bridge (agentic-engineering-template#189).
+#
+# PUSH_BLOCKLIST is |-separated values, each optionally labeled
+# value=pb:name (= and | reserved in values; unlabeled entries fall
+# back to their raw field position). The values ARE the secret: they
+# go only into the config file named by $1, and everything this
+# script prints is value-silent — labels and counts, never a value.
+# Trailing newlines and stray pipes are tolerated, matching every
+# other consumer of the variable.
+#
+# Config shape validated against trufflehog 3.97.1:
+#   detectors: [{name, keywords: [v], regex: {match: v-escaped}}]
+# keywords is TruffleHog's prefilter and must be a literal substring
+# of the match, so the raw value serves as its own keyword.
+set -euo pipefail
+
+out="${1:?usage: trufflehog-detectors.sh <config-file>}"
+
+list="$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d '\r\n')"
+if [ -z "${list//|/}" ]; then
+    echo "PUSH_BLOCKLIST is empty — no denylist detectors generated (audit runs with stock rules only)"
+    exit 0
+fi
+
+printf 'detectors:\n' >"$out"
+n=0
+count=0
+IFS='|'
+for entry in $list; do
+    n=$((n + 1))
+    [ -z "$entry" ] && continue
+    value="${entry%%=*}"
+    label="${entry#*=}"
+    [ "$label" = "$entry" ] && label="entry $n"
+    [ -z "$value" ] && continue
+    # RE2 has no \Q..\E; escape every metacharacter individually.
+    # The $ inside the sed class is a regex anchor, not a variable:
+    # shellcheck disable=SC2016
+    escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
+    # Single-quoted YAML scalars: only ' is special (doubled below);
+    # double quotes would treat the regex backslashes as YAML escapes
+    # and trufflehog rejects the whole config.
+    yq_value="${value//\'/\'\'}"
+    yq_escaped="${escaped//\'/\'\'}"
+    yq_label="${label//\'/\'\'}"
+    {
+        printf "  - name: '%s'\n" "$yq_label"
+        printf '    keywords:\n'
+        printf "      - '%s'\n" "$yq_value"
+        printf '    regex:\n'
+        printf "      match: '%s'\n" "$yq_escaped"
+    } >>"$out"
+    count=$((count + 1))
+    echo "detector: $label"
+done
+echo "$count denylist detector(s) written to $out"

--- a/decision-memory/scripts/ci/trufflehog-report.sh
+++ b/decision-memory/scripts/ci/trufflehog-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reduce a TruffleHog JSON findings stream to value-silent ::error
+# lines — layer 3's reporter (agentic-engineering-template#189). The
+# raw stream carries the matched secret (Raw/RawV2), so only the
+# detector name (the denylist label for custom detectors) and the
+# location are ever printed. Exits 1 iff findings exist, so the
+# workflow run itself is the alert.
+set -euo pipefail
+
+findings_file="${1:?usage: trufflehog-report.sh <findings.jsonl>}"
+
+python3 - "$findings_file" <<'PY'
+import json
+import sys
+
+findings = 0
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if "DetectorName" not in d:
+            continue
+        findings += 1
+        name = (d.get("ExtraData") or {}).get("name") or d["DetectorName"]
+        gh = ((d.get("SourceMetadata") or {}).get("Data") or {}).get("Github") or {}
+        where = gh.get("link") or " ".join(
+            str(gh.get(k)) for k in ("repository", "file", "line") if gh.get(k)
+        ) or "unknown location"
+        print(f"::error::{name} found at {where} — scrub the surface; the value is never printed here")
+print(f"{findings} finding(s)")
+sys.exit(1 if findings else 0)
+PY

--- a/evidence-memory/scripts/ci/trufflehog-detectors.sh
+++ b/evidence-memory/scripts/ci/trufflehog-detectors.sh
@@ -41,10 +41,13 @@ for entry in $list; do
     escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
     # Single-quoted YAML scalars: only ' is special (doubled below);
     # double quotes would treat the regex backslashes as YAML escapes
-    # and trufflehog rejects the whole config.
-    yq_value="${value//\'/\'\'}"
-    yq_escaped="${escaped//\'/\'\'}"
-    yq_label="${label//\'/\'\'}"
+    # and trufflehog rejects the whole config. The quote lives in a
+    # variable because bash 3.2 (macOS) keeps the backslashes of an
+    # escaped-quote replacement string literal.
+    q="'"
+    yq_value="${value//"$q"/$q$q}"
+    yq_escaped="${escaped//"$q"/$q$q}"
+    yq_label="${label//"$q"/$q$q}"
     {
         printf "  - name: '%s'\n" "$yq_label"
         printf '    keywords:\n'

--- a/evidence-memory/scripts/ci/trufflehog-detectors.sh
+++ b/evidence-memory/scripts/ci/trufflehog-detectors.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Turn PUSH_BLOCKLIST into a TruffleHog custom-detector config — the
+# layer-3 audit's denylist bridge (agentic-engineering-template#189).
+#
+# PUSH_BLOCKLIST is |-separated values, each optionally labeled
+# value=pb:name (= and | reserved in values; unlabeled entries fall
+# back to their raw field position). The values ARE the secret: they
+# go only into the config file named by $1, and everything this
+# script prints is value-silent — labels and counts, never a value.
+# Trailing newlines and stray pipes are tolerated, matching every
+# other consumer of the variable.
+#
+# Config shape validated against trufflehog 3.97.1:
+#   detectors: [{name, keywords: [v], regex: {match: v-escaped}}]
+# keywords is TruffleHog's prefilter and must be a literal substring
+# of the match, so the raw value serves as its own keyword.
+set -euo pipefail
+
+out="${1:?usage: trufflehog-detectors.sh <config-file>}"
+
+list="$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d '\r\n')"
+if [ -z "${list//|/}" ]; then
+    echo "PUSH_BLOCKLIST is empty — no denylist detectors generated (audit runs with stock rules only)"
+    exit 0
+fi
+
+printf 'detectors:\n' >"$out"
+n=0
+count=0
+IFS='|'
+for entry in $list; do
+    n=$((n + 1))
+    [ -z "$entry" ] && continue
+    value="${entry%%=*}"
+    label="${entry#*=}"
+    [ "$label" = "$entry" ] && label="entry $n"
+    [ -z "$value" ] && continue
+    # RE2 has no \Q..\E; escape every metacharacter individually.
+    # The $ inside the sed class is a regex anchor, not a variable:
+    # shellcheck disable=SC2016
+    escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
+    # Single-quoted YAML scalars: only ' is special (doubled below);
+    # double quotes would treat the regex backslashes as YAML escapes
+    # and trufflehog rejects the whole config.
+    yq_value="${value//\'/\'\'}"
+    yq_escaped="${escaped//\'/\'\'}"
+    yq_label="${label//\'/\'\'}"
+    {
+        printf "  - name: '%s'\n" "$yq_label"
+        printf '    keywords:\n'
+        printf "      - '%s'\n" "$yq_value"
+        printf '    regex:\n'
+        printf "      match: '%s'\n" "$yq_escaped"
+    } >>"$out"
+    count=$((count + 1))
+    echo "detector: $label"
+done
+echo "$count denylist detector(s) written to $out"

--- a/evidence-memory/scripts/ci/trufflehog-report.sh
+++ b/evidence-memory/scripts/ci/trufflehog-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reduce a TruffleHog JSON findings stream to value-silent ::error
+# lines — layer 3's reporter (agentic-engineering-template#189). The
+# raw stream carries the matched secret (Raw/RawV2), so only the
+# detector name (the denylist label for custom detectors) and the
+# location are ever printed. Exits 1 iff findings exist, so the
+# workflow run itself is the alert.
+set -euo pipefail
+
+findings_file="${1:?usage: trufflehog-report.sh <findings.jsonl>}"
+
+python3 - "$findings_file" <<'PY'
+import json
+import sys
+
+findings = 0
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if "DetectorName" not in d:
+            continue
+        findings += 1
+        name = (d.get("ExtraData") or {}).get("name") or d["DetectorName"]
+        gh = ((d.get("SourceMetadata") or {}).get("Data") or {}).get("Github") or {}
+        where = gh.get("link") or " ".join(
+            str(gh.get(k)) for k in ("repository", "file", "line") if gh.get(k)
+        ) or "unknown location"
+        print(f"::error::{name} found at {where} — scrub the surface; the value is never printed here")
+print(f"{findings} finding(s)")
+sys.exit(1 if findings else 0)
+PY

--- a/scripts/ci/trufflehog-detectors.sh
+++ b/scripts/ci/trufflehog-detectors.sh
@@ -41,10 +41,13 @@ for entry in $list; do
     escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
     # Single-quoted YAML scalars: only ' is special (doubled below);
     # double quotes would treat the regex backslashes as YAML escapes
-    # and trufflehog rejects the whole config.
-    yq_value="${value//\'/\'\'}"
-    yq_escaped="${escaped//\'/\'\'}"
-    yq_label="${label//\'/\'\'}"
+    # and trufflehog rejects the whole config. The quote lives in a
+    # variable because bash 3.2 (macOS) keeps the backslashes of an
+    # escaped-quote replacement string literal.
+    q="'"
+    yq_value="${value//"$q"/$q$q}"
+    yq_escaped="${escaped//"$q"/$q$q}"
+    yq_label="${label//"$q"/$q$q}"
     {
         printf "  - name: '%s'\n" "$yq_label"
         printf '    keywords:\n'

--- a/scripts/ci/trufflehog-detectors.sh
+++ b/scripts/ci/trufflehog-detectors.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Turn PUSH_BLOCKLIST into a TruffleHog custom-detector config — the
+# layer-3 audit's denylist bridge (agentic-engineering-template#189).
+#
+# PUSH_BLOCKLIST is |-separated values, each optionally labeled
+# value=pb:name (= and | reserved in values; unlabeled entries fall
+# back to their raw field position). The values ARE the secret: they
+# go only into the config file named by $1, and everything this
+# script prints is value-silent — labels and counts, never a value.
+# Trailing newlines and stray pipes are tolerated, matching every
+# other consumer of the variable.
+#
+# Config shape validated against trufflehog 3.97.1:
+#   detectors: [{name, keywords: [v], regex: {match: v-escaped}}]
+# keywords is TruffleHog's prefilter and must be a literal substring
+# of the match, so the raw value serves as its own keyword.
+set -euo pipefail
+
+out="${1:?usage: trufflehog-detectors.sh <config-file>}"
+
+list="$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d '\r\n')"
+if [ -z "${list//|/}" ]; then
+    echo "PUSH_BLOCKLIST is empty — no denylist detectors generated (audit runs with stock rules only)"
+    exit 0
+fi
+
+printf 'detectors:\n' >"$out"
+n=0
+count=0
+IFS='|'
+for entry in $list; do
+    n=$((n + 1))
+    [ -z "$entry" ] && continue
+    value="${entry%%=*}"
+    label="${entry#*=}"
+    [ "$label" = "$entry" ] && label="entry $n"
+    [ -z "$value" ] && continue
+    # RE2 has no \Q..\E; escape every metacharacter individually.
+    # The $ inside the sed class is a regex anchor, not a variable:
+    # shellcheck disable=SC2016
+    escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
+    # Single-quoted YAML scalars: only ' is special (doubled below);
+    # double quotes would treat the regex backslashes as YAML escapes
+    # and trufflehog rejects the whole config.
+    yq_value="${value//\'/\'\'}"
+    yq_escaped="${escaped//\'/\'\'}"
+    yq_label="${label//\'/\'\'}"
+    {
+        printf "  - name: '%s'\n" "$yq_label"
+        printf '    keywords:\n'
+        printf "      - '%s'\n" "$yq_value"
+        printf '    regex:\n'
+        printf "      match: '%s'\n" "$yq_escaped"
+    } >>"$out"
+    count=$((count + 1))
+    echo "detector: $label"
+done
+echo "$count denylist detector(s) written to $out"

--- a/scripts/ci/trufflehog-report.sh
+++ b/scripts/ci/trufflehog-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reduce a TruffleHog JSON findings stream to value-silent ::error
+# lines — layer 3's reporter (agentic-engineering-template#189). The
+# raw stream carries the matched secret (Raw/RawV2), so only the
+# detector name (the denylist label for custom detectors) and the
+# location are ever printed. Exits 1 iff findings exist, so the
+# workflow run itself is the alert.
+set -euo pipefail
+
+findings_file="${1:?usage: trufflehog-report.sh <findings.jsonl>}"
+
+python3 - "$findings_file" <<'PY'
+import json
+import sys
+
+findings = 0
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if "DetectorName" not in d:
+            continue
+        findings += 1
+        name = (d.get("ExtraData") or {}).get("name") or d["DetectorName"]
+        gh = ((d.get("SourceMetadata") or {}).get("Data") or {}).get("Github") or {}
+        where = gh.get("link") or " ".join(
+            str(gh.get(k)) for k in ("repository", "file", "line") if gh.get(k)
+        ) or "unknown location"
+        print(f"::error::{name} found at {where} — scrub the surface; the value is never printed here")
+print(f"{findings} finding(s)")
+sys.exit(1 if findings else 0)
+PY

--- a/template/scripts/ci/trufflehog-detectors.sh
+++ b/template/scripts/ci/trufflehog-detectors.sh
@@ -41,10 +41,13 @@ for entry in $list; do
     escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
     # Single-quoted YAML scalars: only ' is special (doubled below);
     # double quotes would treat the regex backslashes as YAML escapes
-    # and trufflehog rejects the whole config.
-    yq_value="${value//\'/\'\'}"
-    yq_escaped="${escaped//\'/\'\'}"
-    yq_label="${label//\'/\'\'}"
+    # and trufflehog rejects the whole config. The quote lives in a
+    # variable because bash 3.2 (macOS) keeps the backslashes of an
+    # escaped-quote replacement string literal.
+    q="'"
+    yq_value="${value//"$q"/$q$q}"
+    yq_escaped="${escaped//"$q"/$q$q}"
+    yq_label="${label//"$q"/$q$q}"
     {
         printf "  - name: '%s'\n" "$yq_label"
         printf '    keywords:\n'

--- a/template/scripts/ci/trufflehog-detectors.sh
+++ b/template/scripts/ci/trufflehog-detectors.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Turn PUSH_BLOCKLIST into a TruffleHog custom-detector config — the
+# layer-3 audit's denylist bridge (agentic-engineering-template#189).
+#
+# PUSH_BLOCKLIST is |-separated values, each optionally labeled
+# value=pb:name (= and | reserved in values; unlabeled entries fall
+# back to their raw field position). The values ARE the secret: they
+# go only into the config file named by $1, and everything this
+# script prints is value-silent — labels and counts, never a value.
+# Trailing newlines and stray pipes are tolerated, matching every
+# other consumer of the variable.
+#
+# Config shape validated against trufflehog 3.97.1:
+#   detectors: [{name, keywords: [v], regex: {match: v-escaped}}]
+# keywords is TruffleHog's prefilter and must be a literal substring
+# of the match, so the raw value serves as its own keyword.
+set -euo pipefail
+
+out="${1:?usage: trufflehog-detectors.sh <config-file>}"
+
+list="$(printf %s "${PUSH_BLOCKLIST:-}" | tr -d '\r\n')"
+if [ -z "${list//|/}" ]; then
+    echo "PUSH_BLOCKLIST is empty — no denylist detectors generated (audit runs with stock rules only)"
+    exit 0
+fi
+
+printf 'detectors:\n' >"$out"
+n=0
+count=0
+IFS='|'
+for entry in $list; do
+    n=$((n + 1))
+    [ -z "$entry" ] && continue
+    value="${entry%%=*}"
+    label="${entry#*=}"
+    [ "$label" = "$entry" ] && label="entry $n"
+    [ -z "$value" ] && continue
+    # RE2 has no \Q..\E; escape every metacharacter individually.
+    # The $ inside the sed class is a regex anchor, not a variable:
+    # shellcheck disable=SC2016
+    escaped="$(printf %s "$value" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g' -e 's/\]/\\]/g')"
+    # Single-quoted YAML scalars: only ' is special (doubled below);
+    # double quotes would treat the regex backslashes as YAML escapes
+    # and trufflehog rejects the whole config.
+    yq_value="${value//\'/\'\'}"
+    yq_escaped="${escaped//\'/\'\'}"
+    yq_label="${label//\'/\'\'}"
+    {
+        printf "  - name: '%s'\n" "$yq_label"
+        printf '    keywords:\n'
+        printf "      - '%s'\n" "$yq_value"
+        printf '    regex:\n'
+        printf "      match: '%s'\n" "$yq_escaped"
+    } >>"$out"
+    count=$((count + 1))
+    echo "detector: $label"
+done
+echo "$count denylist detector(s) written to $out"

--- a/template/scripts/ci/trufflehog-report.sh
+++ b/template/scripts/ci/trufflehog-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reduce a TruffleHog JSON findings stream to value-silent ::error
+# lines — layer 3's reporter (agentic-engineering-template#189). The
+# raw stream carries the matched secret (Raw/RawV2), so only the
+# detector name (the denylist label for custom detectors) and the
+# location are ever printed. Exits 1 iff findings exist, so the
+# workflow run itself is the alert.
+set -euo pipefail
+
+findings_file="${1:?usage: trufflehog-report.sh <findings.jsonl>}"
+
+python3 - "$findings_file" <<'PY'
+import json
+import sys
+
+findings = 0
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if "DetectorName" not in d:
+            continue
+        findings += 1
+        name = (d.get("ExtraData") or {}).get("name") or d["DetectorName"]
+        gh = ((d.get("SourceMetadata") or {}).get("Data") or {}).get("Github") or {}
+        where = gh.get("link") or " ".join(
+            str(gh.get(k)) for k in ("repository", "file", "line") if gh.get(k)
+        ) or "unknown location"
+        print(f"::error::{name} found at {where} — scrub the surface; the value is never printed here")
+print(f"{findings} finding(s)")
+sys.exit(1 if findings else 0)
+PY

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/trufflehog-audit.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/trufflehog-audit.yml.jinja
@@ -1,0 +1,110 @@
+name: TruffleHog audit
+
+# Layer 3 of the leak-prevention stack
+# (agentic-engineering-template#189): a daily retroactive scan of THIS
+# repo's surfaces no hook can gate — issue and PR descriptions and
+# comments, plus full git history — with TruffleHog's stock credential
+# rules AND the PUSH_BLOCKLIST identity denylist as custom detectors.
+# One job per repo, responsible only for the repo it lives on: the
+# scan runs on the repo's own token (no org enumeration, no app
+# credential) and is free on public repos. A finding turns the run
+# red — the red run is the alert. Layers 1–2 gate what agents push;
+# this net catches what publishes without a gate (a comment posted by
+# hand, content that predates the gates, a denylist entry added after
+# the fact).
+on:
+  schedule:
+    - cron: "26 5 * * *"
+  workflow_dispatch:
+    inputs:
+      scan_private:
+        description: >-
+          Scan even though this repo is private — the
+          scan-before-going-public check.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: trufflehog-audit
+
+jobs:
+  audit:
+    name: "trufflehog self-scan"
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      # Private repos are not exposed, so their daily run stops here
+      # for free instead of billing a scan nobody needs. The dispatch
+      # input overrides for the moment before a repo goes public.
+      - name: Skip private repos unless explicitly overridden
+        id: visibility
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          OVERRIDE: {% raw %}${{ inputs.scan_private }}{% endraw %}
+        run: |
+          set -euo pipefail
+          private="$(gh api "repos/$GITHUB_REPOSITORY" --jq .private)"
+          if [ "$private" = "true" ] && [ "$OVERRIDE" != "true" ]; then
+            echo "::notice::private repo — not exposed, audit skipped (dispatch with scan_private to override)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.visibility.outputs.skip == 'false'
+
+      # Pinned by version AND sha256 (the ci-ok gitleaks convention):
+      # a moving release tag must not swap the scanner under the audit.
+      - name: Install trufflehog 3.97.1 (pinned by sha256)
+        if: steps.visibility.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          curl -sSfL -o trufflehog.tar.gz \
+            https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_linux_amd64.tar.gz
+          echo "f863ea3a8d786f7d097870496c977944cce7372a2fe1e56707d965016e543ece  trufflehog.tar.gz" | sha256sum -c
+          tar -xzf trufflehog.tar.gz trufflehog
+
+      # The denylist values live only in the org secret and the config
+      # file generated here; the generator's own output is value-silent
+      # and GitHub additionally masks the secret in logs. An empty
+      # blocklist is loud but not fatal: stock rules still scan.
+      - name: Generate denylist detectors from PUSH_BLOCKLIST
+        if: steps.visibility.outputs.skip == 'false'
+        env:
+          PUSH_BLOCKLIST: {% raw %}${{ secrets.PUSH_BLOCKLIST }}{% endraw %}
+        run: |
+          set -euo pipefail
+          scripts/ci/trufflehog-detectors.sh "$RUNNER_TEMP/detectors.yaml"
+          if [ ! -e "$RUNNER_TEMP/detectors.yaml" ]; then
+            echo "::warning::PUSH_BLOCKLIST is empty — the scan runs with stock credential rules only (identity layer off)."
+            printf 'detectors: []\n' > "$RUNNER_TEMP/detectors.yaml"
+          fi
+
+      # --json so findings can be reduced to value-silent lines: the
+      # raw stream carries the matched secret (Raw/RawV2), so it is
+      # never printed — only detector label and location.
+      - name: Scan this repo — git history, issues, PRs, comments
+        if: steps.visibility.outputs.skip == 'false'
+        env:
+          GH_AUDIT_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+        run: |
+          set -euo pipefail
+          ./trufflehog github "--repo=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --issue-comments --pr-comments \
+            --config "$RUNNER_TEMP/detectors.yaml" \
+            --token "$GH_AUDIT_TOKEN" \
+            --json --no-update --fail --log-level=-1 \
+            > "$RUNNER_TEMP/findings.jsonl" && rc=0 || rc=$?
+          # trufflehog --fail exits 183 on findings (the reporter turns
+          # those red itself); any other nonzero exit is a scan failure
+          # and must not pass silently.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 183 ]; then
+            echo "::error::trufflehog exited $rc (scan failure, not findings)"
+            exit "$rc"
+          fi
+          scripts/ci/trufflehog-report.sh "$RUNNER_TEMP/findings.jsonl"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,200 @@
+"""Layer 3 of #189: a daily self-audit stamped into every repo.
+
+Each repo scans ONLY itself — issue and PR descriptions and comments
+plus git history — with TruffleHog's stock rules and the PUSH_BLOCKLIST
+identity denylist as custom detectors. No central sweep: the job runs
+where it lives, on the repo's own GITHUB_TOKEN (no org enumeration, no
+app credential), free on public repos. Private repos skip cheaply at a
+visibility gate — they are not exposed — with a dispatch override for
+the scan-before-going-public case.
+
+The two bash bridges are template-owned and byte-pinned like
+check_gate.py: the detector generator writes the denylist values ONLY
+into the config file it is told to write, and the reporter reduces
+TruffleHog's JSON (whose Raw field carries the matched secret) to
+value-silent ::error lines.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+TEMPLATE_CI = ROOT / "template" / "scripts" / "ci"
+GENERATOR = "trufflehog-detectors.sh"
+REPORTER = "trufflehog-report.sh"
+
+WORKFLOW_PATHS = [
+    ROOT
+    / "template"
+    / "{% if agentic_forge == 'github' %}.github{% endif %}"
+    / "workflows"
+    / "trufflehog-audit.yml.jinja",
+]
+
+PINNED_TARBALL = "trufflehog_3.97.1_linux_amd64.tar.gz"
+PINNED_SHA = "f863ea3a8d786f7d097870496c977944cce7372a2fe1e56707d965016e543ece"
+
+
+def run_generator(tmp_path, blocklist, conf_name="detectors.yaml"):
+    conf = tmp_path / conf_name
+    env = {"PATH": "/usr/bin:/bin"}
+    if blocklist is not None:
+        env["PUSH_BLOCKLIST"] = blocklist
+    proc = subprocess.run(
+        ["bash", str(TEMPLATE_CI / GENERATOR), str(conf)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return proc, conf
+
+
+def run_reporter(tmp_path, lines):
+    findings = tmp_path / "findings.jsonl"
+    findings.write_text("\n".join(lines) + "\n" if lines else "")
+    return subprocess.run(
+        ["bash", str(TEMPLATE_CI / REPORTER), str(findings)],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestDetectorGenerator:
+    def test_labeled_entries_become_detectors_named_by_their_label(self, tmp_path):
+        proc, conf = run_generator(tmp_path, "hunter2=pb:old-pw|alice@ex.com=pb:mail")
+        assert proc.returncode == 0
+        text = conf.read_text()
+        assert "name: 'pb:old-pw'" in text
+        assert "name: 'pb:mail'" in text
+        assert "hunter2" in text
+
+    def test_an_unlabeled_entry_falls_back_to_its_field_position(self, tmp_path):
+        proc, conf = run_generator(tmp_path, "alpha=pb:a|bravo")
+        assert proc.returncode == 0
+        assert "name: 'entry 2'" in conf.read_text()
+
+    def test_values_are_regex_escaped_into_single_quoted_yaml(self, tmp_path):
+        # Double-quoted YAML rejects the regex escapes as unknown escape
+        # characters and trufflehog drops the whole config — proven
+        # against 3.97.1. Single quotes leave only ' special (doubled).
+        proc, conf = run_generator(tmp_path, "it's+x@ex.com=pb:q")
+        assert proc.returncode == 0
+        text = conf.read_text()
+        assert "match: 'it''s\\+x@ex\\.com'" in text
+        assert '"' not in text
+
+    def test_output_never_carries_a_value_only_labels_and_counts(self, tmp_path):
+        proc, _ = run_generator(tmp_path, "sekritvalue9=pb:x")
+        assert proc.returncode == 0
+        assert "sekritvalue9" not in proc.stdout + proc.stderr
+        assert "pb:x" in proc.stdout
+
+    def test_trailing_newlines_and_stray_pipes_are_tolerated(self, tmp_path):
+        proc, conf = run_generator(tmp_path, "alpha=pb:a||bravo=pb:b|\n")
+        assert proc.returncode == 0
+        text = conf.read_text()
+        assert text.count("name:") == 2
+        assert "name: ''" not in text
+
+    def test_an_empty_or_unset_blocklist_writes_no_config_and_says_so(self, tmp_path):
+        proc, conf = run_generator(tmp_path, None)
+        assert proc.returncode == 0
+        assert not conf.exists()
+        assert "empty" in proc.stdout
+
+
+class TestReporter:
+    def test_no_findings_exits_zero_and_says_zero(self, tmp_path):
+        proc = run_reporter(tmp_path, [])
+        assert proc.returncode == 0
+        assert "0 finding(s)" in proc.stdout
+
+    def test_a_custom_finding_is_red_named_by_label_and_link_value_silent(
+        self, tmp_path
+    ):
+        finding = json.dumps(
+            {
+                "DetectorName": "CustomRegex",
+                "ExtraData": {"name": "pb:old-pw"},
+                "Raw": "sekritvalue9",
+                "SourceMetadata": {
+                    "Data": {"Github": {"link": "https://github.com/o/r/f.txt#L3"}}
+                },
+            }
+        )
+        proc = run_reporter(tmp_path, [finding])
+        assert proc.returncode == 1
+        assert "pb:old-pw" in proc.stdout
+        assert "https://github.com/o/r/f.txt#L3" in proc.stdout
+        assert "sekritvalue9" not in proc.stdout + proc.stderr
+        assert "::error" in proc.stdout
+
+    def test_stock_findings_name_the_detector_and_noise_is_skipped(self, tmp_path):
+        lines = [
+            "not json at all",
+            json.dumps({"level": "info", "msg": "progress line"}),
+            json.dumps(
+                {
+                    "DetectorName": "AWS",
+                    "Raw": "AKIAxxxx",
+                    "SourceMetadata": {
+                        "Data": {"Github": {"file": "cfg.py", "line": 9}}
+                    },
+                }
+            ),
+        ]
+        proc = run_reporter(tmp_path, lines)
+        assert proc.returncode == 1
+        assert "AWS" in proc.stdout
+        assert "cfg.py" in proc.stdout
+        assert "AKIA" not in proc.stdout
+        assert "1 finding(s)" in proc.stdout
+
+
+def test_audit_workflow_is_stamped_daily_self_scoped_and_pinned():
+    """One job per repo, responsible only for the repo it lives on
+    (principal's ruling over the central org sweep): daily schedule,
+    the repo's own token, the pinned scanner, both comment surfaces,
+    and the denylist secret."""
+    for path in WORKFLOW_PATHS:
+        text = path.read_text()
+        assert "schedule:" in text, path
+        assert text.count("* * *") == 1 and "* * 1" not in text, path  # daily
+        assert "workflow_dispatch:" in text, path
+        assert PINNED_TARBALL in text, path
+        assert PINNED_SHA in text, path
+        assert "--issue-comments" in text, path
+        assert "--pr-comments" in text, path
+        assert "secrets.PUSH_BLOCKLIST" in text, path
+        assert "runs-on: {{ agentic_actions_runner }}" in text, path
+        assert "trufflehog-detectors.sh" in text, path
+        assert "trufflehog-report.sh" in text, path
+        assert "GITHUB_REPOSITORY" in text, path
+
+
+def test_private_repos_skip_at_a_visibility_gate_with_an_override():
+    """Private repos are not exposed, so their daily job stops at a
+    cheap visibility check — but a dispatch override exists for the
+    scan-this-before-making-it-public case."""
+    text = WORKFLOW_PATHS[0].read_text()
+    assert "scan_private" in text
+    assert ".private" in text
+
+
+def test_audit_scripts_are_byte_identical_everywhere():
+    for name in (GENERATOR, REPORTER):
+        source = (TEMPLATE_CI / name).read_bytes()
+        for copy in (
+            ROOT / "scripts" / "ci" / name,
+            ROOT / "decision-memory" / "scripts" / "ci" / name,
+            ROOT / "evidence-memory" / "scripts" / "ci" / name,
+        ):
+            assert copy.read_bytes() == source, f"{copy} drifted from the template"
+
+
+def test_root_stamp_carries_the_audit_workflow():
+    text = (ROOT / ".github" / "workflows" / "trufflehog-audit.yml").read_text()
+    assert "{%" not in text
+    assert "runs-on: ubuntu-latest" in text

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -41,6 +41,12 @@ STORE_FILES = frozenset(
         ".github/workflows/ci-ok.yml",
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
+        # The audit's script bridges render with the shared scripts/ci
+        # payload; the audit WORKFLOW does not — stores render only
+        # their own workflow set, and as private repos they are not
+        # exposed (#189: the visibility gate would skip them anyway).
+        "scripts/ci/trufflehog-detectors.sh",
+        "scripts/ci/trufflehog-report.sh",
         ".github/workflows/template-update.yml",
         ".github/workflows/ticket-closed.yml",
         ".gitignore",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -55,6 +55,10 @@ COMMON_FILES = frozenset(
         # The uniform gate's judge (#137) renders on every forge; only
         # its GitHub workflow vehicle is forge-conditional.
         "scripts/ci/check_gate.py",
+        # The daily self-audit's denylist bridges (#189): value-silent
+        # bash on both ends of the trufflehog scan.
+        "scripts/ci/trufflehog-detectors.sh",
+        "scripts/ci/trufflehog-report.sh",
     }
 )
 
@@ -74,6 +78,8 @@ GITHUB_ONLY_FILES = frozenset(
         # The uniform CI gate (#137): the one required context and the
         # keyword file its checks read.
         ".github/workflows/ci-ok.yml",
+        # The daily per-repo self-audit (#189, layer 3).
+        ".github/workflows/trufflehog-audit.yml",
         ".github/reference-keywords.json",
         # The merge-approval gate (#187): the approver allowlist its
         # check reads.

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -35,6 +35,12 @@ STORE_FILES = frozenset(
         ".github/workflows/ci-ok.yml",
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
+        # The audit's script bridges render with the shared scripts/ci
+        # payload; the audit WORKFLOW does not — stores render only
+        # their own workflow set, and as private repos they are not
+        # exposed (#189: the visibility gate would skip them anyway).
+        "scripts/ci/trufflehog-detectors.sh",
+        "scripts/ci/trufflehog-report.sh",
         ".github/workflows/template-update.yml",
         ".github/workflows/ticket-closed.yml",
         ".github/workflows/labels.yml",


### PR DESCRIPTION
ADVANCES #189

Layer 3, shaped by the principal's ruling on [meta!117](https://github.com/pandoscope/meta/pull/117): **no central org sweep — every stamped repo runs a daily TruffleHog scan of only itself**, on its own `GITHUB_TOKEN`. That removes the release-bot credential and org enumeration entirely, and the minutes are **free on public repos** — which is exactly where the exposure is.

**What each repo's daily job does** (`.github/workflows/trufflehog-audit.yml`, template-stamped):

- **Visibility gate first**: a private repo is not exposed, so its run stops at one cheap API call — with a `scan_private` dispatch input as the scan-before-going-public override.
- TruffleHog **3.97.1 pinned by version AND sha256** (the ci-ok gitleaks convention) scans this repo's git history, issue and PR descriptions, and comments (`--issue-comments --pr-comments`).
- **PUSH_BLOCKLIST as custom detectors**: `scripts/ci/trufflehog-detectors.sh` (byte-pinned like `check_gate.py`) turns the org secret into a detector config — labels become detector names, values go only into the runtime config file, and single-quoted YAML scalars are load-bearing (double quotes break on regex escapes; proven against the real binary).
- **Value-silent reporting**: findings JSON carries the matched secret in `Raw`, so `scripts/ci/trufflehog-report.sh` reduces it to `::error` lines naming only the detector label and location, exiting 1 iff findings exist — the red run is the alert. Exit 183 (findings) vs other-nonzero (scan failure) are distinguished; an empty blocklist warns loudly and scans with stock rules.
- Store variants render the script bridges with the shared `scripts/ci` payload but not the workflow — they render only their own workflow set, and as private repos the gate would skip them anyway.

**Testing**: red-first pytest (`tests/test_audit.py`, 13 tests) covering generator labeling/escaping/YAML-quoting/value-silence/newline-tolerance, reporter value-silence on custom and stock findings, workflow wiring (daily, pinned, both comment surfaces, visibility gate, runner answer), byte-pin identity across all copies, and the rendered root stamp. Generator + config validated end-to-end against the pinned binary. Full suite 312 green; e2e and store frozensets updated; two-commit template-first shape preserved.

Supersedes the central-sweep approach of [meta!117](https://github.com/pandoscope/meta/pull/117), which will be closed in its favor. Remaining on #189: layer 4 — `run_secret_scanning` as an independent net (#104).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790878536&installation_model_id=432661&pr_number=200&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F200&signature=1b428fd85d2fbbd992ed0ece14dddd0699d601a59a5651359b0a8eefaf1505be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->