### PR TITLE
feat(template): stamped settings run a repo-owned session-start.local.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,3 +328,5 @@ When something fails that automation or an instruction could have prevented — 
 ## Project Conventions
 
 Repo-specific rules live in [docs/conventions.md](docs/conventions.md). Copier seeds that file once and never overwrites it — put rich local conventions there, not in this template-owned file.
+
+Repo-specific session bootstrap — tools a fresh session needs that the template does not install — lives in `scripts/session-start.local.sh`, seeded the same way. The stamped `.claude/settings.json` runs it after its own SessionStart hooks; that settings file is template-owned and never edited locally.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This template only writes files it is configured to own. It does not silently ta
 | --- | --- |
 | `AGENTS.md`, `CLAUDE.md` | agentic-template |
 | `docs/conventions.md` | **project** — seeded once by agentic-template, never overwritten (`_skip_if_exists`) |
+| `scripts/session-start.local.sh` | **project** — seeded once by agentic-template, never overwritten (`_skip_if_exists`); the stamped `.claude/settings.json` runs it as its last SessionStart hook |
 | `skills-lock.json`, `.agents/skills/`, `.claude/skills` (symlink) | agentic-template |
 | `docs/glossary/`, `docs/architecture.md` | agentic-template |
 | `.editorconfig`, `.codespellrc`, `commitlint.config.mjs` | agentic-template |

--- a/copier.yml
+++ b/copier.yml
@@ -179,6 +179,10 @@ _answers_file: .copier-answers.agentic.yml
 # live there so AGENTS.md updates never conflict with hand-written content.
 _skip_if_exists:
   - "{% if agentic_subtemplate == 'template' %}docs/conventions.md{% endif %}"
+  # The repo's own SessionStart bootstrap (#220): the stamped
+  # .claude/settings.json is template-owned and runs this script last, so a
+  # repo's session tooling lives here instead of drifting the settings file.
+  - "{% if agentic_subtemplate == 'template' %}scripts/session-start.local.sh{% endif %}"
   # The store's preference set (source + render) and its config knobs are
   # seeded once and owned by the store; everything else in the decision-memory
   # subtemplate is vendored (overwritten on copier update). Clobbering any of

--- a/scripts/session-start.local.sh
+++ b/scripts/session-start.local.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Repo-local SessionStart bootstrap.
+#
+# Seeded once by the agentic template and never overwritten by
+# `copier update`. The stamped .claude/settings.json is template-owned
+# and runs this script after its own hooks, so tooling a fresh session
+# needs in THIS repo goes here — never into the settings file.
+#
+# Best-effort and quiet: a failed bootstrap must never block a session.
+set -u

--- a/template/.claude/settings.json.jinja
+++ b/template/.claude/settings.json.jinja
@@ -10,7 +10,11 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/ensure-prek.sh\""
-          }{% endif %}
+          }{% endif %},
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/session-start.local.sh\""
+          }
         ]
       }
     ]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -346,3 +346,5 @@ When something fails that automation or an instruction could have prevented — 
 ## Project Conventions
 
 Repo-specific rules live in [docs/conventions.md](docs/conventions.md). Copier seeds that file once and never overwrites it — put rich local conventions there, not in this template-owned file.
+
+Repo-specific session bootstrap — tools a fresh session needs that the template does not install — lives in `scripts/session-start.local.sh`, seeded the same way. The stamped `.claude/settings.json` runs it after its own SessionStart hooks; that settings file is template-owned and never edited locally.

--- a/template/scripts/session-start.local.sh
+++ b/template/scripts/session-start.local.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Repo-local SessionStart bootstrap.
+#
+# Seeded once by the agentic template and never overwritten by
+# `copier update`. The stamped .claude/settings.json is template-owned
+# and runs this script after its own hooks, so tooling a fresh session
+# needs in THIS repo goes here — never into the settings file.
+#
+# Best-effort and quiet: a failed bootstrap must never block a session.
+set -u

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -32,6 +32,8 @@ COMMON_FILES = frozenset(
         "scripts/agent-shims/gh",
         "scripts/agent-shims/tea",
         "scripts/doctor.sh",
+        # Repo-owned SessionStart bootstrap, seeded once (#220).
+        "scripts/session-start.local.sh",
         # Shared glossary terms, stamped into every generated repo (#52).
         "docs/glossary/decision-memory.md",
         "docs/glossary/reinset.md",

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -369,6 +369,45 @@ def test_conventions_file_seeded_once_and_never_overwritten(
     assert conventions.read_text() == "# Hand-written vault rules\n"
 
 
+def test_local_session_hook_seeded_once_and_wired_last(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """#220: the stamped settings run a repo-owned SessionStart script.
+
+    `.claude/settings.json` is template-owned, so a repo's own session
+    bootstrap cannot live there without failing the drift check. The
+    template seeds `scripts/session-start.local.sh` once, runs it after
+    its own hooks, and never overwrites it.
+    """
+    dst_path = _render(tmp_path, base_answers, "local-session-hook")
+
+    settings = json.loads((dst_path / ".claude" / "settings.json").read_text())
+    commands = [
+        hook["command"]
+        for group in settings["hooks"]["SessionStart"]
+        for hook in group["hooks"]
+    ]
+    assert commands[-1] == 'bash "$CLAUDE_PROJECT_DIR/scripts/session-start.local.sh"'
+
+    local_hook = dst_path / "scripts" / "session-start.local.sh"
+    assert local_hook.stat().st_mode & 0o111, "local hook must be executable"
+    _check_file_contents(local_hook, ["never overwritten", "set -u"])
+
+    local_hook.write_text("#!/usr/bin/env bash\nnpm install -g bats\n")
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=base_answers,
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+    assert local_hook.read_text() == "#!/usr/bin/env bash\nnpm install -g bats\n"
+
+
 def test_language_non_english_omits_codespell(
     tmp_path: Path,
     base_answers: dict[str, str],


### PR DESCRIPTION
CLOSES #220

`.claude/settings.json` is template-owned, so a repo's own SessionStart bootstrap had nowhere to go: any local hook is drift, and the v4.11.2 drift check on skills' template-update PR stays red for as long as skills needs its bats/shellcheck installer.

**Change**

- The stamped `.claude/settings.json` runs `scripts/session-start.local.sh` as its last SessionStart hook, after `enable-agent-shims.sh` and (with prek) `ensure-prek.sh`.
- The template seeds `scripts/session-start.local.sh` once with a no-op body, listed in `_skip_if_exists` like `docs/conventions.md`: repo-owned, never overwritten by `copier update`, structurally exempt from the drift check.
- AGENTS.md (Project Conventions) names the file as the home for repo-local session bootstrap; README's file-ownership table gains the row.
- Test: rendered settings end with the local hook; the seeded script is executable and survives a re-render with local content. The e2e file set carries the new file.
- Root restamped as its own commit (AGENTS.md sentence, seeded script).

**Follow-up in consumers:** move any local SessionStart hook into the seeded script once the release lands; skills' `ensure-test-tools.sh` is the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBsy9XFFuRepNnPNc6VqYb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967010&installation_model_id=432661&pr_number=221&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F221&signature=3371547499ac0f1c99d1afb17f8a7c2726e080c3b66aec2d36bf1d671f5f3c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->