### PR TITLE
fix(gate): a review reply answers by naming any commit on the PR

### DIFF
--- a/.github/workflows/ci-ok.yml
+++ b/.github/workflows/ci-ok.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Every review thread opened by a human needs a PR-author reply
-      # carrying a full commit URL verified against this PR's commits,
+      # naming a commit (URL or sha) verified against this PR's commits,
       # or a line starting `No commit:` followed by
       # the reason (the marker is rendered from reference-keywords.json,
       # the single source). Resolving a thread is not answering it (#143).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,11 +154,11 @@ Code-specific skills:
   recognized the reference. Every ticket number in a
   `claude/((?:[a-z][a-z0-9]*?)?\d+(?:-(?:[a-z][a-z0-9]*?)?\d+)*)-` branch must appear as a canonical
   reference in the body.
-- **Answer every review comment with a full commit URL or `No commit: <why>`**
-  (enforced by the `review-answers` job): the commit URL must be a real
-  commit on the PR — verify with `git rev-parse` before pasting, never
-  expand a short hash from memory — and resolving a thread is not
-  answering it.
+- **Answer every review comment by naming the fixing commit or `No commit: <why>`**
+  (enforced by the `review-answers` job): the commit — as a URL or a
+  sha of seven or more hex digits — must be a real commit on the PR;
+  verify with `git rev-parse` before pasting, never expand a short hash
+  from memory, and resolving a thread is not answering it.
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 - **A push rejected over a commit you did not write is rebased around, never forced.**
   Branch rules re-evaluate every commit an update spans, not just the new ones,

--- a/decision-memory/.github/workflows/ci-ok.yml.jinja
+++ b/decision-memory/.github/workflows/ci-ok.yml.jinja
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Every review thread opened by a human needs a PR-author reply
-      # carrying a full commit URL verified against this PR's commits,
+      # naming a commit (URL or sha) verified against this PR's commits,
       # or a line starting `{{ refkw.no_commit_marker }}` followed by
       # the reason (the marker is rendered from reference-keywords.json,
       # the single source). Resolving a thread is not answering it (#143).

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -341,18 +341,22 @@ def review_violations(
     what to do next, not a human who already knows which comment they
     left.
 
-    Answered: a full commit URL under `base_url` whose sha is one of
-    this PR's own commits — a pasted-but-wrong link fails, and a bare
-    hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    Answered: the reply names a commit that is one of this PR's own —
+    as a commit URL under `base_url`, the PR's own /commits/<sha> URL,
+    or a bare sha of seven or more hex digits; the gate already holds
+    the PR's shas, so any spelling it can match is proof enough and
+    demanding one spelling only cost a round-trip (#205). A sha not on
+    the PR fails whatever wraps it. Or a line starting exactly with the
+    central file's `no_commit_marker`. A thread the reviewer RESOLVED is off
     the worklist regardless: resolution is the reviewer's own sign-off
     that nothing more is needed, and demanding a reply on top of it
     gated pandoscope/skills#30 on wording nobody was waiting for
     (agentic-engineering-template#166).
     """
-    url_re = re.compile(
-        re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
-    )
+    # Any hex run of 7-40 digits is a candidate; only a prefix of one of
+    # the PR's own shas answers, so hex-looking prose cannot pass by
+    # accident and a pasted-but-wrong sha still fails.
+    sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
     problems = []
     for comments in threads:
         first = comments[0]
@@ -368,7 +372,7 @@ def review_violations(
             body = reply.get("body") or ""
             linked = any(
                 any(sha.startswith(match.group(1)) for sha in pr_shas)
-                for match in url_re.finditer(body)
+                for match in sha_re.finditer(body)
             )
             marked = any(line.strip().startswith(marker) for line in body.splitlines())
             if linked or marked:
@@ -383,8 +387,10 @@ def review_violations(
             problems.append(
                 f'unanswered review thread by {opener} at {where}: "{quote}"'
                 + (f" ({link})" if link else "")
-                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
-                " line, or the reviewer resolves the thread"
+                + " — reply naming a commit on this PR (its URL or sha; a sha"
+                " not on the PR fails, and amending the commit invalidates"
+                f" the reference), or a '{marker} <why>' line, or the reviewer"
+                " resolves the thread"
             )
     return problems
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,6 +28,7 @@ For any change touching a templated file, always follow this route:
      --data agentic_project_description="Copier template for agentic engineering scaffolding" \
      --data agentic_project_slug=agentic-engineering-template \
      --data agentic_repo_owner=frankify-app \
+     --data agentic_merge_approvers=pando-genet \
      . <tmp-render-dir>
    ```
 

--- a/evidence-memory/.github/workflows/ci-ok.yml.jinja
+++ b/evidence-memory/.github/workflows/ci-ok.yml.jinja
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Every review thread opened by a human needs a PR-author reply
-      # carrying a full commit URL verified against this PR's commits,
+      # naming a commit (URL or sha) verified against this PR's commits,
       # or a line starting `{{ refkw.no_commit_marker }}` followed by
       # the reason (the marker is rendered from reference-keywords.json,
       # the single source). Resolving a thread is not answering it (#143).

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -341,18 +341,22 @@ def review_violations(
     what to do next, not a human who already knows which comment they
     left.
 
-    Answered: a full commit URL under `base_url` whose sha is one of
-    this PR's own commits — a pasted-but-wrong link fails, and a bare
-    hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    Answered: the reply names a commit that is one of this PR's own —
+    as a commit URL under `base_url`, the PR's own /commits/<sha> URL,
+    or a bare sha of seven or more hex digits; the gate already holds
+    the PR's shas, so any spelling it can match is proof enough and
+    demanding one spelling only cost a round-trip (#205). A sha not on
+    the PR fails whatever wraps it. Or a line starting exactly with the
+    central file's `no_commit_marker`. A thread the reviewer RESOLVED is off
     the worklist regardless: resolution is the reviewer's own sign-off
     that nothing more is needed, and demanding a reply on top of it
     gated pandoscope/skills#30 on wording nobody was waiting for
     (agentic-engineering-template#166).
     """
-    url_re = re.compile(
-        re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
-    )
+    # Any hex run of 7-40 digits is a candidate; only a prefix of one of
+    # the PR's own shas answers, so hex-looking prose cannot pass by
+    # accident and a pasted-but-wrong sha still fails.
+    sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
     problems = []
     for comments in threads:
         first = comments[0]
@@ -368,7 +372,7 @@ def review_violations(
             body = reply.get("body") or ""
             linked = any(
                 any(sha.startswith(match.group(1)) for sha in pr_shas)
-                for match in url_re.finditer(body)
+                for match in sha_re.finditer(body)
             )
             marked = any(line.strip().startswith(marker) for line in body.splitlines())
             if linked or marked:
@@ -383,8 +387,10 @@ def review_violations(
             problems.append(
                 f'unanswered review thread by {opener} at {where}: "{quote}"'
                 + (f" ({link})" if link else "")
-                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
-                " line, or the reviewer resolves the thread"
+                + " — reply naming a commit on this PR (its URL or sha; a sha"
+                " not on the PR fails, and amending the commit invalidates"
+                f" the reference), or a '{marker} <why>' line, or the reviewer"
+                " resolves the thread"
             )
     return problems
 

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -341,18 +341,22 @@ def review_violations(
     what to do next, not a human who already knows which comment they
     left.
 
-    Answered: a full commit URL under `base_url` whose sha is one of
-    this PR's own commits — a pasted-but-wrong link fails, and a bare
-    hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    Answered: the reply names a commit that is one of this PR's own —
+    as a commit URL under `base_url`, the PR's own /commits/<sha> URL,
+    or a bare sha of seven or more hex digits; the gate already holds
+    the PR's shas, so any spelling it can match is proof enough and
+    demanding one spelling only cost a round-trip (#205). A sha not on
+    the PR fails whatever wraps it. Or a line starting exactly with the
+    central file's `no_commit_marker`. A thread the reviewer RESOLVED is off
     the worklist regardless: resolution is the reviewer's own sign-off
     that nothing more is needed, and demanding a reply on top of it
     gated pandoscope/skills#30 on wording nobody was waiting for
     (agentic-engineering-template#166).
     """
-    url_re = re.compile(
-        re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
-    )
+    # Any hex run of 7-40 digits is a candidate; only a prefix of one of
+    # the PR's own shas answers, so hex-looking prose cannot pass by
+    # accident and a pasted-but-wrong sha still fails.
+    sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
     problems = []
     for comments in threads:
         first = comments[0]
@@ -368,7 +372,7 @@ def review_violations(
             body = reply.get("body") or ""
             linked = any(
                 any(sha.startswith(match.group(1)) for sha in pr_shas)
-                for match in url_re.finditer(body)
+                for match in sha_re.finditer(body)
             )
             marked = any(line.strip().startswith(marker) for line in body.splitlines())
             if linked or marked:
@@ -383,8 +387,10 @@ def review_violations(
             problems.append(
                 f'unanswered review thread by {opener} at {where}: "{quote}"'
                 + (f" ({link})" if link else "")
-                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
-                " line, or the reviewer resolves the thread"
+                + " — reply naming a commit on this PR (its URL or sha; a sha"
+                " not on the PR fails, and amending the commit invalidates"
+                f" the reference), or a '{marker} <why>' line, or the reviewer"
+                " resolves the thread"
             )
     return problems
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -165,11 +165,11 @@ Code-specific skills:
   recognized the reference. Every ticket number in a
   `{{ refkw.branch_pattern }}` branch must appear as a canonical
   reference in the body.
-- **Answer every review comment with a full commit URL or `{{ refkw.no_commit_marker }} <why>`**
-  (enforced by the `review-answers` job): the commit URL must be a real
-  commit on the PR — verify with `git rev-parse` before pasting, never
-  expand a short hash from memory — and resolving a thread is not
-  answering it.
+- **Answer every review comment by naming the fixing commit or `{{ refkw.no_commit_marker }} <why>`**
+  (enforced by the `review-answers` job): the commit — as a URL or a
+  sha of seven or more hex digits — must be a real commit on the PR;
+  verify with `git rev-parse` before pasting, never expand a short hash
+  from memory, and resolving a thread is not answering it.
 - Document unexpected encounters and design decisions in commit message as well as PR/Issue
 - **A push rejected over a commit you did not write is rebased around, never forced.**
   Branch rules re-evaluate every commit an update spans, not just the new ones,

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -341,18 +341,22 @@ def review_violations(
     what to do next, not a human who already knows which comment they
     left.
 
-    Answered: a full commit URL under `base_url` whose sha is one of
-    this PR's own commits — a pasted-but-wrong link fails, and a bare
-    hash fails by design — or a line starting exactly with the central
-    file's `no_commit_marker`. A thread the reviewer RESOLVED is off
+    Answered: the reply names a commit that is one of this PR's own —
+    as a commit URL under `base_url`, the PR's own /commits/<sha> URL,
+    or a bare sha of seven or more hex digits; the gate already holds
+    the PR's shas, so any spelling it can match is proof enough and
+    demanding one spelling only cost a round-trip (#205). A sha not on
+    the PR fails whatever wraps it. Or a line starting exactly with the
+    central file's `no_commit_marker`. A thread the reviewer RESOLVED is off
     the worklist regardless: resolution is the reviewer's own sign-off
     that nothing more is needed, and demanding a reply on top of it
     gated pandoscope/skills#30 on wording nobody was waiting for
     (agentic-engineering-template#166).
     """
-    url_re = re.compile(
-        re.escape(base_url) + r"/[\w.-]+/[\w.-]+/commit/([0-9a-f]{7,40})\b"
-    )
+    # Any hex run of 7-40 digits is a candidate; only a prefix of one of
+    # the PR's own shas answers, so hex-looking prose cannot pass by
+    # accident and a pasted-but-wrong sha still fails.
+    sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
     problems = []
     for comments in threads:
         first = comments[0]
@@ -368,7 +372,7 @@ def review_violations(
             body = reply.get("body") or ""
             linked = any(
                 any(sha.startswith(match.group(1)) for sha in pr_shas)
-                for match in url_re.finditer(body)
+                for match in sha_re.finditer(body)
             )
             marked = any(line.strip().startswith(marker) for line in body.splitlines())
             if linked or marked:
@@ -383,8 +387,10 @@ def review_violations(
             problems.append(
                 f'unanswered review thread by {opener} at {where}: "{quote}"'
                 + (f" ({link})" if link else "")
-                + f" — reply with a commit URL on this PR or a '{marker} <why>'"
-                " line, or the reviewer resolves the thread"
+                + " — reply naming a commit on this PR (its URL or sha; a sha"
+                " not on the PR fails, and amending the commit invalidates"
+                f" the reference), or a '{marker} <why>' line, or the reviewer"
+                " resolves the thread"
             )
     return problems
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/ci-ok.yml.jinja
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Every review thread opened by a human needs a PR-author reply
-      # carrying a full commit URL verified against this PR's commits,
+      # naming a commit (URL or sha) verified against this PR's commits,
       # or a line starting `{{ refkw.no_commit_marker }}` followed by
       # the reason (the marker is rendered from reference-keywords.json,
       # the single source). Resolving a thread is not answering it (#143).

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -217,23 +217,33 @@ def test_verified_commit_url_answers_a_thread():
     )
 
 
-def test_bare_hash_or_wrong_sha_does_not_answer():
-    hash_only = [thread("pando-genet", ("pando-ramet", "Fixed in 5e1f03e"))]
-    wrong = [
-        thread(
-            "pando-genet",
-            (
-                "pando-ramet",
-                "Fixed in https://github.com/o/r/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            ),
-        )
-    ]
-    assert gate.review_violations(
-        hash_only, "pando-ramet", SHAS, "https://github.com", "No commit:"
-    )
-    assert gate.review_violations(
-        wrong, "pando-ramet", SHAS, "https://github.com", "No commit:"
-    )
+def test_any_spelling_of_a_pr_commit_answers():
+    """The gate holds the PR's shas; matching one is the proof (#205)."""
+    for body in (
+        "Fixed in 5e1f03e",
+        "Fixed in https://github.com/o/r/pull/9/commits/5e1f03edb10baf9e7ad0dfa8d9c36dfdc055a13b",
+        "see 5e1f03edb10baf9e7ad0dfa8d9c36dfdc055a13b (folded)",
+    ):
+        threads = [thread("pando-genet", ("pando-ramet", body))]
+        assert (
+            gate.review_violations(
+                threads, "pando-ramet", SHAS, "https://github.com", "No commit:"
+            )
+            == []
+        ), body
+
+
+def test_a_sha_not_on_the_pr_does_not_answer_however_wrapped():
+    for body in (
+        "Fixed in https://github.com/o/r/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "Fixed in aaaaaaa",
+        "the value 0xdeadbeef is a bitmask, not a commit",
+        "Fixed in 5e1f03",  # six digits: below the floor, not a sha
+    ):
+        threads = [thread("pando-genet", ("pando-ramet", body))]
+        assert gate.review_violations(
+            threads, "pando-ramet", SHAS, "https://github.com", "No commit:"
+        ), body
 
 
 def test_no_commit_marker_answers_but_loose_wording_does_not():


### PR DESCRIPTION
CLOSES #205
ADVANCES pandoscope/meta#118

The review-answers gate accepted exactly one spelling — `<server>/<owner>/<repo>/commit/<sha>` — and told a reply in any other form only "reply with a commit URL". On meta!88 that cost two wrong-shaped replies and a read of the regex; the finding then landed in a consumer's CLAUDE.md (meta!119), where review sent it back here because the gate is template-owned. The principal's ruling on top: if the reply carries a sha that IS an existing commit on the PR, the gate can just match it and save the agent a round-trip.

**Change (template-first route, two commits):**
1. **Any spelling of a PR commit answers.** The gate already holds the PR's own shas, so a commit URL, the PR's `/pull/N/commits/<sha>` URL, or a bare sha of ≥7 hex digits all answer when the sha is one of the PR's commits; a sha not on the PR still fails whatever wraps it, so hex-looking prose (`0xdeadbeef`, six-digit fragments) cannot pass by accident. The error now names the rule. AGENTS.md's rule and the ci-ok comment say "naming the commit" rather than "a full commit URL" — in the template source and both store subtemplates' copies. `docs/conventions.md`'s self-render command gains the `agentic_merge_approvers` answer copier now requires (it no longer rendered without it).
2. `chore: reapply template to self` — root `scripts/ci/check_gate.py`, `AGENTS.md` and `.github/workflows/ci-ok.yml` adopted verbatim from the render.

No Learnings line in this repo's CLAUDE.md: it is render output here (the self-application state test has no Learnings exemption), and with this change there is nothing left to learn.

Tests: new cases for each accepted spelling and each rejected one; `test_self_application`, `test_ci_gate`, `test_generate_project` and both store suites — 158/158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb