### PR TITLE
feat(template): seed the files a repo must own

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -179,6 +179,17 @@ _answers_file: .copier-answers.agentic.yml
 # live there so AGENTS.md updates never conflict with hand-written content.
 _skip_if_exists:
   - "{% if agentic_subtemplate == 'template' %}docs/conventions.md{% endif %}"
+  # The architecture stub and the project's own glossary term are seeds
+  # too (#216): both start as a one-liner derived from the answers and a
+  # real repo grows the document in place. Stamping them again would
+  # reset that on every update, and the drift check would then judge a
+  # repo for owning its own architecture.
+  - "{% if agentic_subtemplate == 'template' and agentic_project_kind == 'code' %}docs/architecture.md{% endif %}"
+  - "{% if agentic_subtemplate == 'template' %}docs/glossary/{{ agentic_project_slug }}.md{% endif %}"
+  # Repo-owned hooks (language formatters, type checkers) live here; the
+  # stamped .pre-commit-config.yaml delegates to it, so they run on every
+  # commit while the drift check has no template-owned file to judge.
+  - "{% if agentic_subtemplate == 'template' and agentic_precommit == 'prek' %}.pre-commit-config.local.yaml{% endif %}"
   # The store's preference set (source + render) and its config knobs are
   # seeded once and owned by the store; everything else in the decision-memory
   # subtemplate is vendored (overwritten on copier update). Clobbering any of

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.local.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.local.yaml{% endif %}.jinja
@@ -1,0 +1,12 @@
+# Repo-owned hooks — this file belongs to {{ agentic_project_name }}, not
+# to the agentic template.
+#
+# The template seeds it once and never stamps it again, so the vendored
+# drift check never judges it and `copier update` never conflicts with
+# it. Put the hooks that only this repo needs here (language formatters,
+# type checkers, project-specific scripts); the shared hooks stay in
+# `.pre-commit-config.yaml`, which the template owns.
+#
+# The stamped config runs this file through a `repo-hooks` hook, so
+# everything below fires on the same commit as the shared hooks.
+repos: []

--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -117,6 +117,17 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # Repo-owned hooks (#216): a repo's own language hooks live in
+      # `.pre-commit-config.local.yaml`, which the template seeds once
+      # and never stamps again. Delegating keeps them on the same
+      # commit as the shared hooks without giving the repo a reason to
+      # edit this template-owned file — which the vendored drift check
+      # would then flag on every run. No staged files, or no local
+      # config, means nothing to run.
+      - id: repo-hooks
+        name: repo-owned hooks
+        entry: bash -c '[ "$#" -gt 0 ] && [ -f .pre-commit-config.local.yaml ] || exit 0; exec {{ agentic_precommit }} run --config .pre-commit-config.local.yaml --files "$@"' --
+        language: system
       - id: disambiguate-lint
         name: disambiguate --lint
         entry: uvx disambiguate=={{ agentic_disambiguate_version }} --lint{% if agentic_disambiguate_roots %} {{ agentic_disambiguate_roots }}{% endif %}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -106,6 +106,9 @@ EXPECTED_WITH_PREK = (
     | GITHUB_ONLY_FILES
     | {
         ".pre-commit-config.yaml",
+        # Seeded once (#216): a home for the repo's own hooks that the
+        # template never stamps again and the drift check never judges.
+        ".pre-commit-config.local.yaml",
         "scripts/ensure-prek.sh",
     }
 )

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -1243,3 +1243,70 @@ def test_no_question_gate_consults_the_environment() -> None:
         "probe into `default` so the answer is asked, recorded, and "
         "reproducible."
     )
+
+
+def test_architecture_and_project_term_are_seeded_once(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """The architecture stub and the project's own glossary term are
+    seeds, not stamps (#216).
+
+    Both start as one-liners derived from the answers, and a real repo
+    grows the full document in place. Stamping them again would reset
+    that on every `copier update`, and the vendored-drift check would
+    then judge a repo for owning its own architecture.
+    """
+    dst_path = _render(tmp_path, base_answers, "seeded")
+
+    architecture = dst_path / "docs" / "architecture.md"
+    term = dst_path / "docs" / "glossary" / f"{base_answers['agentic_project_slug']}.md"
+    architecture.write_text("# The real architecture\n")
+    term.write_text("## Snake Farm\n\nThe real definition.\n")
+
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=base_answers,
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert architecture.read_text() == "# The real architecture\n"
+    assert term.read_text() == "## Snake Farm\n\nThe real definition.\n"
+
+
+def test_repo_owned_hooks_get_a_seeded_config_of_their_own(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """A repo's language hooks live in a file the template seeds once
+    and never stamps again (#216).
+
+    The stamped config delegates to it, so the hooks still run on every
+    commit, while the vendored-drift check has nothing to judge — the
+    repo never has to edit a template-owned file to lint its own code.
+    """
+    dst_path = _render(tmp_path, base_answers, "repo-hooks")
+
+    local = dst_path / ".pre-commit-config.local.yaml"
+    _check_file_contents(local, ["repos:"])
+    stamped = (dst_path / ".pre-commit-config.yaml").read_text()
+    assert "repo-hooks" in stamped
+    assert ".pre-commit-config.local.yaml" in stamped
+
+    local.write_text("repos:\n  - repo: local\n    hooks: []\n")
+    copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=base_answers,
+        defaults=True,
+        unsafe=True,
+        skip_tasks=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+    assert local.read_text() == "repos:\n  - repo: local\n    hooks: []\n"

--- a/tests/test_self_application.py
+++ b/tests/test_self_application.py
@@ -43,13 +43,13 @@ def _skip_if_exists_paths() -> set[str]:
     paths: set[str] = set()
     for entry in config.get("_skip_if_exists", []):
         # Entries are jinja-guarded per subtemplate, e.g.
-        # "{% if ... %}docs/conventions.md{% endif %}" — keep the literal
-        # text between the tags.
-        for literal in re.findall(r"%\}([^{]+)\{%", entry):
-            if literal.strip():
-                paths.add(literal.strip())
-        if "{%" not in entry and entry.strip():
-            paths.add(entry.strip())
+        # "{% if ... %}docs/conventions.md{% endif %}" — drop the tags and
+        # keep what they guard. An answer interpolation inside the path
+        # ("docs/glossary/{{ agentic_project_slug }}.md") stays verbatim:
+        # only a render resolves it, and the guard leaves it alone too.
+        literal = re.sub(r"\{%.*?%\}", "", entry).strip()
+        if literal:
+            paths.add(literal)
     return paths
 
 


### PR DESCRIPTION
ADVANCES #216

The vendored-drift check reached its first verdict on a real consumer and flagged three files the repo legitimately owns. This makes room for all three.

## What changed

- **`docs/architecture.md` and `docs/glossary/<project_slug>.md` join `_skip_if_exists`.** Both start as a one-liner derived from the answers; a real repo grows the document in place. Stamping them again resets that on every update, and the drift check then judges a repo for owning its own architecture.
- **Repo-owned hooks get `.pre-commit-config.local.yaml`**, seeded once and never stamped again. The stamped config gains a `repo-hooks` hook that delegates to it, so a repo's language hooks (formatters, type checkers) run on the same commit as the shared ones while the drift check has no template-owned file to judge. No staged files, or no local config, means nothing to run.
- The seeded-path readers (the commit-hook guard and its YAML-parsing counterpart in the tests) now keep an answer interpolation inside a seeded path verbatim, since only a render resolves it.

## Tests

Red first, then green: a re-render leaves an edited architecture doc, project term, and local hooks file untouched; the stamped config carries the delegation. The prek frozenset gains the seeded file. Full suite 347 green.

Delegation verified against a real render: a repo-owned canary hook in `.pre-commit-config.local.yaml` ran on the staged file and its failure propagated through `repo-hooks`.

## Acceptance criteria

- [x] `_skip_if_exists` covers `docs/architecture.md` and `docs/glossary/<slug>.md`
- [x] Repo-owned pre-commit hooks have a home the drift check does not judge
- [ ] pandoscope/disambiguate#82's drift job is green on the release that carries this

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967756&installation_model_id=432661&pr_number=224&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F224&signature=b5547b23ec8251d62c64fc41721acdc000676185429f16ccb5103a413b167bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->