### PR TITLE
fix(ci): the drift check blanks installer-owned skills-lock.json hashes

### DIFF
--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -58,9 +58,13 @@ jobs:
 
           # Seeded (_skip_if_exists) files already exist, so recopy
           # leaves them alone — they stay exempt structurally.
+          # --overwrite: recopy prompts "Overwrite CLAUDE.md?" wherever
+          # that file carries the local Learnings it invites, and a
+          # runner has no terminal to answer — the restore below is
+          # what keeps that content exempt, not the prompt.
           uvx --with copier-template-extensions copier recopy \
             --answers-file "$answers_file" \
-            --defaults --trust --skip-tasks --vcs-ref "$stamped"
+            --defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"
 
           # The recopy re-delivers every shared glossary term, including
           # the ones this repo's stamp pruned as unlinked (#67). Prune

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -57,11 +57,12 @@ jobs:
           stamped="$(awk '$1 == "_commit:" {print $2}' "$answers_file")"
 
           # Seeded (_skip_if_exists) files already exist, so recopy
-          # leaves them alone — they stay exempt structurally.
-          # --overwrite: recopy prompts "Overwrite CLAUDE.md?" wherever
-          # that file carries the local Learnings it invites, and a
-          # runner has no terminal to answer — the restore below is
-          # what keeps that content exempt, not the prompt.
+          # leaves them alone — they stay exempt structurally. Every
+          # other stamped file, CLAUDE.md included, is template-owned
+          # and must not drift in any repo (#199): --overwrite lets a
+          # runner with no terminal past copier's "Overwrite?" prompt
+          # so the diff below judges the drift instead of the job
+          # dying before it — fail loudly, never exempt silently.
           uvx --with copier-template-extensions copier recopy \
             --answers-file "$answers_file" \
             --defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"
@@ -71,13 +72,6 @@ jobs:
           # again, with the same script the update ran, so the diff
           # judges the converged state, not the raw render (#203).
           bash scripts/ci/prune_glossary.sh || true
-
-          # CLAUDE.md invites local Learnings ("new non-obvious
-          # findings go in this file") and copier update three-way
-          # merges them, so local content there is sanctioned, not
-          # drift. Restore it after the recopy: the diff judges only
-          # files that are pristine-by-contract.
-          git checkout -- CLAUDE.md
 
           if [ -n "$(git status --porcelain)" ]; then
             git status --porcelain

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -73,6 +73,18 @@ jobs:
           # judges the converged state, not the raw render (#203).
           bash scripts/ci/prune_glossary.sh || true
 
+          # skills-lock.json: the post-render skill installer recomputes
+          # every computedHash from the installed files, so the stamped
+          # hashes are stale by construction (#214). Judge the lock with
+          # that one installer-owned field blanked — a differing skill
+          # set, source or path still fails loudly below.
+          if [ -f skills-lock.json ] && git cat-file -e HEAD:skills-lock.json 2>/dev/null; then
+            strip='walk(if type == "object" and has("computedHash") then .computedHash = "" else . end)'
+            if [ "$(git show HEAD:skills-lock.json | jq -S "$strip")" = "$(jq -S "$strip" skills-lock.json)" ]; then
+              git checkout -- skills-lock.json
+            fi
+          fi
+
           if [ -n "$(git status --porcelain)" ]; then
             git status --porcelain
             git diff

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -967,13 +967,14 @@ def test_root_stamp_carries_the_payload_scan_workflow():
 # ------------------------------------------------------- template drift
 
 
-def test_drift_recopy_never_prompts():
+def test_drift_check_fails_loudly_on_claude_md_drift():
     """Measured on pandoscope/disambiguate#82: `copier recopy` asks
-    "Overwrite CLAUDE.md? (Y/n)" wherever CLAUDE.md carries the local
-    Learnings it invites, and a non-interactive runner dies there
-    before the diff — the drift check goes red on the sanctioned
-    content it exists to exempt. --overwrite answers the prompt; the
-    CLAUDE.md restore right after keeps the exemption (#199)."""
+    "Overwrite CLAUDE.md? (Y/n)" wherever that file diverged, and a
+    non-interactive runner dies there before the diff — the drift
+    check never reached its verdict. --overwrite gets past the prompt;
+    the verdict then covers CLAUDE.md like every other stamped file.
+    Ruled on #213: CLAUDE.md must not drift in any repo, so no restore
+    exempts it (#199)."""
     text = (
         ROOT
         / "template"
@@ -981,5 +982,6 @@ def test_drift_recopy_never_prompts():
         / "workflows"
         / "lint.yml.jinja"
     ).read_text()
-    recopy = text[text.index("copier recopy") : text.index("git checkout -- CLAUDE.md")]
+    recopy = text[text.index("copier recopy") : text.index("git status --porcelain")]
     assert "--overwrite" in recopy
+    assert "git checkout -- CLAUDE.md" not in text

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -962,3 +962,24 @@ def test_root_stamp_carries_the_payload_scan_workflow():
     text = (ROOT / ".github" / "workflows" / "payload-scan.yml").read_text()
     assert "{%" not in text
     assert "runs-on: ubuntu-latest" in text
+
+
+# ------------------------------------------------------- template drift
+
+
+def test_drift_recopy_never_prompts():
+    """Measured on pandoscope/disambiguate#82: `copier recopy` asks
+    "Overwrite CLAUDE.md? (Y/n)" wherever CLAUDE.md carries the local
+    Learnings it invites, and a non-interactive runner dies there
+    before the diff — the drift check goes red on the sanctioned
+    content it exists to exempt. --overwrite answers the prompt; the
+    CLAUDE.md restore right after keeps the exemption (#199)."""
+    text = (
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "lint.yml.jinja"
+    ).read_text()
+    recopy = text[text.index("copier recopy") : text.index("git checkout -- CLAUDE.md")]
+    assert "--overwrite" in recopy

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -985,3 +985,22 @@ def test_drift_check_fails_loudly_on_claude_md_drift():
     recopy = text[text.index("copier recopy") : text.index("git status --porcelain")]
     assert "--overwrite" in recopy
     assert "git checkout -- CLAUDE.md" not in text
+
+
+def test_drift_check_blanks_installer_owned_lock_hashes():
+    """Measured on pandoscope/disambiguate#82 (#214): the post-render
+    skill installer recomputes every computedHash in skills-lock.json,
+    so the stamped hashes are stale by construction in every consumer.
+    The verdict compares the lock with those fields blanked — skill
+    set, sources and paths still fail loudly; the one installer-owned
+    field does not."""
+    text = (
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "lint.yml.jinja"
+    ).read_text()
+    step = text[text.index("copier recopy") : text.index("git status --porcelain")]
+    assert "computedHash" in step
+    assert "skills-lock.json" in step

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -542,7 +542,9 @@ def test_lint_workflow_guards_vendored_template_drift(
     template-update weekly audit covers. Rendered even without prek,
     like the conflict-marker job: both guard the template contract. The
     template repo itself carries no answers file, so the job skips
-    cleanly there.
+    cleanly there. CLAUDE.md is judged like every other stamped file
+    (#213 ruling: fail loudly, never exempt silently); --overwrite only
+    gets a terminal-less runner past copier's prompt to that verdict.
     """
     for precommit in ("prek", "none"):
         answers = {**base_answers, "agentic_precommit": precommit}
@@ -552,7 +554,7 @@ def test_lint_workflow_guards_vendored_template_drift(
             dst_path / ".github" / "workflows" / "lint.yml",
             [
                 "copier recopy",
-                '--defaults --trust --skip-tasks --vcs-ref "$stamped"',
+                '--defaults --trust --skip-tasks --overwrite --vcs-ref "$stamped"',
                 "copier-template-extensions",
                 # Recopy resurrects the terms the stamp pruned; the drift
                 # job prunes again so a converged glossary is not drift
@@ -560,11 +562,6 @@ def test_lint_workflow_guards_vendored_template_drift(
                 "bash scripts/ci/prune_glossary.sh || true",
                 "awk '$1 == \"_commit:\" {print $2}'",
                 "not a stamped repo",
-                # CLAUDE.md invites local Learnings and copier update
-                # three-way-merges them — the drift job must restore
-                # it after recopy, or every Learnings-bearing repo
-                # goes permanently red.
-                "git checkout -- CLAUDE.md",
                 "git status --porcelain",
                 "template-owned",
             ],


### PR DESCRIPTION
CLOSES #214. Stacked on #213 (its commits show here until it merges).

Third measurement on pandoscope/disambiguate#82 after CLAUDE.md and AGENTS.md were restored to their renders: the drift job prompts `Overwrite skills-lock.json?`, and with #213's `--overwrite` it would fail the diff — on every consumer. The only difference is every `computedHash`: the template stamps release-time hashes, and the post-render task `npx skills@latest experimental_install` recomputes them from the installed files. Stale by construction; nothing a consumer did.

The verdict now compares `skills-lock.json` with `computedHash` blanked on both sides (`jq walk`, sorted keys). If skill set, sources and paths match, the file is restored and drops out of the diff; if any of those differ, the recopied file stays in and the job fails loudly as before. No exemption of the file, only of the one installer-owned field. Red-first test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790965033&installation_model_id=432661&pr_number=215&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F215&signature=85f0a0cf1badad3d78f5513cf42d774a32feed872157b1135dbee93c0cc4f06d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->