### PR TITLE
feat(prek): a working branch refuses a merge commit at merge, commit and push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills"
 default_stages: [pre-commit]
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-merge-commit, pre-push]
 
 ci:
   autofix_commit_msg: "chore(pre-commit.ci): auto fixes"
@@ -17,6 +17,28 @@ repos:
         language: script
         pass_filenames: false
         always_run: true
+      # Linear history (skills#147), mirrored from the template's config:
+      # a claude/* branch is rebased onto main, never merged into.
+      - id: linear-history-merge
+        name: no merge commit on a working branch (merge)
+        entry: scripts/check-linear-history.sh --merge
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-merge-commit]
+      - id: linear-history-commit
+        name: no merge commit on a working branch (commit)
+        entry: scripts/check-linear-history.sh --commit
+        language: script
+        pass_filenames: false
+        always_run: true
+      - id: linear-history
+        name: no merge commit on a working branch (push)
+        entry: scripts/check-linear-history.sh --push
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
       # The self-application route, checked where the information still
       # exists (#130). A root file with a `template/` counterpart is
       # render output, so a commit edits the source or the stamp, never

--- a/scripts/check-linear-history.sh
+++ b/scripts/check-linear-history.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Linear history (skills#147): a claude/* branch is updated by rebase
+# onto the default branch, never by merging anything into it. The
+# only legitimate merge commits are the ones the forge makes when it
+# merges a PR. Measured 2026-08-16: main merged INTO a working branch
+# dragged 45 upstream commits into its rebase range, and the repair
+# took four steps.
+#
+# One script, three prek stages, one mode flag each:
+#   --merge   pre-merge-commit: `git merge` is about to commit a merge
+#             on the current branch. Refused on claude/*. git leaves
+#             the merge staged (MERGE_HEAD) when the hook says no, so
+#             the advice starts with the abort.
+#   --commit  pre-commit: a conflicted merge is being finished with
+#             `git commit`, which the merge stage never sees. Refused
+#             on claude/* when MERGE_HEAD exists.
+#   --push    pre-push: the backstop for a merge that got past both
+#             (--no-verify). The pushed ref's own range — merges
+#             reachable from the tip and not from the default branch
+#             — must be empty; a merge main already holds is the
+#             forge's and passes. Refs come from prek's environment
+#             (PRE_COMMIT_LOCAL_BRANCH, PRE_COMMIT_TO_REF); run by
+#             hand, HEAD stands in.
+# Non-agent branches carry no constraint.
+set -euo pipefail
+
+mode="${1:-}"
+case "$mode" in
+    --merge|--commit|--push) ;;
+    *) echo "usage: $0 --merge | --commit | --push" >&2; exit 2 ;;
+esac
+
+default="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+if [ -z "$default" ] && git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    default=origin/main
+fi
+: "${default:=origin/main}"
+
+refuse() {
+    printf '\n⚠️  **LINEAR HISTORY: A WORKING BRANCH IS REBASED, NEVER MERGED INTO**  ⚠️\n\n' >&2
+    printf '%s\n' "$@" >&2
+    printf '\n' >&2
+    exit 1
+}
+
+if [ "$mode" = --push ]; then
+    ref="${PRE_COMMIT_LOCAL_BRANCH:-$(git symbolic-ref -q HEAD 2>/dev/null || true)}"
+    tip="${PRE_COMMIT_TO_REF:-HEAD}"
+    case "$ref" in
+        refs/heads/claude/*) branch="${ref#refs/heads/}" ;;
+        *) exit 0 ;;
+    esac
+    # Nothing to judge against: without the default branch on the
+    # remote the forge's merges and a session's look alike.
+    git rev-parse --verify --quiet "$default" >/dev/null 2>&1 || exit 0
+    merges="$(git rev-list --merges "$tip" --not "$default")"
+    [ -n "$merges" ] || exit 0
+    first="$(printf '%s\n' "$merges" | tail -n 1)"
+    count="$(printf '%s\n' "$merges" | grep -c .)"
+    refuse \
+        "    $branch carries $count merge commit(s) $default does not hold, the first being" \
+        "      $(git log -1 --format='%h %s' "$first")" \
+        "    A working branch is rebased onto $default, never merged into (skills#147);" \
+        "    the only merge commits are the forge's own. The push is refused until" \
+        "    the history is linear again:" \
+        "" \
+        "      git rebase $default"
+fi
+
+branch="$(git symbolic-ref -q --short HEAD 2>/dev/null || true)"
+case "$branch" in
+    claude/*) ;;
+    *) exit 0 ;;
+esac
+if [ "$mode" = --commit ]; then
+    git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1 || exit 0
+fi
+refuse \
+    "    $branch is a working branch, and a merge commit on it is illegal: the only" \
+    "    merge commits are the ones the forge makes when it merges a PR (skills#147)." \
+    "    The merge is staged but not committed; undo it and take the upstream work" \
+    "    by rebase:" \
+    "" \
+    "      git merge --abort && git rebase $default"

--- a/template/scripts/check-linear-history.sh
+++ b/template/scripts/check-linear-history.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Linear history (skills#147): a claude/* branch is updated by rebase
+# onto the default branch, never by merging anything into it. The
+# only legitimate merge commits are the ones the forge makes when it
+# merges a PR. Measured 2026-08-16: main merged INTO a working branch
+# dragged 45 upstream commits into its rebase range, and the repair
+# took four steps.
+#
+# One script, three prek stages, one mode flag each:
+#   --merge   pre-merge-commit: `git merge` is about to commit a merge
+#             on the current branch. Refused on claude/*. git leaves
+#             the merge staged (MERGE_HEAD) when the hook says no, so
+#             the advice starts with the abort.
+#   --commit  pre-commit: a conflicted merge is being finished with
+#             `git commit`, which the merge stage never sees. Refused
+#             on claude/* when MERGE_HEAD exists.
+#   --push    pre-push: the backstop for a merge that got past both
+#             (--no-verify). The pushed ref's own range — merges
+#             reachable from the tip and not from the default branch
+#             — must be empty; a merge main already holds is the
+#             forge's and passes. Refs come from prek's environment
+#             (PRE_COMMIT_LOCAL_BRANCH, PRE_COMMIT_TO_REF); run by
+#             hand, HEAD stands in.
+# Non-agent branches carry no constraint.
+set -euo pipefail
+
+mode="${1:-}"
+case "$mode" in
+    --merge|--commit|--push) ;;
+    *) echo "usage: $0 --merge | --commit | --push" >&2; exit 2 ;;
+esac
+
+default="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+if [ -z "$default" ] && git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    default=origin/main
+fi
+: "${default:=origin/main}"
+
+refuse() {
+    printf '\n⚠️  **LINEAR HISTORY: A WORKING BRANCH IS REBASED, NEVER MERGED INTO**  ⚠️\n\n' >&2
+    printf '%s\n' "$@" >&2
+    printf '\n' >&2
+    exit 1
+}
+
+if [ "$mode" = --push ]; then
+    ref="${PRE_COMMIT_LOCAL_BRANCH:-$(git symbolic-ref -q HEAD 2>/dev/null || true)}"
+    tip="${PRE_COMMIT_TO_REF:-HEAD}"
+    case "$ref" in
+        refs/heads/claude/*) branch="${ref#refs/heads/}" ;;
+        *) exit 0 ;;
+    esac
+    # Nothing to judge against: without the default branch on the
+    # remote the forge's merges and a session's look alike.
+    git rev-parse --verify --quiet "$default" >/dev/null 2>&1 || exit 0
+    merges="$(git rev-list --merges "$tip" --not "$default")"
+    [ -n "$merges" ] || exit 0
+    first="$(printf '%s\n' "$merges" | tail -n 1)"
+    count="$(printf '%s\n' "$merges" | grep -c .)"
+    refuse \
+        "    $branch carries $count merge commit(s) $default does not hold, the first being" \
+        "      $(git log -1 --format='%h %s' "$first")" \
+        "    A working branch is rebased onto $default, never merged into (skills#147);" \
+        "    the only merge commits are the forge's own. The push is refused until" \
+        "    the history is linear again:" \
+        "" \
+        "      git rebase $default"
+fi
+
+branch="$(git symbolic-ref -q --short HEAD 2>/dev/null || true)"
+case "$branch" in
+    claude/*) ;;
+    *) exit 0 ;;
+esac
+if [ "$mode" = --commit ]; then
+    git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1 || exit 0
+fi
+refuse \
+    "    $branch is a working branch, and a merge commit on it is illegal: the only" \
+    "    merge commits are the ones the forge makes when it merges a PR (skills#147)." \
+    "    The merge is staged but not committed; undo it and take the upstream work" \
+    "    by rebase:" \
+    "" \
+    "      git merge --abort && git rebase $default"

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -116,6 +116,28 @@ jobs:
         run: |
           npm install --no-save --no-audit --no-fund @commitlint/cli@19 @commitlint/config-conventional@19
           npx --no-install commitlint --config commitlint.config.mjs --from {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %} --to {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+
+  # Linear history (skills#147): a working branch is rebased onto
+  # main, never merged into. The commit hooks refuse the merge locally;
+  # this is the layer a --no-verify or a hookless clone cannot skip.
+  # Judged on the PR's own range, so the forge's merges on main are
+  # never in it.
+  linear-history:
+    name: "linear history (PR commits)"
+    if: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
+    runs-on: {{ agentic_actions_runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: No merge commit in the PR's range
+        run: |
+          merges="$(git rev-list --merges {% raw %}${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}{% endraw %})"
+          [ -z "$merges" ] && { echo "The PR's range is linear."; exit 0; }
+          git log --no-walk --format='%h %s' $merges
+          echo "::error::The PR carries merge commit(s). A working branch is rebased onto main, never merged into (skills#147): git rebase origin/main, then push with --force-with-lease."
+          exit 1
 {%- if agentic_precommit == 'prek' %}
 
   prek:

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -7,7 +7,7 @@
 # otherwise fail on code it cannot change.
 exclude: "CHANGELOG.md|.copier-answers.agentic.yml|.all-contributorsrc|\\.agents/skills|\\.claude/skills|scripts/ci/"
 default_stages: [pre-commit]
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-merge-commit, pre-push]
 
 ci:
   autofix_commit_msg: "chore(pre-commit.ci): auto fixes"
@@ -90,6 +90,33 @@ repos:
         language: script
         pass_filenames: false
         always_run: true
+      # Linear history (skills#147): a claude/* branch is rebased onto
+      # main, never merged into; the forge's own merges are the only
+      # merge commits. One script, three stages: the merge is refused
+      # as `git merge` would commit it, a conflicted merge finished by
+      # hand is refused at commit time, and the push is the backstop
+      # for one that got past both — judged on the branch's own range,
+      # so a merge main already holds passes.
+      - id: linear-history-merge
+        name: no merge commit on a working branch (merge)
+        entry: scripts/check-linear-history.sh --merge
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-merge-commit]
+      - id: linear-history-commit
+        name: no merge commit on a working branch (commit)
+        entry: scripts/check-linear-history.sh --commit
+        language: script
+        pass_filenames: false
+        always_run: true
+      - id: linear-history
+        name: no merge commit on a working branch (push)
+        entry: scripts/check-linear-history.sh --push
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
       - id: disambiguate-lint
         name: disambiguate --lint
         entry: uvx disambiguate=={{ agentic_disambiguate_version }} --lint{% if agentic_disambiguate_roots %} {{ agentic_disambiguate_roots }}{% endif %}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -51,6 +51,7 @@ COMMON_FILES = frozenset(
         "docs/glossary/template-stamp.md",
         "docs/glossary/pandoscope-template.md",
         "scripts/check-branch-name.sh",
+        "scripts/check-linear-history.sh",
         "scripts/enable-agent-shims.sh",
         "skills-lock.json",
         # The uniform gate's judge (#137) renders on every forge; only

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -659,6 +660,149 @@ def test_branch_name_hook_guards_the_pattern(
 
     assert run_on("chore/template-update-v9").returncode == 0
     assert run_on("claude/anything", keywords=False).returncode == 0
+
+
+def test_linear_history_hooks_refuse_a_merge_into_a_working_branch(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """A claude/* branch is rebased onto main, never merged into
+    (skills#147): the only merge commits are the forge's own. Three
+    prek stages share one script — the merge is refused as `git merge`
+    would commit it, a conflicted merge finished with `git commit` is
+    refused at pre-commit, and the push is the backstop for a merge
+    that got past both. A merge commit main already holds passes."""
+    dst_path = _render(tmp_path, base_answers, "linear-history-hooks")
+
+    _check_file_contents(
+        dst_path / ".pre-commit-config.yaml",
+        [
+            "default_install_hook_types: [pre-commit, commit-msg, pre-merge-commit, pre-push]",
+            "id: linear-history",
+            "scripts/check-linear-history.sh",
+            "stages: [pre-merge-commit]",
+            "stages: [pre-push]",
+        ],
+    )
+    _check_file_contents(
+        dst_path / ".github" / "workflows" / "lint.yml",
+        [
+            "linear-history:",
+            'name: "linear history (PR commits)"',
+            "git rev-list --merges",
+        ],
+    )
+    script = dst_path / "scripts" / "check-linear-history.sh"
+    assert script.stat().st_mode & 0o111, "hook script must be executable"
+
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.test",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.test",
+    }
+
+    def git(repo: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        ).stdout.strip()
+
+    def land(repo: Path, branch: str, msg: str) -> None:
+        git(repo, "checkout", "-q", branch)
+        with (repo / f"{branch.replace('/', '-')}.txt").open("a") as fh:
+            fh.write(msg + "\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", msg)
+        git(repo, "push", "-q", "origin", branch)
+
+    def diverged(name: str) -> Path:
+        """A working branch off main, with main advanced past it on origin."""
+        origin = tmp_path / f"{name}.git"
+        subprocess.run(
+            ["git", "init", "-q", "--bare", "-b", "main", origin], check=True
+        )
+        repo = tmp_path / name
+        subprocess.run(
+            ["git", "clone", "-q", str(origin), str(repo)],
+            check=True,
+            capture_output=True,
+        )
+        git(repo, "checkout", "-q", "-b", "main")
+        (repo / "README.md").write_text("seed\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "chore: seed")
+        git(repo, "push", "-q", "-u", "origin", "main")
+        git(repo, "remote", "set-head", "origin", "main")
+        git(repo, "checkout", "-q", "-b", "claude/147-work", "main")
+        land(repo, "claude/147-work", "feat: the work")
+        land(repo, "main", "feat: a merged PR")
+        git(repo, "checkout", "-q", "claude/147-work")
+        git(repo, "fetch", "-q", "origin")
+        return repo
+
+    def check(repo: Path, mode: str, **extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(script), mode],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={**env, **extra},
+        )
+
+    # --merge: the pre-merge-commit stage, on a working branch.
+    repo = diverged("merge")
+    refused = check(repo, "--merge")
+    assert refused.returncode != 0
+    assert "git merge --abort && git rebase origin/main" in refused.stderr
+    git(repo, "checkout", "-q", "main")
+    assert check(repo, "--merge").returncode == 0, "main is not a working branch"
+
+    # --commit: a conflicted merge being finished by hand.
+    repo = diverged("commit")
+    assert check(repo, "--commit").returncode == 0, "an ordinary commit passes"
+    (repo / ".git" / "MERGE_HEAD").write_text(
+        git(repo, "rev-parse", "origin/main") + "\n"
+    )
+    refused = check(repo, "--commit")
+    assert refused.returncode != 0
+    assert "git merge --abort && git rebase origin/main" in refused.stderr
+
+    # --push: the backstop, fed the refs prek hands a pre-push hook.
+    repo = diverged("push")
+    git(repo, "merge", "--no-ff", "origin/main", "-m", "chore: merge main")
+    refs = {
+        "PRE_COMMIT_LOCAL_BRANCH": "refs/heads/claude/147-work",
+        "PRE_COMMIT_TO_REF": git(repo, "rev-parse", "HEAD"),
+    }
+    refused = check(repo, "--push", **refs)
+    assert refused.returncode != 0
+    assert "chore: merge main" in refused.stderr
+    assert "git rebase origin/main" in refused.stderr
+    git(repo, "reset", "-q", "--hard", "HEAD~1")
+    git(repo, "rebase", "-q", "origin/main")
+    refs["PRE_COMMIT_TO_REF"] = git(repo, "rev-parse", "HEAD")
+    assert check(repo, "--push", **refs).returncode == 0, "a linear branch pushes"
+
+    # A forge merge on main is not the branch's: a working branch off
+    # a merged main is linear in its own range.
+    repo = diverged("forge")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "--no-ff", "claude/147-work", "-m", "Merge pull request #1")
+    git(repo, "push", "-q", "origin", "main")
+    git(repo, "checkout", "-q", "-b", "claude/148-next", "main")
+    (repo / "next.txt").write_text("next\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "feat: next")
+    refs = {
+        "PRE_COMMIT_LOCAL_BRANCH": "refs/heads/claude/148-next",
+        "PRE_COMMIT_TO_REF": git(repo, "rev-parse", "HEAD"),
+    }
+    assert check(repo, "--push", **refs).returncode == 0
 
 
 def test_commitlint_config_rejects_fixup_and_squash_commits(


### PR DESCRIPTION
## What

The linear-history rule (skills#147) at template level, next to the naming half that already lives here: a `claude/*` branch is rebased onto main, never merged into, and the only merge commits are the forge's own. Measured 2026-08-16: main merged INTO a working branch dragged 45 upstream commits into its rebase range, and the repair took four steps.

- **`scripts/check-linear-history.sh`**, one script at three prek stages. `--merge` (pre-merge-commit) refuses the commit `git merge` is about to make; git leaves the merge staged when the hook says no, so the advice is `git merge --abort && git rebase origin/main`. `--commit` (pre-commit) refuses a conflicted merge being finished by hand, which the merge stage never sees. `--push` (pre-push) is the backstop for a merge that got past both: the pushed ref's own range (`--merges <tip> --not origin/<default>`) must be empty, so a merge main already holds is the forge's and passes. Refs come from the environment prek hands a pre-push hook.
- **`default_install_hook_types`** gains `pre-merge-commit` and `pre-push`; `ensure-prek` already installs the configured types into every clone at session start, so no new install site exists anywhere.
- **`linear history (PR commits)`** job in the lint workflow: the PR's range may hold no merge commit. This is the layer no `--no-verify` or hookless clone skips.
- **AGENTS.md** names all three under the existing "merge commits only on main" rule.

## Tests

Test-first: the red commit renders the config and workflow and exercises the script on real repos in all three modes (refused on a working branch, passes on main; a conflicted merge refused; a merge in the branch's range refused naming it, a linear branch and a branch off a forge-merged main pass). Then the feature, then the self-apply restamp per docs/conventions.md. `test_generate_project` and `test_e2e` green (50), prek clean.

Supersedes meta!123, which placed the same hooks in meta's environment setup and reached only CCoW clones; skills!178 carries the heartbeat check and the kata.

ADVANCES pandoscope/skills#147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790966452&installation_model_id=432661&pr_number=219&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F219&signature=58fa65e82cfd703deb0606b79b81c7f03018ee8375013e570d88e29a32029b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->