### PR TITLE
fix(template): three stamped files every consumer's own hooks rewrote

### DIFF
--- a/docs/glossary/.markdownlint-cli2.yaml
+++ b/docs/glossary/.markdownlint-cli2.yaml
@@ -1,4 +1,11 @@
 # Glossary entries start with `##` per the Disambiguate definition,
 # so the first-line-h1 rule does not apply here.
+#
+# MD049 (consistent emphasis style) resolves to asterisk in any term file
+# that also emphasizes prose, which collides with the literal `_Avoid_:`
+# prefix the avoided-term grammar requires. The prefix is a token of the
+# glossary format, not emphasis the author chose, so the rule is off here
+# rather than the grammar bent to suit it.
 config:
   MD041: false
+  MD049: false

--- a/docs/glossary/pandoscope-template.md
+++ b/docs/glossary/pandoscope-template.md
@@ -6,8 +6,6 @@
      auto-prune marker above lets `disambiguate prune` remove this term
      from a repo that never links it. -->
 
-<!-- the repo seed term is outside the shared set -->
-<!-- d10e: ignore[unlinked-term] agentic-engineering-template -->
 The agentic-engineering-template repo — the integrator every project is
 generated from. It [stamps](template-stamp.md) the per-project integration layer and
 carries learned conventions into every stamped repo via `copier update`.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -206,4 +206,3 @@ fi
 echo
 echo "Re-checking..."
 exec "$0"
-

--- a/template/docs/glossary/.markdownlint-cli2.yaml
+++ b/template/docs/glossary/.markdownlint-cli2.yaml
@@ -1,4 +1,11 @@
 # Glossary entries start with `##` per the Disambiguate definition,
 # so the first-line-h1 rule does not apply here.
+#
+# MD049 (consistent emphasis style) resolves to asterisk in any term file
+# that also emphasizes prose, which collides with the literal `_Avoid_:`
+# prefix the avoided-term grammar requires. The prefix is a token of the
+# glossary format, not emphasis the author chose, so the rule is off here
+# rather than the grammar bent to suit it.
 config:
   MD041: false
+  MD049: false

--- a/template/docs/glossary/pandoscope-template.md
+++ b/template/docs/glossary/pandoscope-template.md
@@ -6,8 +6,6 @@
      auto-prune marker above lets `disambiguate prune` remove this term
      from a repo that never links it. -->
 
-<!-- the repo seed term is outside the shared set -->
-<!-- d10e: ignore[unlinked-term] agentic-engineering-template -->
 The agentic-engineering-template repo — the integrator every project is
 generated from. It [stamps](template-stamp.md) the per-project integration layer and
 carries learned conventions into every stamped repo via `copier update`.

--- a/template/scripts/doctor.sh.jinja
+++ b/template/scripts/doctor.sh.jinja
@@ -214,4 +214,4 @@ fi
 echo
 echo "Re-checking..."
 exec "$0"
-{% endraw %}
+{%- endraw %}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -321,3 +321,28 @@ def test_e2e_smoke_full_render_runs_tasks(
     assert (dst_path / ".agents" / "skills").is_dir(), (
         "post-render skills install must populate .agents/skills/"
     )
+
+
+def test_stamped_files_survive_a_consumers_own_hooks_unchanged(tmp_path, base_answers):
+    """Measured on pandoscope/disambiguate#82 (#216): the drift check
+    flagged three template-side defects every consumer trips on —
+    doctor.sh rendering with a doubled final newline (end-of-file-fixer
+    trims it), the glossary markdownlint config lacking MD049 off (the
+    avoided-term grammar's literal `_Avoid_:` prefix collides with it),
+    and a stale suppression in pandoscope-template.md."""
+    dst_path = tmp_path / "stamp-hooks"
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=base_answers,
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        vcs_ref="HEAD",
+    )
+    doctor = (dst_path / "scripts" / "doctor.sh").read_bytes()
+    assert doctor.endswith(b"\n") and not doctor.endswith(b"\n\n")
+    lint = (dst_path / "docs" / "glossary" / ".markdownlint-cli2.yaml").read_text()
+    assert "MD049: false" in lint
+    term = (dst_path / "docs" / "glossary" / "pandoscope-template.md").read_text()
+    assert "ignore[unlinked-term]" not in term


### PR DESCRIPTION
ADVANCES #216. ADVANCES #198.

With #213 and #215 released, the vendored-drift job reached its verdict on pandoscope/disambiguate#82 for the first time ([job](https://github.com/pandoscope/disambiguate/actions/runs/33667024053/job/100371186716)). Of its seven findings, three are template-side defects every consumer trips on, fixed here:

- `scripts/doctor.sh` rendered with a doubled final newline (`{% raw %}{% endraw %}{% endraw %}` on its own line); every consumer's end-of-file-fixer trims it. Now `{% raw %}{%- endraw %}{% endraw %}`.
- `docs/glossary/.markdownlint-cli2.yaml` lacked `MD049: false`: the avoided-term grammar's literal `_Avoid_:` prefix collides with the emphasis-style rule, so consumers turned it off by hand. Rationale carried in the file.
- `docs/glossary/pandoscope-template.md` carried `ignore[unlinked-term] agentic-engineering-template`, a stale suppression in every consumer where that name is not a term (#198).

Red-first test in `tests/test_e2e.py`; two-commit template-first shape. The remaining findings are #216's design question (files the template stamps but repos own) and one consumer-side config-scoped suppression already on disambiguate#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790965817&installation_model_id=432661&pr_number=217&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F217&signature=a4d506de41fe93c2c99c44f339514326d115ee9f2af9945485da8a8bff484bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->