### PR TITLE
fix(ci): the drift check's recopy never waits on a prompt

### DIFF
--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -58,9 +58,13 @@ jobs:
 
           # Seeded (_skip_if_exists) files already exist, so recopy
           # leaves them alone — they stay exempt structurally.
+          # --overwrite: recopy prompts "Overwrite CLAUDE.md?" wherever
+          # that file carries the local Learnings it invites, and a
+          # runner has no terminal to answer — the restore below is
+          # what keeps that content exempt, not the prompt.
           uvx --with copier-template-extensions copier recopy \
             --answers-file "$answers_file" \
-            --defaults --trust --skip-tasks --vcs-ref "$stamped"
+            --defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"
 
           # The recopy re-delivers every shared glossary term, including
           # the ones this repo's stamp pruned as unlinked (#67). Prune

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -57,11 +57,12 @@ jobs:
           stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
 
           # Seeded (_skip_if_exists) files already exist, so recopy
-          # leaves them alone — they stay exempt structurally.
-          # --overwrite: recopy prompts "Overwrite CLAUDE.md?" wherever
-          # that file carries the local Learnings it invites, and a
-          # runner has no terminal to answer — the restore below is
-          # what keeps that content exempt, not the prompt.
+          # leaves them alone — they stay exempt structurally. Every
+          # other stamped file, CLAUDE.md included, is template-owned
+          # and must not drift in any repo (#199): --overwrite lets a
+          # runner with no terminal past copier's "Overwrite?" prompt
+          # so the diff below judges the drift instead of the job
+          # dying before it — fail loudly, never exempt silently.
           uvx --with copier-template-extensions copier recopy \
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"
@@ -71,13 +72,6 @@ jobs:
           # again, with the same script the update ran, so the diff
           # judges the converged state, not the raw render (#203).
           bash scripts/ci/prune_glossary.sh || true
-
-          # CLAUDE.md invites local Learnings ("new non-obvious
-          # findings go in this file") and copier update three-way
-          # merges them, so local content there is sanctioned, not
-          # drift. Restore it after the recopy: the diff judges only
-          # files that are pristine-by-contract.
-          git checkout -- CLAUDE.md
 
           if [ -n "$(git status --porcelain)" ]; then
             git status --porcelain

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -967,13 +967,14 @@ def test_root_stamp_carries_the_payload_scan_workflow():
 # ------------------------------------------------------- template drift
 
 
-def test_drift_recopy_never_prompts():
+def test_drift_check_fails_loudly_on_claude_md_drift():
     """Measured on pandoscope/disambiguate#82: `copier recopy` asks
-    "Overwrite CLAUDE.md? (Y/n)" wherever CLAUDE.md carries the local
-    Learnings it invites, and a non-interactive runner dies there
-    before the diff — the drift check goes red on the sanctioned
-    content it exists to exempt. --overwrite answers the prompt; the
-    CLAUDE.md restore right after keeps the exemption (#199)."""
+    "Overwrite CLAUDE.md? (Y/n)" wherever that file diverged, and a
+    non-interactive runner dies there before the diff — the drift
+    check never reached its verdict. --overwrite gets past the prompt;
+    the verdict then covers CLAUDE.md like every other stamped file.
+    Ruled on #213: CLAUDE.md must not drift in any repo, so no restore
+    exempts it (#199)."""
     text = (
         ROOT
         / "template"
@@ -981,5 +982,6 @@ def test_drift_recopy_never_prompts():
         / "workflows"
         / "lint.yml.jinja"
     ).read_text()
-    recopy = text[text.index("copier recopy") : text.index("git checkout -- CLAUDE.md")]
+    recopy = text[text.index("copier recopy") : text.index("git status --porcelain")]
     assert "--overwrite" in recopy
+    assert "git checkout -- CLAUDE.md" not in text

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -962,3 +962,24 @@ def test_root_stamp_carries_the_payload_scan_workflow():
     text = (ROOT / ".github" / "workflows" / "payload-scan.yml").read_text()
     assert "{%" not in text
     assert "runs-on: ubuntu-latest" in text
+
+
+# ------------------------------------------------------- template drift
+
+
+def test_drift_recopy_never_prompts():
+    """Measured on pandoscope/disambiguate#82: `copier recopy` asks
+    "Overwrite CLAUDE.md? (Y/n)" wherever CLAUDE.md carries the local
+    Learnings it invites, and a non-interactive runner dies there
+    before the diff — the drift check goes red on the sanctioned
+    content it exists to exempt. --overwrite answers the prompt; the
+    CLAUDE.md restore right after keeps the exemption (#199)."""
+    text = (
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "lint.yml.jinja"
+    ).read_text()
+    recopy = text[text.index("copier recopy") : text.index("git checkout -- CLAUDE.md")]
+    assert "--overwrite" in recopy

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -542,7 +542,9 @@ def test_lint_workflow_guards_vendored_template_drift(
     template-update weekly audit covers. Rendered even without prek,
     like the conflict-marker job: both guard the template contract. The
     template repo itself carries no answers file, so the job skips
-    cleanly there.
+    cleanly there. CLAUDE.md is judged like every other stamped file
+    (#213 ruling: fail loudly, never exempt silently); --overwrite only
+    gets a terminal-less runner past copier's prompt to that verdict.
     """
     for precommit in ("prek", "none"):
         answers = {**base_answers, "agentic_precommit": precommit}
@@ -552,7 +554,7 @@ def test_lint_workflow_guards_vendored_template_drift(
             dst_path / ".github" / "workflows" / "lint.yml",
             [
                 "copier recopy",
-                '--defaults --trust --skip-tasks --vcs-ref "$stamped"',
+                '--defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"',
                 "copier-template-extensions",
                 # Recopy resurrects the terms the stamp pruned; the drift
                 # job prunes again so a converged glossary is not drift
@@ -560,11 +562,6 @@ def test_lint_workflow_guards_vendored_template_drift(
                 "bash scripts/ci/prune_glossary.sh || true",
                 "awk '$1 == \"_commit:\" {print $2}'",
                 "not a stamped repo",
-                # CLAUDE.md invites local Learnings and copier update
-                # three-way-merges them — the drift job must restore
-                # it after recopy, or every Learnings-bearing repo
-                # goes permanently red.
-                "git checkout -- CLAUDE.md",
                 "git status --porcelain",
                 "template-owned",
             ],


### PR DESCRIPTION
ADVANCES #199.

Measured on pandoscope/disambiguate#82 ([job](https://github.com/pandoscope/disambiguate/actions/runs/33652347782/job/100322253112)): the stamped lint workflow's "vendored files match the stamped template" job runs `copier recopy`, which asks `Overwrite CLAUDE.md? (Y/n)` wherever CLAUDE.md diverged — and a runner has no terminal, so the job dies with "Interactive session required: Consider using `--overwrite`" before the diff ever runs. The check never reached its verdict.

`--overwrite` gets past the prompt so the diff runs. Per the review ruling, CLAUDE.md is judged like every other stamped file — no restore exempts it; a repo whose CLAUDE.md drifted goes red, loudly. (The earlier exemption in this workflow and the "Learnings go in this file" invitation in the stamped CLAUDE.md contradict that ruling; the invitation is #199's consolidation work.) Red-first test in `tests/test_ci_gate.py`. The root repo carries no `lint.yml`, so no restamp commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa