### PR TITLE
Run the glossary prune on the template root; a removal fails loudly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,16 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      # The glossary prune, for real, on this root too (#210). Consumers
+      # converge by deletion; here the glossary is pinned render output
+      # kept reachable by README.md's index, so a removal is a defect:
+      # the script restores tracked terms and fails naming them.
+      - id: prune-glossary
+        name: "glossary prune removes nothing (every term reachable)"
+        entry: scripts/dev/prune_glossary.sh
+        language: script
+        pass_filenames: false
+        always_run: true
       # Identity class (#189): PUSH_BLOCKLIST is `|`-separated values
       # in env, never committed — exactly grep's alternation syntax.
       # An entry may name its placeholder (`value=pb:name`); labels

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ These links live in this repo's own README, which is NOT part of the render —
 so in a generated repo the same terms arrive unlinked, stay orphaned until
 something references them, and can be removed with `disambiguate prune`.
 
+The same prune runs on this root too — the `prune-glossary` prek hook, which
+the lint CI job runs on every PR, with the pin from `copier.yml`. Here every
+term must survive it: the glossary is render output pinned by the
+self-application test, so a removal is a defect, and the hook fails naming
+the term and restoring it.
+
 ## Developing this template
 
 ```shell

--- a/scripts/dev/prune_glossary.sh
+++ b/scripts/dev/prune_glossary.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# The glossary prune, run for real on the template's own root (#210).
+#
+# Consumers converge by deletion: every stamp re-delivers the shared
+# term set and `disambiguate prune` drops what nothing links (#67,
+# #203). This root is different. Its glossary is render output that
+# tests/test_self_application.py pins byte-for-byte, and the Glossary
+# index in README.md is what keeps every term reachable. So the same
+# prune runs here with the same pin, but a removal is not convergence,
+# it is a defect: a README link dropped, or a term nothing reaches.
+# The hook fails loudly, names the terms, and puts tracked ones back
+# so a commit hook never leaves the tree mutated.
+#
+# The pin is copier.yml's default for agentic_disambiguate_version:
+# the root has no answers file (.copier-answers.agentic.yml is a
+# deliberate divergence), and reading the default keeps one source.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+pin="$(awk '
+    $1 == "agentic_disambiguate_version:" { in_q = 1; next }
+    in_q && $1 == "default:" { gsub(/"/, "", $2); print $2; exit }
+    in_q && /^[^ #]/ { in_q = 0 }
+' copier.yml)"
+if [ -z "$pin" ]; then
+    echo "prune_glossary: copier.yml has no agentic_disambiguate_version default" >&2
+    exit 1
+fi
+
+glossary=docs/glossary
+list_terms() { find "$glossary" -maxdepth 1 -name '*.md' | sort; }
+
+before="$(list_terms)"
+uvx "disambiguate==$pin" prune
+removed="$(comm -23 <(printf '%s\n' "$before") <(list_terms))"
+
+[ -n "$removed" ] || exit 0
+
+{
+    echo "GLOSSARY PRUNE REMOVED TERMS FROM THE TEMPLATE ROOT"
+    while IFS= read -r file; do
+        if git checkout --quiet -- "$file" 2>/dev/null; then
+            echo "  $file  (restored)"
+        else
+            echo "  $file  (untracked: not restorable, re-create it)"
+        fi
+    done <<< "$removed"
+    echo "Nothing reachable from README.md links them. On this root the"
+    echo "glossary is render output pinned by tests/test_self_application.py,"
+    echo "so a removal is a defect, not convergence: link each term from the"
+    echo "Glossary index in README.md (or from the doc that should reach it),"
+    echo "or drop it from template/docs/glossary/ and restamp."
+} >&2
+exit 1

--- a/tests/test_prune_glossary.py
+++ b/tests/test_prune_glossary.py
@@ -1,0 +1,111 @@
+"""The glossary prune runs for real on the template root and removes nothing.
+
+Consumers converge by deletion (#67, #203). This root's glossary is render
+output pinned by `test_self_application.py` and kept reachable by the
+Glossary index in README.md, so `scripts/dev/prune_glossary.sh` runs the
+same pinned prune and treats a removal as a defect (#210): it names the
+term, restores it, and exits non-zero.
+
+The fixture is a copy of the root's own linking documents, so the test
+also proves the root as committed survives its own prune.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "scripts" / "dev" / "prune_glossary.sh"
+# What reachability is computed over, plus the pin's source and the hook.
+COPIED = ("README.md", "AGENTS.md", "CLAUDE.md", "copier.yml", "docs")
+
+
+def _fixture(tmp_path: Path) -> Path:
+    repo = tmp_path / "root"
+    repo.mkdir()
+    for name in COPIED:
+        src = PROJECT_ROOT / name
+        if src.is_dir():
+            shutil.copytree(src, repo / name)
+        else:
+            shutil.copy2(src, repo / name)
+    (repo / "scripts" / "dev").mkdir(parents=True)
+    shutil.copy2(SCRIPT, repo / "scripts" / "dev" / SCRIPT.name)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    return repo
+
+
+def _prune(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/dev/prune_glossary.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _needs_uvx() -> None:
+    if shutil.which("uvx") is None:
+        pytest.skip("the prune runs disambiguate through uvx")
+
+
+def test_the_root_as_committed_survives_its_own_prune(tmp_path: Path) -> None:
+    repo = _fixture(tmp_path)
+    terms = sorted(p.name for p in (repo / "docs" / "glossary").glob("*.md"))
+
+    result = _prune(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert sorted(p.name for p in (repo / "docs" / "glossary").glob("*.md")) == terms
+
+
+def test_a_dropped_readme_link_fails_naming_and_restoring_the_term(
+    tmp_path: Path,
+) -> None:
+    repo = _fixture(tmp_path)
+    readme = repo / "README.md"
+    lines = readme.read_text(encoding="utf-8").splitlines(keepends=True)
+    kept = [line for line in lines if "docs/glossary/reinset.md" not in line]
+    assert len(kept) == len(lines) - 1, "fixture: README links reinset exactly once"
+    readme.write_text("".join(kept), encoding="utf-8")
+
+    result = _prune(repo)
+
+    assert result.returncode == 1
+    assert "REMOVED TERMS" in result.stderr
+    assert "docs/glossary/reinset.md" in result.stderr
+    assert "(restored)" in result.stderr
+    assert (repo / "docs" / "glossary" / "reinset.md").is_file(), (
+        "a tracked term the prune removed is put back"
+    )
+
+
+def test_a_missing_pin_is_its_own_loud_failure(tmp_path: Path) -> None:
+    repo = _fixture(tmp_path)
+    (repo / "copier.yml").write_text("agentic_project_name:\n  type: str\n")
+
+    result = _prune(repo)
+
+    assert result.returncode == 1
+    assert "agentic_disambiguate_version" in result.stderr


### PR DESCRIPTION
CLOSES #210

Consumers converge their glossary by deletion after every stamp (#67, #203). The template root never ran the prune: the update workflow is a deliberate divergence and the self-render skips tasks, so the README's claim that the copied terms are "lintable here" had nothing behind it. A dropped README link or a hand-deleted term passed every gate the repo has.

**Ruling applied:** run the real prune here too, and treat any removal as a loud failure.

- `scripts/dev/prune_glossary.sh` runs `uvx disambiguate==<pin> prune` on the root, with the pin read from `copier.yml`'s `agentic_disambiguate_version` default (the root has no answers file). If the run removes a glossary file it names each term, restores the tracked ones so a commit hook never leaves the tree mutated, explains why a removal is a defect on this root (the glossary is render output pinned by the self-application test), and exits 1. A missing pin is its own failure.
- Registered as the `prune-glossary` local hook in the root `.pre-commit-config.yaml` (already a deliberate divergence). The existing `prek run --all-files` lint job runs it on every PR; local commits run it too.
- README glossary paragraph says the same prune runs here and that a removal fails naming the term.
- `tests/test_prune_glossary.py`: the root as committed survives its own prune; one dropped README link fails naming and restoring the term; a missing pin fails on its own.

Measured before the change, on a scratch copy with one link removed: `--lint` exits 1, `prune --dry-run` exits 0 while reporting the orphan. The real prune plus a file-count check is what turns the removal into a failure.

Root-only files, no template source touched, so no restamp is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952587&installation_model_id=432661&pr_number=212&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F212&signature=6e986f13c8607d455b91b5497d3c8597e85fdf309a9965f1882460739740ad1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->