### PR TITLE
feat(template): keep a joined update PR's own body

### DIFF
--- a/decision-memory/.github/workflows/template-update.yml.jinja
+++ b/decision-memory/.github/workflows/template-update.yml.jinja
@@ -282,7 +282,22 @@ jobs:
             echo "## Template changelog ($NEW_REF)"
             echo
             echo "$changelog"
-          } > /tmp/pr-body.md
+          } > /tmp/pr-release.md
+
+          # Compose the body. A joined PR keeps its own text — a
+          # hand-opened update PR carries the canonical ticket
+          # reference the gate reads, and rewriting it turned a green
+          # PR red (#218). Only the release section this workflow
+          # wrote before is replaced.
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr view "$EXISTING_PR" --json body --jq .body \
+              > /tmp/pr-existing.md || : > /tmp/pr-existing.md
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md /tmp/pr-existing.md > /tmp/pr-body.md
+          else
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md > /tmp/pr-body.md
+          fi
 
           # The ticket gate's designed escape (#137): a bot-authored PR
           # carrying the `automated` label needs no ticket reference — a
@@ -294,9 +309,10 @@ jobs:
             --description "Bot-authored maintenance PR; the ticket gate's designed escape" \
             || true
 
-          # A joined PR is refreshed in place — title, body and label
-          # brought to the new release — so one PR carries the update
-          # conversation however many releases pass through it.
+          # A joined PR is refreshed in place — title, release notes
+          # and label brought to the new release — so one PR carries
+          # the update conversation however many releases pass through
+          # it, without losing the body it was opened with.
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "chore: update agentic template to $NEW_REF" \

--- a/decision-memory/scripts/ci/template-update-body.sh
+++ b/decision-memory/scripts/ci/template-update-body.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compose the body of a template-update PR (#218).
+#
+# Usage: template-update-body.sh <release-section> [<existing-body>]
+#
+# A fresh PR gets the release section alone. Joining an existing PR —
+# one a human opened and referenced a ticket from — must not throw that
+# body away: the ticket gate reads the body, and a rewrite turns a green
+# PR red. So the existing text is kept verbatim above the release
+# section, and only a release section this script wrote before is
+# replaced, so a PR that survives five releases carries one set of notes
+# rather than five.
+set -euo pipefail
+
+MARKER='<!-- agentic-template-update -->'
+
+release_file="${1:?release section file required}"
+existing_file="${2:-}"
+
+if [ -n "$existing_file" ] && [ -s "$existing_file" ]; then
+  # Everything above the marker is the PR's own body. Without a marker
+  # the whole thing is (the first join on a hand-authored PR).
+  kept="$(awk -v marker="$MARKER" '
+    index($0, marker) { exit }
+    { print }
+  ' "$existing_file")"
+  # Drop trailing blank lines so the seam is one blank line, always.
+  kept="$(printf '%s\n' "$kept" | sed -e :a -e '/^\s*$/{$d;N;ba' -e '}')"
+  if [ -n "$kept" ]; then
+    printf '%s\n\n' "$kept"
+  fi
+fi
+
+printf '%s\n\n' "$MARKER"
+cat "$release_file"

--- a/evidence-memory/.github/workflows/template-update.yml.jinja
+++ b/evidence-memory/.github/workflows/template-update.yml.jinja
@@ -282,7 +282,22 @@ jobs:
             echo "## Template changelog ($NEW_REF)"
             echo
             echo "$changelog"
-          } > /tmp/pr-body.md
+          } > /tmp/pr-release.md
+
+          # Compose the body. A joined PR keeps its own text — a
+          # hand-opened update PR carries the canonical ticket
+          # reference the gate reads, and rewriting it turned a green
+          # PR red (#218). Only the release section this workflow
+          # wrote before is replaced.
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr view "$EXISTING_PR" --json body --jq .body \
+              > /tmp/pr-existing.md || : > /tmp/pr-existing.md
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md /tmp/pr-existing.md > /tmp/pr-body.md
+          else
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md > /tmp/pr-body.md
+          fi
 
           # The ticket gate's designed escape (#137): a bot-authored PR
           # carrying the `automated` label needs no ticket reference — a
@@ -294,9 +309,10 @@ jobs:
             --description "Bot-authored maintenance PR; the ticket gate's designed escape" \
             || true
 
-          # A joined PR is refreshed in place — title, body and label
-          # brought to the new release — so one PR carries the update
-          # conversation however many releases pass through it.
+          # A joined PR is refreshed in place — title, release notes
+          # and label brought to the new release — so one PR carries
+          # the update conversation however many releases pass through
+          # it, without losing the body it was opened with.
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "chore: update agentic template to $NEW_REF" \

--- a/evidence-memory/scripts/ci/template-update-body.sh
+++ b/evidence-memory/scripts/ci/template-update-body.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compose the body of a template-update PR (#218).
+#
+# Usage: template-update-body.sh <release-section> [<existing-body>]
+#
+# A fresh PR gets the release section alone. Joining an existing PR —
+# one a human opened and referenced a ticket from — must not throw that
+# body away: the ticket gate reads the body, and a rewrite turns a green
+# PR red. So the existing text is kept verbatim above the release
+# section, and only a release section this script wrote before is
+# replaced, so a PR that survives five releases carries one set of notes
+# rather than five.
+set -euo pipefail
+
+MARKER='<!-- agentic-template-update -->'
+
+release_file="${1:?release section file required}"
+existing_file="${2:-}"
+
+if [ -n "$existing_file" ] && [ -s "$existing_file" ]; then
+  # Everything above the marker is the PR's own body. Without a marker
+  # the whole thing is (the first join on a hand-authored PR).
+  kept="$(awk -v marker="$MARKER" '
+    index($0, marker) { exit }
+    { print }
+  ' "$existing_file")"
+  # Drop trailing blank lines so the seam is one blank line, always.
+  kept="$(printf '%s\n' "$kept" | sed -e :a -e '/^\s*$/{$d;N;ba' -e '}')"
+  if [ -n "$kept" ]; then
+    printf '%s\n\n' "$kept"
+  fi
+fi
+
+printf '%s\n\n' "$MARKER"
+cat "$release_file"

--- a/scripts/ci/template-update-body.sh
+++ b/scripts/ci/template-update-body.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compose the body of a template-update PR (#218).
+#
+# Usage: template-update-body.sh <release-section> [<existing-body>]
+#
+# A fresh PR gets the release section alone. Joining an existing PR —
+# one a human opened and referenced a ticket from — must not throw that
+# body away: the ticket gate reads the body, and a rewrite turns a green
+# PR red. So the existing text is kept verbatim above the release
+# section, and only a release section this script wrote before is
+# replaced, so a PR that survives five releases carries one set of notes
+# rather than five.
+set -euo pipefail
+
+MARKER='<!-- agentic-template-update -->'
+
+release_file="${1:?release section file required}"
+existing_file="${2:-}"
+
+if [ -n "$existing_file" ] && [ -s "$existing_file" ]; then
+  # Everything above the marker is the PR's own body. Without a marker
+  # the whole thing is (the first join on a hand-authored PR).
+  kept="$(awk -v marker="$MARKER" '
+    index($0, marker) { exit }
+    { print }
+  ' "$existing_file")"
+  # Drop trailing blank lines so the seam is one blank line, always.
+  kept="$(printf '%s\n' "$kept" | sed -e :a -e '/^\s*$/{$d;N;ba' -e '}')"
+  if [ -n "$kept" ]; then
+    printf '%s\n\n' "$kept"
+  fi
+fi
+
+printf '%s\n\n' "$MARKER"
+cat "$release_file"

--- a/session-memory/.github/workflows/template-update.yml.jinja
+++ b/session-memory/.github/workflows/template-update.yml.jinja
@@ -282,7 +282,22 @@ jobs:
             echo "## Template changelog ($NEW_REF)"
             echo
             echo "$changelog"
-          } > /tmp/pr-body.md
+          } > /tmp/pr-release.md
+
+          # Compose the body. A joined PR keeps its own text — a
+          # hand-opened update PR carries the canonical ticket
+          # reference the gate reads, and rewriting it turned a green
+          # PR red (#218). Only the release section this workflow
+          # wrote before is replaced.
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr view "$EXISTING_PR" --json body --jq .body \
+              > /tmp/pr-existing.md || : > /tmp/pr-existing.md
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md /tmp/pr-existing.md > /tmp/pr-body.md
+          else
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md > /tmp/pr-body.md
+          fi
 
           # The ticket gate's designed escape (#137): a bot-authored PR
           # carrying the `automated` label needs no ticket reference — a
@@ -294,9 +309,10 @@ jobs:
             --description "Bot-authored maintenance PR; the ticket gate's designed escape" \
             || true
 
-          # A joined PR is refreshed in place — title, body and label
-          # brought to the new release — so one PR carries the update
-          # conversation however many releases pass through it.
+          # A joined PR is refreshed in place — title, release notes
+          # and label brought to the new release — so one PR carries
+          # the update conversation however many releases pass through
+          # it, without losing the body it was opened with.
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "chore: update agentic template to $NEW_REF" \

--- a/session-memory/scripts/ci/template-update-body.sh
+++ b/session-memory/scripts/ci/template-update-body.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compose the body of a template-update PR (#218).
+#
+# Usage: template-update-body.sh <release-section> [<existing-body>]
+#
+# A fresh PR gets the release section alone. Joining an existing PR —
+# one a human opened and referenced a ticket from — must not throw that
+# body away: the ticket gate reads the body, and a rewrite turns a green
+# PR red. So the existing text is kept verbatim above the release
+# section, and only a release section this script wrote before is
+# replaced, so a PR that survives five releases carries one set of notes
+# rather than five.
+set -euo pipefail
+
+MARKER='<!-- agentic-template-update -->'
+
+release_file="${1:?release section file required}"
+existing_file="${2:-}"
+
+if [ -n "$existing_file" ] && [ -s "$existing_file" ]; then
+  # Everything above the marker is the PR's own body. Without a marker
+  # the whole thing is (the first join on a hand-authored PR).
+  kept="$(awk -v marker="$MARKER" '
+    index($0, marker) { exit }
+    { print }
+  ' "$existing_file")"
+  # Drop trailing blank lines so the seam is one blank line, always.
+  kept="$(printf '%s\n' "$kept" | sed -e :a -e '/^\s*$/{$d;N;ba' -e '}')"
+  if [ -n "$kept" ]; then
+    printf '%s\n\n' "$kept"
+  fi
+fi
+
+printf '%s\n\n' "$MARKER"
+cat "$release_file"

--- a/template/scripts/ci/template-update-body.sh
+++ b/template/scripts/ci/template-update-body.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compose the body of a template-update PR (#218).
+#
+# Usage: template-update-body.sh <release-section> [<existing-body>]
+#
+# A fresh PR gets the release section alone. Joining an existing PR —
+# one a human opened and referenced a ticket from — must not throw that
+# body away: the ticket gate reads the body, and a rewrite turns a green
+# PR red. So the existing text is kept verbatim above the release
+# section, and only a release section this script wrote before is
+# replaced, so a PR that survives five releases carries one set of notes
+# rather than five.
+set -euo pipefail
+
+MARKER='<!-- agentic-template-update -->'
+
+release_file="${1:?release section file required}"
+existing_file="${2:-}"
+
+if [ -n "$existing_file" ] && [ -s "$existing_file" ]; then
+  # Everything above the marker is the PR's own body. Without a marker
+  # the whole thing is (the first join on a hand-authored PR).
+  kept="$(awk -v marker="$MARKER" '
+    index($0, marker) { exit }
+    { print }
+  ' "$existing_file")"
+  # Drop trailing blank lines so the seam is one blank line, always.
+  kept="$(printf '%s\n' "$kept" | sed -e :a -e '/^\s*$/{$d;N;ba' -e '}')"
+  if [ -n "$kept" ]; then
+    printf '%s\n\n' "$kept"
+  fi
+fi
+
+printf '%s\n\n' "$MARKER"
+cat "$release_file"

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/template-update.yml.jinja
@@ -282,7 +282,22 @@ jobs:
             echo "## Template changelog ($NEW_REF)"
             echo
             echo "$changelog"
-          } > /tmp/pr-body.md
+          } > /tmp/pr-release.md
+
+          # Compose the body. A joined PR keeps its own text — a
+          # hand-opened update PR carries the canonical ticket
+          # reference the gate reads, and rewriting it turned a green
+          # PR red (#218). Only the release section this workflow
+          # wrote before is replaced.
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr view "$EXISTING_PR" --json body --jq .body \
+              > /tmp/pr-existing.md || : > /tmp/pr-existing.md
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md /tmp/pr-existing.md > /tmp/pr-body.md
+          else
+            bash scripts/ci/template-update-body.sh \
+              /tmp/pr-release.md > /tmp/pr-body.md
+          fi
 
           # The ticket gate's designed escape (#137): a bot-authored PR
           # carrying the `automated` label needs no ticket reference — a
@@ -294,9 +309,10 @@ jobs:
             --description "Bot-authored maintenance PR; the ticket gate's designed escape" \
             || true
 
-          # A joined PR is refreshed in place — title, body and label
-          # brought to the new release — so one PR carries the update
-          # conversation however many releases pass through it.
+          # A joined PR is refreshed in place — title, release notes
+          # and label brought to the new release — so one PR carries
+          # the update conversation however many releases pass through
+          # it, without losing the body it was opened with.
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "chore: update agentic template to $NEW_REF" \

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -42,6 +42,7 @@ STORE_FILES = frozenset(
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
         "scripts/ci/prune_glossary.sh",
+        "scripts/ci/template-update-body.sh",
         # The audit's script bridges render with the shared scripts/ci
         # payload; the audit WORKFLOW does not — stores render only
         # their own workflow set, and as private repos they are not

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -59,6 +59,7 @@ COMMON_FILES = frozenset(
         # The glossary prune (#67, #203, #210): task, update workflow,
         # drift job and the template root all run this one script.
         "scripts/ci/prune_glossary.sh",
+        "scripts/ci/template-update-body.sh",
         # The daily self-audit's denylist bridges (#189): value-silent
         # bash on both ends of the trufflehog scan.
         "scripts/ci/trufflehog-detectors.sh",

--- a/tests/test_evidence_subtemplate.py
+++ b/tests/test_evidence_subtemplate.py
@@ -36,6 +36,7 @@ STORE_FILES = frozenset(
         ".github/reference-keywords.json",
         "scripts/ci/check_gate.py",
         "scripts/ci/prune_glossary.sh",
+        "scripts/ci/template-update-body.sh",
         # The audit's script bridges render with the shared scripts/ci
         # payload; the audit WORKFLOW does not — stores render only
         # their own workflow set, and as private repos they are not

--- a/tests/test_session_memory_subtemplate.py
+++ b/tests/test_session_memory_subtemplate.py
@@ -37,6 +37,7 @@ STORE_FILES = frozenset(
         # The glossary prune every stamped repo runs (#203); a store has
         # no glossary, so here it reports that and exits 0.
         "scripts/ci/prune_glossary.sh",
+        "scripts/ci/template-update-body.sh",
     }
 )
 

--- a/tests/test_update_pr_body.py
+++ b/tests/test_update_pr_body.py
@@ -1,0 +1,79 @@
+"""The updater's join path keeps the PR's own body (#218).
+
+Joining a stale `chore/template-update-*` PR used to rewrite its body
+with the workflow's template. A PR a human opened carries the canonical
+`ADVANCES ...` reference there, so the join turned the ticket gate red
+on a PR that had passed it. The composer keeps that text verbatim and
+appends the release notes under a marker it owns, replacing only the
+section it wrote itself.
+"""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+COMPOSER = ROOT / "template" / "scripts" / "ci" / "template-update-body.sh"
+MARKER = "<!-- agentic-template-update -->"
+
+
+def compose(tmp_path: Path, release: str, existing: str | None = None) -> str:
+    release_file = tmp_path / "release.md"
+    release_file.write_text(release)
+    args = [str(release_file)]
+    if existing is not None:
+        existing_file = tmp_path / "existing.md"
+        existing_file.write_text(existing)
+        args.append(str(existing_file))
+    proc = subprocess.run(
+        ["bash", str(COMPOSER), *args], capture_output=True, text=True, check=True
+    )
+    return proc.stdout
+
+
+def test_a_fresh_pr_body_is_the_release_section(tmp_path: Path) -> None:
+    out = compose(tmp_path, "Automated update v1 -> v2.\n")
+    assert out == f"{MARKER}\n\nAutomated update v1 -> v2.\n"
+
+
+def test_a_joined_body_survives_verbatim_above_the_release_notes(
+    tmp_path: Path,
+) -> None:
+    existing = "Rebuilt by hand.\n\nADVANCES #216\n"
+    out = compose(tmp_path, "Automated update v1 -> v2.\n", existing)
+
+    assert out.startswith("Rebuilt by hand.\n\nADVANCES #216\n")
+    assert "ADVANCES #216" in out.split(MARKER)[0]
+    assert out.endswith("Automated update v1 -> v2.\n")
+
+
+def test_a_second_join_replaces_only_its_own_section(tmp_path: Path) -> None:
+    first = compose(tmp_path, "Automated update v1 -> v2.\n", "ADVANCES #216\n")
+    second = compose(tmp_path, "Automated update v2 -> v3.\n", first)
+
+    assert second.count(MARKER) == 1
+    assert "v1 -> v2" not in second
+    assert second == f"ADVANCES #216\n\n{MARKER}\n\nAutomated update v2 -> v3.\n"
+
+
+def test_an_empty_existing_body_leaves_no_leading_blank_line(tmp_path: Path) -> None:
+    assert compose(tmp_path, "notes\n", "") == f"{MARKER}\n\nnotes\n"
+    assert compose(tmp_path, "notes\n", "\n\n") == f"{MARKER}\n\nnotes\n"
+
+
+def test_the_join_path_feeds_the_existing_body_to_the_composer() -> None:
+    """The composer only helps if the workflow reads the body it is
+    about to replace. Pinned on the source the stores copy, so the
+    check covers every stamped copy of the workflow.
+    """
+    workflow = (
+        ROOT
+        / "template"
+        / "{% if agentic_forge == 'github' %}.github{% endif %}"
+        / "workflows"
+        / "template-update.yml.jinja"
+    ).read_text()
+
+    assert 'gh pr view "$EXISTING_PR" --json body' in workflow
+    assert "scripts/ci/template-update-body.sh" in workflow
+    # The join edit posts the composed body, not the release section.
+    assert "--body-file /tmp/pr-body.md" in workflow


### PR DESCRIPTION
CLOSES #218

Joining a stale update PR rewrote its body with the workflow's own template, dropping the canonical ticket reference a hand-opened PR carries. The ticket gate reads that reference, so the join turned two green consumer PRs red at one release.

## What changed

- A byte-pinned composer, `scripts/ci/template-update-body.sh`, builds the PR body. The existing text is kept verbatim above a marker the workflow owns, and only the release section written under that marker is replaced. A PR that survives five releases carries one set of notes, not five.
- The join path now reads the current body before editing; the fresh-PR path is unchanged in effect.
- The script is copied into the three store subtemplates alongside the workflow they already pin byte-identical.

## Tests

New `tests/test_update_pr_body.py`: a fresh body is the release section alone, a joined body survives verbatim above the notes, a second join replaces only its own section, and an empty existing body leaves no leading blank line. One test pins the workflow wiring so the composer cannot be orphaned. Full suite 350 green.

## Acceptance criteria

- [x] A joined PR's original body text is preserved verbatim above the appended release notes
- [x] Test on the workflow's join branch of `template-update.yml.jinja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC3EFouHkiuQcB7kRN5gpa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790968112&installation_model_id=432661&pr_number=225&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F225&signature=e02d1e31a0fcff6127c9264cb518f489f816e366ba786cc4b431d9cd3d2a0262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->