### PR TITLE
fix(ci): an engine status the repo token cannot see is a notice, not a failure

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -69,15 +69,21 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY" > "$RUNNER_TEMP/repo.json"
           scanning="$(jq -r '.security_and_analysis.secret_scanning.status // "unset"' "$RUNNER_TEMP/repo.json")"
           protection="$(jq -r '.security_and_analysis.secret_scanning_push_protection.status // "unset"' "$RUNNER_TEMP/repo.json")"
+          # The repo token sees no security_and_analysis block at all
+          # (that needs admin scope), so "unset" means unobservable, not
+          # off: say so and let the alert feed below be the check. Only
+          # a status the token can see and that is not "enabled" is red.
           rc=0
-          if [ "$scanning" != "enabled" ]; then
-            echo "::error::GitHub secret scanning is '$scanning' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
-            rc=1
-          fi
-          if [ "$protection" != "enabled" ]; then
-            echo "::error::GitHub push protection is '$protection' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
-            rc=1
-          fi
+          for engine in "secret scanning=$scanning" "push protection=$protection"; do
+            name="${engine%%=*}"
+            status="${engine#*=}"
+            if [ "$status" = "unset" ]; then
+              echo "::notice::GitHub $name status is not visible to the repo token on $GITHUB_REPOSITORY — the alert feed below is the check"
+            elif [ "$status" != "enabled" ]; then
+              echo "::error::GitHub $name is '$status' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
+              rc=1
+            fi
+          done
           echo "secret scanning: $scanning; push protection: $protection"
           exit "$rc"
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/secret-scanning.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/secret-scanning.yml.jinja
@@ -69,15 +69,21 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY" > "$RUNNER_TEMP/repo.json"
           scanning="$(jq -r '.security_and_analysis.secret_scanning.status // "unset"' "$RUNNER_TEMP/repo.json")"
           protection="$(jq -r '.security_and_analysis.secret_scanning_push_protection.status // "unset"' "$RUNNER_TEMP/repo.json")"
+          # The repo token sees no security_and_analysis block at all
+          # (that needs admin scope), so "unset" means unobservable, not
+          # off: say so and let the alert feed below be the check. Only
+          # a status the token can see and that is not "enabled" is red.
           rc=0
-          if [ "$scanning" != "enabled" ]; then
-            echo "::error::GitHub secret scanning is '$scanning' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
-            rc=1
-          fi
-          if [ "$protection" != "enabled" ]; then
-            echo "::error::GitHub push protection is '$protection' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
-            rc=1
-          fi
+          for engine in "secret scanning=$scanning" "push protection=$protection"; do
+            name="${engine%%=*}"
+            status="${engine#*=}"
+            if [ "$status" = "unset" ]; then
+              echo "::notice::GitHub $name status is not visible to the repo token on $GITHUB_REPOSITORY — the alert feed below is the check"
+            elif [ "$status" != "enabled" ]; then
+              echo "::error::GitHub $name is '$status' on $GITHUB_REPOSITORY — enable it under Settings → Code security (free on public repos)"
+              rc=1
+            fi
+          done
           echo "secret scanning: $scanning; push protection: $protection"
           exit "$rc"
 

--- a/tests/test_native_scan.py
+++ b/tests/test_native_scan.py
@@ -112,6 +112,19 @@ def test_native_scan_workflow_is_daily_self_scoped_and_checks_both_engines():
     assert "RUNNER_TEMP" in text
 
 
+def test_an_unobservable_engine_status_is_a_notice_not_a_failure():
+    """Measured on the first run: the repo token gets no
+    security_and_analysis block at all (admin scope), so 'unset' must
+    not fail every public repo daily — it says so and lets the alert
+    feed be the check. A status the token CAN see and that is not
+    'enabled' stays red."""
+    text = WORKFLOW.read_text()
+    assert '"unset"' in text
+    assert "::notice::" in text
+    assert "not visible to the repo token" in text
+    assert '"$status" != "enabled"' in text
+
+
 def test_native_scan_workflow_does_not_collide_with_the_audit_schedule():
     audit = WORKFLOW.with_name("trufflehog-audit.yml.jinja").read_text()
 


### PR DESCRIPTION
ADVANCES #189.

The first `secret-scanning.yml` run on main (dispatched right after #207 merged, [run 33643984003](https://github.com/pandoscope/agentic-engineering-template/actions/runs/33643984003)) turned red on `unset` for both engines: the repo token receives no `security_and_analysis` block at all — reading it needs admin scope — so the enablement check as written could never pass on any repo, and the alert-feed step behind it never ran.

Now a status the token cannot observe is a `::notice` that hands the check to the alert feed below; a status the token CAN see and that is not `enabled` stays `::error`. Test added; two-commit template-first shape. Whether the repo token can read the alert feed itself is the next thing the first run after this merge answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952422&installation_model_id=432661&pr_number=211&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F211&signature=c04392a9f18e5448a25368469d08183a5a31d6c895e71a0a198a694db80f1e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->