### PR TITLE
fix(template): drift guard tolerates CLAUDE.md's sanctioned local Learnings

### DIFF
--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -62,6 +62,13 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks --vcs-ref "$stamped"
 
+          # CLAUDE.md invites local Learnings ("new non-obvious
+          # findings go in this file") and copier update three-way
+          # merges them, so local content there is sanctioned, not
+          # drift. Restore it after the recopy: the diff judges only
+          # files that are pristine-by-contract.
+          git checkout -- CLAUDE.md
+
           if [ -n "$(git status --porcelain)" ]; then
             git status --porcelain
             git diff

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -552,6 +552,11 @@ def test_lint_workflow_guards_vendored_template_drift(
                 "copier-template-extensions",
                 "awk '$1 == \"_commit:\" {print $2}'",
                 "not a stamped repo",
+                # CLAUDE.md invites local Learnings and copier update
+                # three-way-merges them — the drift job must restore
+                # it after recopy, or every Learnings-bearing repo
+                # goes permanently red.
+                "git checkout -- CLAUDE.md",
                 "git status --porcelain",
                 "template-owned",
             ],


### PR DESCRIPTION
ADVANCES #196

Follow-up bug fix to the just-merged #197, caught before its first release fan-out. `CLAUDE.md` is template-vendored **and** instructs repos to append Learnings locally ("new non-obvious findings go in this file" — meta's copy carries several today). `copier update` three-way-merges those, so they survive updates — but the new `template-drift` job's `recopy`-and-diff would misread them as drift and turn every Learnings-bearing repo's lint permanently red.

Fix (TDD, red then green): the drift job restores `CLAUDE.md` after the recopy, so the diff judges only files that are pristine-by-contract. Seeded `_skip_if_exists` files were already exempt structurally; this adds the one vendored-but-locally-extendable file. Full suite green locally: 299 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790882756&installation_model_id=432661&pr_number=201&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F201&signature=437165af260e923f297fa1bc3e219287c38cac0d502c8553c13948ef5348e534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->