### PR TITLE
feat(ci): scan issue and comment payloads for denylist hits on every event

### DIFF
--- a/.github/workflows/payload-scan.yml
+++ b/.github/workflows/payload-scan.yml
@@ -1,0 +1,44 @@
+name: Payload scan
+
+# The event-driven net of the leak-prevention stack
+# (agentic-engineering-template#189, closes #208). Issue bodies, issue
+# comments and review comments auto-publish with no approval step and
+# no hook; the daily audit finds a denylist hit there up to a day
+# later. This job runs the moment one of them is created OR edited
+# and scans only that item — the event payload, nothing else — against
+# PUSH_BLOCKLIST. A hit turns the run red, value-silent: surface and
+# entry label, never the value. The red run is the alert. Not a gate
+# (the surface has none) and no credential rules here: layer 3 owns
+# the full history.
+#
+# Free on public repos; a private repo is not exposed, so its runs stop
+# at the job condition without spending a runner minute.
+on:
+  issues:
+    types:
+      - opened
+      - edited
+  issue_comment:
+    types:
+      - created
+      - edited
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  payload:
+    name: "denylist scan of the published item"
+    if: ${{ !github.event.repository.private }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: The item this event published carries no denylist value
+        env:
+          PUSH_BLOCKLIST: ${{ secrets.PUSH_BLOCKLIST }}
+        run: python3 scripts/ci/check_gate.py payload

--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -15,6 +15,8 @@ One subcommand per job in ci-ok.yml:
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+  payload    no PUSH_BLOCKLIST value in the one item an issue or
+             comment event just published (#208; not a gate)
              publishes: title, body, commit messages, commit author
              and committer names/emails, the branch name, the diff,
              the PR's own comment and review threads, and the bodies
@@ -975,6 +977,48 @@ def run_leaks():
     return 1 if problems else 0
 
 
+# ------------------------------------------------------------ payload
+
+
+def payload_surfaces(event):
+    """The one item an issue/comment event just published, labeled.
+
+    The event-driven net (#208) reads nothing but the event: an
+    issue's title and body on `issues`, a comment's body on
+    `issue_comment` (PR conversation comments included) and
+    `pull_request_review_comment`. No repo walk, no API listing —
+    layer 3 owns the full history; this catches the item that just
+    went public, minutes instead of a day.
+    """
+    comment = event.get("comment")
+    if comment:
+        label = f"comment {comment.get('html_url')}"
+        if comment.get("path"):
+            label += f" on {comment['path']}"
+        return [(label, comment.get("body"))]
+    issue = event.get("issue") or event.get("pull_request") or {}
+    where = issue.get("html_url")
+    return [
+        (f"issue {where} title", issue.get("title")),
+        (f"issue {where} body", issue.get("body")),
+    ]
+
+
+def run_payload():
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    problems = leak_violations(payload_surfaces(event), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string in the item this event published.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -984,6 +1028,7 @@ def main():
         "aggregate": run_aggregate,
         "rerun": run_rerun,
         "leaks": run_leaks,
+        "payload": run_payload,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -15,6 +15,8 @@ One subcommand per job in ci-ok.yml:
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+  payload    no PUSH_BLOCKLIST value in the one item an issue or
+             comment event just published (#208; not a gate)
              publishes: title, body, commit messages, commit author
              and committer names/emails, the branch name, the diff,
              the PR's own comment and review threads, and the bodies
@@ -975,6 +977,48 @@ def run_leaks():
     return 1 if problems else 0
 
 
+# ------------------------------------------------------------ payload
+
+
+def payload_surfaces(event):
+    """The one item an issue/comment event just published, labeled.
+
+    The event-driven net (#208) reads nothing but the event: an
+    issue's title and body on `issues`, a comment's body on
+    `issue_comment` (PR conversation comments included) and
+    `pull_request_review_comment`. No repo walk, no API listing —
+    layer 3 owns the full history; this catches the item that just
+    went public, minutes instead of a day.
+    """
+    comment = event.get("comment")
+    if comment:
+        label = f"comment {comment.get('html_url')}"
+        if comment.get("path"):
+            label += f" on {comment['path']}"
+        return [(label, comment.get("body"))]
+    issue = event.get("issue") or event.get("pull_request") or {}
+    where = issue.get("html_url")
+    return [
+        (f"issue {where} title", issue.get("title")),
+        (f"issue {where} body", issue.get("body")),
+    ]
+
+
+def run_payload():
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    problems = leak_violations(payload_surfaces(event), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string in the item this event published.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -984,6 +1028,7 @@ def main():
         "aggregate": run_aggregate,
         "rerun": run_rerun,
         "leaks": run_leaks,
+        "payload": run_payload,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -15,6 +15,8 @@ One subcommand per job in ci-ok.yml:
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+  payload    no PUSH_BLOCKLIST value in the one item an issue or
+             comment event just published (#208; not a gate)
              publishes: title, body, commit messages, commit author
              and committer names/emails, the branch name, the diff,
              the PR's own comment and review threads, and the bodies
@@ -975,6 +977,48 @@ def run_leaks():
     return 1 if problems else 0
 
 
+# ------------------------------------------------------------ payload
+
+
+def payload_surfaces(event):
+    """The one item an issue/comment event just published, labeled.
+
+    The event-driven net (#208) reads nothing but the event: an
+    issue's title and body on `issues`, a comment's body on
+    `issue_comment` (PR conversation comments included) and
+    `pull_request_review_comment`. No repo walk, no API listing —
+    layer 3 owns the full history; this catches the item that just
+    went public, minutes instead of a day.
+    """
+    comment = event.get("comment")
+    if comment:
+        label = f"comment {comment.get('html_url')}"
+        if comment.get("path"):
+            label += f" on {comment['path']}"
+        return [(label, comment.get("body"))]
+    issue = event.get("issue") or event.get("pull_request") or {}
+    where = issue.get("html_url")
+    return [
+        (f"issue {where} title", issue.get("title")),
+        (f"issue {where} body", issue.get("body")),
+    ]
+
+
+def run_payload():
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    problems = leak_violations(payload_surfaces(event), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string in the item this event published.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -984,6 +1028,7 @@ def main():
         "aggregate": run_aggregate,
         "rerun": run_rerun,
         "leaks": run_leaks,
+        "payload": run_payload,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -15,6 +15,8 @@ One subcommand per job in ci-ok.yml:
              place, so a superseded red stops blocking merge (#190) —
              gate-rerun.yml's job, not ci-ok.yml's
   leaks      no PUSH_BLOCKLIST value appears on any surface this PR
+  payload    no PUSH_BLOCKLIST value in the one item an issue or
+             comment event just published (#208; not a gate)
              publishes: title, body, commit messages, commit author
              and committer names/emails, the branch name, the diff,
              the PR's own comment and review threads, and the bodies
@@ -975,6 +977,48 @@ def run_leaks():
     return 1 if problems else 0
 
 
+# ------------------------------------------------------------ payload
+
+
+def payload_surfaces(event):
+    """The one item an issue/comment event just published, labeled.
+
+    The event-driven net (#208) reads nothing but the event: an
+    issue's title and body on `issues`, a comment's body on
+    `issue_comment` (PR conversation comments included) and
+    `pull_request_review_comment`. No repo walk, no API listing —
+    layer 3 owns the full history; this catches the item that just
+    went public, minutes instead of a day.
+    """
+    comment = event.get("comment")
+    if comment:
+        label = f"comment {comment.get('html_url')}"
+        if comment.get("path"):
+            label += f" on {comment['path']}"
+        return [(label, comment.get("body"))]
+    issue = event.get("issue") or event.get("pull_request") or {}
+    where = issue.get("html_url")
+    return [
+        (f"issue {where} title", issue.get("title")),
+        (f"issue {where} body", issue.get("body")),
+    ]
+
+
+def run_payload():
+    values = parse_blocklist(os.environ.get("PUSH_BLOCKLIST"))
+    if not values:
+        print("::warning::PUSH_BLOCKLIST is empty — the denylist layer is inactive")
+        return 0
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+    problems = leak_violations(payload_surfaces(event), values)
+    for problem in problems:
+        print(f"::error::{problem}")
+    if not problems:
+        print("No blocklisted string in the item this event published.")
+    return 1 if problems else 0
+
+
 def main():
     verb = sys.argv[1] if len(sys.argv) > 1 else ""
     runners = {
@@ -984,6 +1028,7 @@ def main():
         "aggregate": run_aggregate,
         "rerun": run_rerun,
         "leaks": run_leaks,
+        "payload": run_payload,
     }
     if verb not in runners:
         print(f"usage: check_gate.py {{{'|'.join(runners)}}}", file=sys.stderr)

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/payload-scan.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/payload-scan.yml.jinja
@@ -1,0 +1,44 @@
+name: Payload scan
+
+# The event-driven net of the leak-prevention stack
+# (agentic-engineering-template#189, closes #208). Issue bodies, issue
+# comments and review comments auto-publish with no approval step and
+# no hook; the daily audit finds a denylist hit there up to a day
+# later. This job runs the moment one of them is created OR edited
+# and scans only that item — the event payload, nothing else — against
+# PUSH_BLOCKLIST. A hit turns the run red, value-silent: surface and
+# entry label, never the value. The red run is the alert. Not a gate
+# (the surface has none) and no credential rules here: layer 3 owns
+# the full history.
+#
+# Free on public repos; a private repo is not exposed, so its runs stop
+# at the job condition without spending a runner minute.
+on:
+  issues:
+    types:
+      - opened
+      - edited
+  issue_comment:
+    types:
+      - created
+      - edited
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  payload:
+    name: "denylist scan of the published item"
+    if: {% raw %}${{ !github.event.repository.private }}{% endraw %}
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: The item this event published carries no denylist value
+        env:
+          PUSH_BLOCKLIST: {% raw %}${{ secrets.PUSH_BLOCKLIST }}{% endraw %}
+        run: python3 scripts/ci/check_gate.py payload

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -859,3 +859,106 @@ def test_the_gate_judges_the_live_body_not_the_event_payload(
     monkeypatch.setattr(gate, "paginate", lambda path, token: [])
     assert gate.run_ticket() == 0
     assert "::error::" not in capsys.readouterr().out
+
+
+# ------------------------------------------------------------ payload
+
+
+def test_payload_surfaces_read_only_the_item_the_event_carries():
+    """#208: the event-driven net scans just the one thing that
+    changed — an issue's title and body, or a comment's body — labeled
+    with its link so a hit says where without walking the repo."""
+    issue_event = {
+        "action": "edited",
+        "issue": {"title": "t", "body": "b", "html_url": "https://x/issues/1"},
+    }
+    assert gate.payload_surfaces(issue_event) == [
+        ("issue https://x/issues/1 title", "t"),
+        ("issue https://x/issues/1 body", "b"),
+    ]
+    comment_event = {
+        "action": "created",
+        "issue": {"title": "t", "body": "b", "html_url": "https://x/issues/1"},
+        "comment": {"body": "c", "html_url": "https://x/issues/1#issuecomment-5"},
+    }
+    assert gate.payload_surfaces(comment_event) == [
+        ("comment https://x/issues/1#issuecomment-5", "c"),
+    ]
+    review_comment_event = {
+        "action": "edited",
+        "pull_request": {"title": "t", "body": "b", "html_url": "https://x/pull/2"},
+        "comment": {
+            "body": "rc",
+            "path": "a.py",
+            "html_url": "https://x/pull/2#discussion_r7",
+        },
+    }
+    assert gate.payload_surfaces(review_comment_event) == [
+        ("comment https://x/pull/2#discussion_r7 on a.py", "rc"),
+    ]
+
+
+def test_run_payload_is_red_on_a_hit_value_silent_and_green_when_clean(
+    tmp_path, monkeypatch, capsys
+):
+    event = tmp_path / "event.json"
+    event.write_text(
+        json.dumps(
+            {
+                "action": "created",
+                "issue": {"title": "t", "body": "b", "html_url": "https://x/issues/1"},
+                "comment": {
+                    "body": "ping sekritvalue9 please",
+                    "html_url": "https://x/issues/1#issuecomment-5",
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+    monkeypatch.setenv("PUSH_BLOCKLIST", "sekritvalue9=pb:old-pw|other")
+    assert gate.run_payload() == 1
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "pb:old-pw" in out
+    assert "https://x/issues/1#issuecomment-5" in out
+    assert "sekritvalue9" not in out
+
+    monkeypatch.setenv("PUSH_BLOCKLIST", "other")
+    assert gate.run_payload() == 0
+    assert "::error" not in capsys.readouterr().out
+
+
+def test_run_payload_warns_loudly_on_an_empty_blocklist(monkeypatch, capsys):
+    monkeypatch.setenv("PUSH_BLOCKLIST", "")
+    assert gate.run_payload() == 0
+    assert "::warning" in capsys.readouterr().out
+
+
+def test_payload_scan_workflow_fires_on_every_comment_shaped_event():
+    """The instant-detection piece (#208): issues, issue comments (PR
+    conversation included) and review comments, on create AND edit —
+    a comment scrubbed by edit is also a comment re-leaked by edit.
+    Free on public repos; private repos are not exposed and skip via
+    the event's own repository flag, no API call needed."""
+    text = (
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "payload-scan.yml.jinja"
+    ).read_text()
+    for trigger in ("issues:", "issue_comment:", "pull_request_review_comment:"):
+        assert trigger in text
+    assert text.count("- created") == 2
+    assert text.count("- edited") == 3
+    assert "- opened" in text
+    assert "check_gate.py payload" in text
+    assert "secrets.PUSH_BLOCKLIST" in text
+    assert "github.event.repository.private" in text
+    assert "runs-on: {{ agentic_actions_runner }}" in text
+
+
+def test_root_stamp_carries_the_payload_scan_workflow():
+    text = (ROOT / ".github" / "workflows" / "payload-scan.yml").read_text()
+    assert "{%" not in text
+    assert "runs-on: ubuntu-latest" in text

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -85,6 +85,8 @@ GITHUB_ONLY_FILES = frozenset(
         ".github/workflows/trufflehog-audit.yml",
         # The daily forge-native secret-scanning check (#189, layer 4).
         ".github/workflows/secret-scanning.yml",
+        # The event-driven denylist scan of issue/comment payloads (#208).
+        ".github/workflows/payload-scan.yml",
         ".github/reference-keywords.json",
         # The merge-approval gate (#187): the approver allowlist its
         # check reads.


### PR DESCRIPTION
ADVANCES #189. CLOSES #208.

Stacked on #207 (its two commits show here until it merges; auto-merge is set there).

## What

The event-driven net: `payload-scan.yml` fires on `issues` (opened, edited), `issue_comment` (created, edited — PR conversation comments included) and `pull_request_review_comment` (created, edited), and hands the event to a new `check_gate.py payload` subcommand that reads **only the item that changed** — an issue's title and body, or a comment's body — and matches it against `PUSH_BLOCKLIST` with the leaks job's own parser and value-silent matcher. A hit turns the run red naming surface and entry label, never the value. Minutes instead of the daily audit's day.

Not a gate (the surface has none) and no credential rules here: layer 3 owns the full history. Private repos are not exposed and skip at the job condition on the event's own `repository.private` flag — no API call, no runner minute. `edited` matters as much as `created`: a comment scrubbed by edit is also a comment re-leaked by edit.

## Tests

`tests/test_ci_gate.py` +5: payload surfaces per event shape, red-on-hit value-silent / green-when-clean, loud warning on an empty blocklist, workflow wiring (all three triggers, create AND edit, private-skip condition), root stamp. e2e frozenset updated; `check_gate.py` stays byte-pinned across template/root/dm/em. Two-commit template-first shape; suite 330 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952240&installation_model_id=432661&pr_number=209&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F209&signature=37436520b506e4970fe3a7b5142cb236eed3cbe97bfc31a64ddd77f94e5a18fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->