### PR TITLE
One glossary prune script for every stamped repo, run by the update and drift jobs and on the template root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,17 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      # The glossary prune every stamped repo runs, for real, on this
+      # root too (#210). Consumers converge by deletion; here the
+      # glossary is pinned render output kept reachable by README.md's
+      # index, so a removal is a defect: the stamped script restores
+      # tracked terms and fails naming them.
+      - id: prune-glossary
+        name: "glossary prune removes nothing (every term reachable)"
+        entry: bash scripts/ci/prune_glossary.sh --fail-on-removal
+        language: system
+        pass_filenames: false
+        always_run: true
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
       # An entry may name its placeholder (`value=pb:name`); labels

--- a/README.md
+++ b/README.md
@@ -178,8 +178,16 @@ what makes them lintable here.
 - [pandoscope template](docs/glossary/pandoscope-template.md)
 
 These links live in this repo's own README, which is NOT part of the render —
-so in a generated repo the same terms arrive unlinked, stay orphaned until
-something references them, and can be removed with `disambiguate prune`.
+so in a generated repo the same terms arrive unlinked and are pruned
+(`disambiguate prune`) by the post-stamp task, and again by the rendered
+template-update and lint workflows, which run copier with `--skip-tasks`.
+A consumer keeps exactly the shared terms it links; nothing roots them by
+hand. One script does it everywhere, `scripts/ci/prune_glossary.sh`: the
+post-stamp task, the update workflow and the drift job run it plain, and this
+root runs it on every commit as the `prune-glossary` prek hook with
+`--fail-on-removal` — here every term must survive, because the glossary is
+render output pinned by the self-application test, so a removal is a defect
+and the hook fails naming and restoring the term.
 
 ## Developing this template
 

--- a/copier.yml
+++ b/copier.yml
@@ -214,5 +214,5 @@ _tasks:
   # the set by hand. Advisory for the same reason as the report above — an
   # unconverged glossary is a lint finding, not a reason to lose the stamp.
   - >-
-    {% if agentic_subtemplate == 'template' %}uvx disambiguate=={{ agentic_disambiguate_version }} prune
+    {% if agentic_subtemplate == 'template' %}bash scripts/ci/prune_glossary.sh
     || true{% else %}true{% endif %}

--- a/decision-memory/.github/workflows/template-update.yml.jinja
+++ b/decision-memory/.github/workflows/template-update.yml.jinja
@@ -173,6 +173,16 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks
 
+          # One skipped task must run anyway: the glossary prune (#67).
+          # Every update re-delivers the full shared term set, so without
+          # it each consumer ships orphans and disambiguate --lint goes
+          # red fleet-wide (#203). The script is the same one the task
+          # and the template repo run; it is read after the update so a
+          # bumped script or pin applies to its own release. Advisory
+          # like the task: an unconverged glossary is a lint finding,
+          # not a lost update.
+          bash scripts/ci/prune_glossary.sh || true
+
           new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
           {
             echo "old_ref=$old_ref"

--- a/decision-memory/scripts/ci/prune_glossary.sh
+++ b/decision-memory/scripts/ci/prune_glossary.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The glossary prune, one script for every repo the template stamps
+# (AET#67, AET#203, AET#210).
+#
+# Every stamp re-delivers the shared term set and `disambiguate prune`
+# removes what nothing links, so a repo keeps exactly the shared terms
+# it references. The post-stamp task, the template-update workflow and
+# the drift job all run this same script, and what it removed is
+# committed with the update. The template repo runs it too, on every
+# commit, with --fail-on-removal: there the glossary is render output
+# the self-application test pins and README.md's index keeps reachable,
+# so a removal is a defect, not convergence. The script then names the
+# terms, restores the tracked ones so a commit hook never leaves the
+# tree mutated, and exits 1.
+#
+# The pin is agentic_disambiguate_version: read from
+# .copier-answers.agentic.yml in a stamped repo, from copier.yml's
+# default in the template itself. disambiguate is pre-alpha; an unpinned
+# run would float across breaking releases.
+set -euo pipefail
+
+fail_on_removal=0
+for arg in "$@"; do
+    case "$arg" in
+        --fail-on-removal) fail_on_removal=1 ;;
+        *)
+            echo "prune_glossary: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin=""
+if [ -f .copier-answers.agentic.yml ]; then
+    pin="$(awk '$1 == "agentic_disambiguate_version:" { gsub(/"/, "", $2); print $2 }' \
+        .copier-answers.agentic.yml)"
+elif [ -f copier.yml ]; then
+    pin="$(awk '
+        $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+        in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+        in_q && /^[^ #]/ { in_q = 0 }
+    ' copier.yml)"
+fi
+if [ -z "$pin" ]; then
+    echo "prune_glossary: no agentic_disambiguate_version pin in .copier-answers.agentic.yml or copier.yml" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+if [ ! -d "$glossary" ]; then
+    echo "prune_glossary: no $glossary here, nothing to prune"
+    exit 0
+fi
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+[ -n "$removed" ] || exit 0
+
+if [ "$fail_on_removal" -eq 0 ]; then
+    echo "prune_glossary: removed unlinked term(s):"
+    while IFS= read -r file; do echo "  $file"; done <<< "$removed"
+    exit 0
+fi
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/evidence-memory/.github/workflows/template-update.yml.jinja
+++ b/evidence-memory/.github/workflows/template-update.yml.jinja
@@ -173,6 +173,16 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks
 
+          # One skipped task must run anyway: the glossary prune (#67).
+          # Every update re-delivers the full shared term set, so without
+          # it each consumer ships orphans and disambiguate --lint goes
+          # red fleet-wide (#203). The script is the same one the task
+          # and the template repo run; it is read after the update so a
+          # bumped script or pin applies to its own release. Advisory
+          # like the task: an unconverged glossary is a lint finding,
+          # not a lost update.
+          bash scripts/ci/prune_glossary.sh || true
+
           new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
           {
             echo "old_ref=$old_ref"

--- a/evidence-memory/scripts/ci/prune_glossary.sh
+++ b/evidence-memory/scripts/ci/prune_glossary.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The glossary prune, one script for every repo the template stamps
+# (AET#67, AET#203, AET#210).
+#
+# Every stamp re-delivers the shared term set and `disambiguate prune`
+# removes what nothing links, so a repo keeps exactly the shared terms
+# it references. The post-stamp task, the template-update workflow and
+# the drift job all run this same script, and what it removed is
+# committed with the update. The template repo runs it too, on every
+# commit, with --fail-on-removal: there the glossary is render output
+# the self-application test pins and README.md's index keeps reachable,
+# so a removal is a defect, not convergence. The script then names the
+# terms, restores the tracked ones so a commit hook never leaves the
+# tree mutated, and exits 1.
+#
+# The pin is agentic_disambiguate_version: read from
+# .copier-answers.agentic.yml in a stamped repo, from copier.yml's
+# default in the template itself. disambiguate is pre-alpha; an unpinned
+# run would float across breaking releases.
+set -euo pipefail
+
+fail_on_removal=0
+for arg in "$@"; do
+    case "$arg" in
+        --fail-on-removal) fail_on_removal=1 ;;
+        *)
+            echo "prune_glossary: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin=""
+if [ -f .copier-answers.agentic.yml ]; then
+    pin="$(awk '$1 == "agentic_disambiguate_version:" { gsub(/"/, "", $2); print $2 }' \
+        .copier-answers.agentic.yml)"
+elif [ -f copier.yml ]; then
+    pin="$(awk '
+        $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+        in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+        in_q && /^[^ #]/ { in_q = 0 }
+    ' copier.yml)"
+fi
+if [ -z "$pin" ]; then
+    echo "prune_glossary: no agentic_disambiguate_version pin in .copier-answers.agentic.yml or copier.yml" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+if [ ! -d "$glossary" ]; then
+    echo "prune_glossary: no $glossary here, nothing to prune"
+    exit 0
+fi
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+[ -n "$removed" ] || exit 0
+
+if [ "$fail_on_removal" -eq 0 ]; then
+    echo "prune_glossary: removed unlinked term(s):"
+    while IFS= read -r file; do echo "  $file"; done <<< "$removed"
+    exit 0
+fi
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/scripts/ci/prune_glossary.sh
+++ b/scripts/ci/prune_glossary.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The glossary prune, one script for every repo the template stamps
+# (AET#67, AET#203, AET#210).
+#
+# Every stamp re-delivers the shared term set and `disambiguate prune`
+# removes what nothing links, so a repo keeps exactly the shared terms
+# it references. The post-stamp task, the template-update workflow and
+# the drift job all run this same script, and what it removed is
+# committed with the update. The template repo runs it too, on every
+# commit, with --fail-on-removal: there the glossary is render output
+# the self-application test pins and README.md's index keeps reachable,
+# so a removal is a defect, not convergence. The script then names the
+# terms, restores the tracked ones so a commit hook never leaves the
+# tree mutated, and exits 1.
+#
+# The pin is agentic_disambiguate_version: read from
+# .copier-answers.agentic.yml in a stamped repo, from copier.yml's
+# default in the template itself. disambiguate is pre-alpha; an unpinned
+# run would float across breaking releases.
+set -euo pipefail
+
+fail_on_removal=0
+for arg in "$@"; do
+    case "$arg" in
+        --fail-on-removal) fail_on_removal=1 ;;
+        *)
+            echo "prune_glossary: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin=""
+if [ -f .copier-answers.agentic.yml ]; then
+    pin="$(awk '$1 == "agentic_disambiguate_version:" { gsub(/"/, "", $2); print $2 }' \
+        .copier-answers.agentic.yml)"
+elif [ -f copier.yml ]; then
+    pin="$(awk '
+        $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+        in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+        in_q && /^[^ #]/ { in_q = 0 }
+    ' copier.yml)"
+fi
+if [ -z "$pin" ]; then
+    echo "prune_glossary: no agentic_disambiguate_version pin in .copier-answers.agentic.yml or copier.yml" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+if [ ! -d "$glossary" ]; then
+    echo "prune_glossary: no $glossary here, nothing to prune"
+    exit 0
+fi
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+[ -n "$removed" ] || exit 0
+
+if [ "$fail_on_removal" -eq 0 ]; then
+    echo "prune_glossary: removed unlinked term(s):"
+    while IFS= read -r file; do echo "  $file"; done <<< "$removed"
+    exit 0
+fi
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/session-memory/.github/workflows/template-update.yml.jinja
+++ b/session-memory/.github/workflows/template-update.yml.jinja
@@ -173,6 +173,16 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks
 
+          # One skipped task must run anyway: the glossary prune (#67).
+          # Every update re-delivers the full shared term set, so without
+          # it each consumer ships orphans and disambiguate --lint goes
+          # red fleet-wide (#203). The script is the same one the task
+          # and the template repo run; it is read after the update so a
+          # bumped script or pin applies to its own release. Advisory
+          # like the task: an unconverged glossary is a lint finding,
+          # not a lost update.
+          bash scripts/ci/prune_glossary.sh || true
+
           new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
           {
             echo "old_ref=$old_ref"

--- a/session-memory/scripts/ci/prune_glossary.sh
+++ b/session-memory/scripts/ci/prune_glossary.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The glossary prune, one script for every repo the template stamps
+# (AET#67, AET#203, AET#210).
+#
+# Every stamp re-delivers the shared term set and `disambiguate prune`
+# removes what nothing links, so a repo keeps exactly the shared terms
+# it references. The post-stamp task, the template-update workflow and
+# the drift job all run this same script, and what it removed is
+# committed with the update. The template repo runs it too, on every
+# commit, with --fail-on-removal: there the glossary is render output
+# the self-application test pins and README.md's index keeps reachable,
+# so a removal is a defect, not convergence. The script then names the
+# terms, restores the tracked ones so a commit hook never leaves the
+# tree mutated, and exits 1.
+#
+# The pin is agentic_disambiguate_version: read from
+# .copier-answers.agentic.yml in a stamped repo, from copier.yml's
+# default in the template itself. disambiguate is pre-alpha; an unpinned
+# run would float across breaking releases.
+set -euo pipefail
+
+fail_on_removal=0
+for arg in "$@"; do
+    case "$arg" in
+        --fail-on-removal) fail_on_removal=1 ;;
+        *)
+            echo "prune_glossary: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin=""
+if [ -f .copier-answers.agentic.yml ]; then
+    pin="$(awk '$1 == "agentic_disambiguate_version:" { gsub(/"/, "", $2); print $2 }' \
+        .copier-answers.agentic.yml)"
+elif [ -f copier.yml ]; then
+    pin="$(awk '
+        $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+        in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+        in_q && /^[^ #]/ { in_q = 0 }
+    ' copier.yml)"
+fi
+if [ -z "$pin" ]; then
+    echo "prune_glossary: no agentic_disambiguate_version pin in .copier-answers.agentic.yml or copier.yml" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+if [ ! -d "$glossary" ]; then
+    echo "prune_glossary: no $glossary here, nothing to prune"
+    exit 0
+fi
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+[ -n "$removed" ] || exit 0
+
+if [ "$fail_on_removal" -eq 0 ]; then
+    echo "prune_glossary: removed unlinked term(s):"
+    while IFS= read -r file; do echo "  $file"; done <<< "$removed"
+    exit 0
+fi
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/template/scripts/ci/prune_glossary.sh
+++ b/template/scripts/ci/prune_glossary.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The glossary prune, one script for every repo the template stamps
+# (AET#67, AET#203, AET#210).
+#
+# Every stamp re-delivers the shared term set and `disambiguate prune`
+# removes what nothing links, so a repo keeps exactly the shared terms
+# it references. The post-stamp task, the template-update workflow and
+# the drift job all run this same script, and what it removed is
+# committed with the update. The template repo runs it too, on every
+# commit, with --fail-on-removal: there the glossary is render output
+# the self-application test pins and README.md's index keeps reachable,
+# so a removal is a defect, not convergence. The script then names the
+# terms, restores the tracked ones so a commit hook never leaves the
+# tree mutated, and exits 1.
+#
+# The pin is agentic_disambiguate_version: read from
+# .copier-answers.agentic.yml in a stamped repo, from copier.yml's
+# default in the template itself. disambiguate is pre-alpha; an unpinned
+# run would float across breaking releases.
+set -euo pipefail
+
+fail_on_removal=0
+for arg in "$@"; do
+    case "$arg" in
+        --fail-on-removal) fail_on_removal=1 ;;
+        *)
+            echo "prune_glossary: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin=""
+if [ -f .copier-answers.agentic.yml ]; then
+    pin="$(awk '$1 == "agentic_disambiguate_version:" { gsub(/"/, "", $2); print $2 }' \
+        .copier-answers.agentic.yml)"
+elif [ -f copier.yml ]; then
+    pin="$(awk '
+        $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+        in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+        in_q && /^[^ #]/ { in_q = 0 }
+    ' copier.yml)"
+fi
+if [ -z "$pin" ]; then
+    echo "prune_glossary: no agentic_disambiguate_version pin in .copier-answers.agentic.yml or copier.yml" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+if [ ! -d "$glossary" ]; then
+    echo "prune_glossary: no $glossary here, nothing to prune"
+    exit 0
+fi
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+[ -n "$removed" ] || exit 0
+
+if [ "$fail_on_removal" -eq 0 ]; then
+    echo "prune_glossary: removed unlinked term(s):"
+    while IFS= read -r file; do echo "  $file"; done <<< "$removed"
+    exit 0
+fi
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -62,6 +62,12 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks --vcs-ref "$stamped"
 
+          # The recopy re-delivers every shared glossary term, including
+          # the ones this repo's stamp pruned as unlinked (#67). Prune
+          # again, with the same script the update ran, so the diff
+          # judges the converged state, not the raw render (#203).
+          bash scripts/ci/prune_glossary.sh || true
+
           # CLAUDE.md invites local Learnings ("new non-obvious
           # findings go in this file") and copier update three-way
           # merges them, so local content there is sanctioned, not

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
@@ -173,6 +173,16 @@ jobs:
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks
 
+          # One skipped task must run anyway: the glossary prune (#67).
+          # Every update re-delivers the full shared term set, so without
+          # it each consumer ships orphans and disambiguate --lint goes
+          # red fleet-wide (#203). The script is the same one the task
+          # and the template repo run; it is read after the update so a
+          # bumped script or pin applies to its own release. Advisory
+          # like the task: an unconverged glossary is a lint finding,
+          # not a lost update.
+          bash scripts/ci/prune_glossary.sh || true
+
           new_ref="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
           {
             echo "old_ref=$old_ref"

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -41,6 +41,7 @@ STORE_FILES = frozenset(
         ".github/workflows/ci-ok.yml",
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
+        "scripts/ci/prune_glossary.sh",
         # The audit's script bridges render with the shared scripts/ci
         # payload; the audit WORKFLOW does not — stores render only
         # their own workflow set, and as private repos they are not

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -56,6 +56,9 @@ COMMON_FILES = frozenset(
         # The uniform gate's judge (#137) renders on every forge; only
         # its GitHub workflow vehicle is forge-conditional.
         "scripts/ci/check_gate.py",
+        # The glossary prune (#67, #203, #210): task, update workflow,
+        # drift job and the template root all run this one script.
+        "scripts/ci/prune_glossary.sh",
         # The daily self-audit's denylist bridges (#189): value-silent
         # bash on both ends of the trufflehog scan.
         "scripts/ci/trufflehog-detectors.sh",

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -35,6 +35,7 @@ STORE_FILES = frozenset(
         ".github/workflows/ci-ok.yml",
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
+        "scripts/ci/prune_glossary.sh",
         # The audit's script bridges render with the shared scripts/ci
         # payload; the audit WORKFLOW does not — stores render only
         # their own workflow set, and as private repos they are not

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -463,6 +463,10 @@ def test_github_forge_ships_template_update_workflow(
             "copier update",
             "--defaults --trust --skip-tasks",
             "copier-template-extensions",
+            # --skip-tasks skips the post-stamp glossary prune; the
+            # workflow runs the same script explicitly or every update
+            # ships orphans (#203).
+            "bash scripts/ci/prune_glossary.sh || true",
             "actions/create-github-app-token",
             "RELEASE_BOT_CLIENT_ID",
             "RELEASE_BOT_PRIVATE_KEY",
@@ -550,6 +554,10 @@ def test_lint_workflow_guards_vendored_template_drift(
                 "copier recopy",
                 '--defaults --trust --skip-tasks --vcs-ref "$stamped"',
                 "copier-template-extensions",
+                # Recopy resurrects the terms the stamp pruned; the drift
+                # job prunes again so a converged glossary is not drift
+                # (#203).
+                "bash scripts/ci/prune_glossary.sh || true",
                 "awk '$1 == \"_commit:\" {print $2}'",
                 "not a stamped repo",
                 # CLAUDE.md invites local Learnings and copier update

--- a/tests/test_prune_glossary.py
+++ b/tests/test_prune_glossary.py
@@ -1,0 +1,185 @@
+"""One glossary prune script for every repo the template stamps (#203, #210).
+
+Consumers converge by deletion: the post-stamp task, the update workflow
+and the drift job run `scripts/ci/prune_glossary.sh`, and what it removes
+is committed. The template root runs the same script with
+`--fail-on-removal`: its glossary is render output pinned by
+`test_self_application.py` and kept reachable by README.md's index, so a
+removal is a defect — named, restored, exit 1.
+
+The stores vendor the script (copier renders one _subdirectory at a
+time), pinned identical here like the shared workflows are.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "template" / "scripts" / "ci" / "prune_glossary.sh"
+STORES = ("session-memory", "decision-memory", "evidence-memory")
+ANSWERS = ".copier-answers.agentic.yml"
+
+
+def _pin() -> str:
+    """copier.yml's default for agentic_disambiguate_version."""
+    in_question = False
+    for line in (PROJECT_ROOT / "copier.yml").read_text().splitlines():
+        if line.startswith("agentic_disambiguate_version:"):
+            in_question = True
+        elif in_question and line.strip().startswith("default:"):
+            return line.split(":", 1)[1].strip().strip('"')
+        elif in_question and line and not line[0].isspace():
+            in_question = False
+    raise AssertionError("copier.yml has no agentic_disambiguate_version default")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _repo(tmp_path: Path, *, answers: bool) -> Path:
+    """A committed repo with the root's own linking documents and glossary.
+
+    `answers=True` makes it a stamped consumer (pin from the answers
+    file); `answers=False` makes it the template root (pin from
+    copier.yml's default).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for name in ("README.md", "AGENTS.md", "CLAUDE.md"):
+        shutil.copy2(PROJECT_ROOT / name, repo / name)
+    shutil.copytree(PROJECT_ROOT / "docs", repo / "docs")
+    (repo / "scripts" / "ci").mkdir(parents=True)
+    shutil.copy2(SCRIPT, repo / "scripts" / "ci" / SCRIPT.name)
+    if answers:
+        (repo / ANSWERS).write_text(
+            f'_commit: v0\nagentic_disambiguate_version: "{_pin()}"\n'
+        )
+    else:
+        shutil.copy2(PROJECT_ROOT / "copier.yml", repo / "copier.yml")
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    return repo
+
+
+def _prune(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/ci/prune_glossary.sh", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _unlink_reinset(repo: Path) -> None:
+    readme = repo / "README.md"
+    lines = readme.read_text(encoding="utf-8").splitlines(keepends=True)
+    kept = [line for line in lines if "docs/glossary/reinset.md" not in line]
+    assert len(kept) == len(lines) - 1, "fixture: README links reinset exactly once"
+    readme.write_text("".join(kept), encoding="utf-8")
+
+
+def _terms(repo: Path) -> list[str]:
+    return sorted(p.name for p in (repo / "docs" / "glossary").glob("*.md"))
+
+
+@pytest.fixture(autouse=True)
+def _needs_uvx() -> None:
+    if shutil.which("uvx") is None:
+        pytest.skip("the prune runs disambiguate through uvx")
+
+
+@pytest.mark.parametrize("store", STORES)
+def test_store_copies_match_the_template_script(store: str) -> None:
+    copy = PROJECT_ROOT / store / "scripts" / "ci" / SCRIPT.name
+    assert copy.read_bytes() == SCRIPT.read_bytes(), (
+        f"{copy} drifted from the template copy — change it once and copy"
+    )
+
+
+def test_a_consumer_prunes_unlinked_terms_and_reports_them(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, answers=True)
+    _unlink_reinset(repo)
+
+    result = _prune(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "removed unlinked term(s)" in result.stdout
+    assert "docs/glossary/reinset.md" in result.stdout
+    assert "reinset.md" not in _terms(repo)
+
+
+def test_the_root_as_committed_survives_its_own_prune(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, answers=False)
+    terms = _terms(repo)
+
+    result = _prune(repo, "--fail-on-removal")
+
+    assert result.returncode == 0, result.stderr
+    assert _terms(repo) == terms
+
+
+def test_fail_on_removal_names_and_restores_the_term(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, answers=False)
+    _unlink_reinset(repo)
+
+    result = _prune(repo, "--fail-on-removal")
+
+    assert result.returncode == 1
+    assert "REMOVED TERMS" in result.stderr
+    assert "docs/glossary/reinset.md" in result.stderr
+    assert "(restored)" in result.stderr
+    assert "reinset.md" in _terms(repo), "a tracked term the prune removed is put back"
+
+
+def test_the_answers_file_pin_wins_over_a_copier_yml(tmp_path: Path) -> None:
+    """A stamped repo that is itself a template reads its own stamp's pin."""
+    repo = _repo(tmp_path, answers=True)
+    (repo / "copier.yml").write_text(
+        'agentic_disambiguate_version:\n  type: str\n  default: "0.0.0-not-a-release"\n'
+    )
+
+    result = _prune(repo)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_repo_without_a_glossary_has_nothing_to_prune(tmp_path: Path) -> None:
+    """The stores ship the script and no glossary; the step must not error."""
+    repo = _repo(tmp_path, answers=True)
+    shutil.rmtree(repo / "docs" / "glossary")
+
+    result = _prune(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "nothing to prune" in result.stdout
+
+
+def test_a_missing_pin_is_its_own_loud_failure(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, answers=False)
+    (repo / "copier.yml").write_text("agentic_project_name:\n  type: str\n")
+
+    result = _prune(repo)
+
+    assert result.returncode == 1
+    assert "agentic_disambiguate_version" in result.stderr
+
+
+def test_an_unknown_argument_is_refused(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, answers=False)
+
+    result = _prune(repo, "--dry-run")
+
+    assert result.returncode == 2
+    assert "unknown argument" in result.stderr

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -34,6 +34,9 @@ STORE_FILES = frozenset(
         "CLAUDE.md",
         "README.md",
         "repo-codes.json",
+        # The glossary prune every stamped repo runs (#203); a store has
+        # no glossary, so here it reports that and exits 0.
+        "scripts/ci/prune_glossary.sh",
     }
 )
 


### PR DESCRIPTION
CLOSES #203
CLOSES #210
ADVANCES #198

**Problem.** #67 made consumers converge their glossary with a post-stamp `disambiguate prune`, so a repo keeps exactly the shared terms it links. The rendered update workflow runs `copier update --skip-tasks`, which skipped that task on the one path that runs every release: the v4.6.0 fan-out shipped thirteen org-genome terms as orphans and every non-store consumer got a hand-written README glossary index, the option #67 rejected. The template root never pruned at all, and nothing linted its glossary despite the README saying the copies are "lintable here".

**Ruling.** The prune is applied the same way in every repository; the only thing the template root adds is a check that it removed nothing, failing loudly if it did.

**Change.** One stamped script, `scripts/ci/prune_glossary.sh`, and every place that prunes runs it:

- the post-stamp task in `copier.yml`;
- the template-update workflow after `copier update`, so the update branch carries the converged state;
- lint's template-drift job after its recopy, since recopy resurrects the pruned terms and a converged glossary is not drift;
- the template root itself, on every commit, as the `prune-glossary` prek hook with `--fail-on-removal`. The lint CI job runs all hooks on every PR, so no new job.

The script reads the pin from `.copier-answers.agentic.yml`, or from `copier.yml`'s default on the template root, which has no answers file. A repo with no glossary reports that and exits 0, so the stores run the same step without an error to swallow. The three store subtemplates vendor the script, pinned byte-identical by test like the shared workflows. With `--fail-on-removal`, a removed term is named, restored if tracked so a commit hook never leaves the tree mutated, and the run exits 1.

**Commits**, on the template-first route: template sources, copies, workflows, tests and README; the `chore: reapply template to self` restamp adopting the script at the root; the root prek registration, which had to follow the restamp so the hook never points at a missing file.

**Measured before the change** on a scratch copy with one README link removed: `--lint` exited 1, `prune --dry-run` exited 0 while reporting the orphan, and the real prune plus a before/after listing is what turns a removal into a failure.

**Tests.** Store copies match the template script; a consumer prunes an unlinked term and reports it; the root as committed survives its own prune; a dropped README link fails naming and restoring the term; the answers-file pin wins over a `copier.yml`; no glossary means nothing to prune; a missing pin and an unknown argument fail on their own. Workflow and file-set expectations updated. Full suite: 337 passed.

Supersedes #212, whose root-only hook this folds in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb