### PR TITLE
fix(replay): mask the if-clause, report leaks and blind baselines

### DIFF
--- a/decision-memory/.agents/skills/compact-preferences/SKILL.md
+++ b/decision-memory/.agents/skills/compact-preferences/SKILL.md
@@ -69,9 +69,13 @@ python .github/store/replay.py cases --out /tmp/cases.json
 
 `cases.json` holds the most recent decisions (`replay_window` in
 `store.config.json`) **masked to their input side** — question,
-context, and options with the recorded prediction role, cited rules and
-in-session reasoning stripped, in a per-record shuffled order so slot
-position carries no signal.
+context, and options with the recorded prediction role, cited rules,
+if-clauses and in-session reasoning stripped, in a per-record shuffled
+order so slot position carries no signal. Its `leaks` list (also
+printed to stderr) names every record whose case still gives the
+answer away: a key carried by all options but one, or a context that
+narrates the ruling. Records are immutable, so a leak is not fixed
+here — carry the list into step 6 and read the gate against it.
 
 ### 4. Predict under the baseline set
 
@@ -175,6 +179,13 @@ Slot numbers in the cases are shuffled per record and mapped back
 during scoring, so a run cannot score by learning that slot 1 is the
 prediction slot. `predicted_slot` in the report is the recorded slot;
 `presented_slot` is what the run answered.
+
+Both reports carry `blind_baselines`: `always_slot_1` and `odd_option`
+(the one option without an if-clause, where exactly one lacks it), the
+hit rates a reader of the cases alone would get. A gated stream at or
+below either number, or a run scoring every leaked case right, is
+measuring the cases, not the rules — say so in the PR and do not lean
+on that pass.
 
 On `insufficient-evidence`, extract first: run `extract-preferences`,
 let sessions score against the rules, and compact once the gated stream

--- a/decision-memory/.github/store/README.md
+++ b/decision-memory/.github/store/README.md
@@ -164,11 +164,19 @@ python .github/store/replay.py gate    --baseline base.json \
 ```
 
 `cases` masks each record to its input side and strips the fields that
-leak the old rule set's answer (`role`, `rules_cited`, and the
-in-session `reasoning`). `score` joins an agent's predictions with the
-recorded `chosen_slot`. `gate` compares two scored runs: exit 0 on
-`pass`, 1 on `fail` when the **preference-driven** hit rate degrades,
-and 3 on `insufficient-evidence`.
+leak the recorded answer or the old rule set (`role`, `rules_cited`,
+`if_clause` — only alternatives carry one, so its absence marks the
+prediction slot — and the in-session `reasoning`). It also lists
+`leaks`, per record: an `odd-option` key carried by every option but
+one, or a `context` that narrates the ruling (a small denylist). Leaks
+are reported to stderr and never repaired — records are immutable — so
+read a pass with them in mind. `score` joins an agent's predictions
+with the recorded `chosen_slot` and reports `blind_baselines` next to
+the streams: `always_slot_1` and `odd_option`, what a reader of the
+case alone would score. `gate` compares two scored runs and carries the
+candidate's baselines: exit 0 on `pass`, 1 on `fail` when the
+**preference-driven** hit rate degrades, and 3 on
+`insufficient-evidence`.
 
 Two streams, exactly as recording uses them: a prediction citing rules
 scores preference-driven, one citing none scores cold. The gate is the

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -211,14 +211,39 @@ def mask_record(record: dict, include_reasoning: bool = False) -> dict:
     return case
 
 
+LEAK_ODD_OPTION = "odd-option"
+
+
+def case_leaks(case: dict) -> list[dict]:
+    """What still identifies the recorded answer in one masked case.
+
+    Structural: a key carried by every option but one singles that
+    option out, exactly as the if-clause did before it was masked. The
+    check runs on the masked case, so a field the recorder adds later
+    is caught the day it ships, not the day someone notices 20/20.
+    """
+    options = case.get("options") or []
+    leaks: list[dict] = []
+    if len(options) < 2:
+        return leaks
+    keys = set().union(*(option.keys() for option in options))
+    for key in sorted(keys):
+        carriers = sum(1 for option in options if key in option)
+        if carriers == len(options) - 1:
+            leaks.append({"id": case.get("id"), "channel": LEAK_ODD_OPTION, "key": key})
+    return leaks
+
+
 def build_cases(
     records: list[dict], window: int, include_reasoning: bool = False
 ) -> dict:
     selected = select_window(records, window)
+    cases = [mask_record(record, include_reasoning) for record in selected]
     return {
         "window": window,
         "count": len(selected),
         "slot_order": "permuted",
+        "leaks": [leak for case in cases for leak in case_leaks(case)],
         "instructions": (
             "For each case, predict which slot the decider will choose. "
             "Answer only from the injected preference set plus the case "
@@ -231,7 +256,7 @@ def build_cases(
             "If you expect the decider to answer with none of the listed "
             "options, predict the slot one past the last one."
         ),
-        "cases": [mask_record(record, include_reasoning) for record in selected],
+        "cases": cases,
     }
 
 

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -30,9 +30,11 @@ stream the CANDIDATE assigns, and the shifts are reported so a hit-rate
 change driven by re-labelling rather than by better rules is visible.
 
 Masking removes `role` and `rules_cited` from the options — they encode
-the original prediction and its stream — and, by default, the
-in-session `reasoning`, which was written under the OLD rule set and
-would otherwise leak that set's answer into the candidate run.
+the original prediction and its stream — the `if_clause`, which only
+alternatives carry and so singles out the prediction slot by its
+absence, and, by default, the in-session `reasoning`, which was written
+under the OLD rule set and would otherwise leak that set's answer into
+the candidate run.
 
 Slot ORDER is masked too, because slot 1 is the prediction slot by
 convention and deciders pick it far more often than chance: on a real
@@ -101,7 +103,12 @@ def preferences_sha256(text: str) -> str:
 
 
 # Option fields that leak the recorded prediction or the old rule set.
-_LEAKY_OPTION_FIELDS = ("role", "rules_cited")
+# `if_clause` is structural: the prediction slot never carries one and
+# every alternative must, so the one option without it IS the recorded
+# prediction. The clause is the recommender's argument for an
+# alternative, not the decider's input, so nothing a predictor
+# legitimately needs is lost.
+_LEAKY_OPTION_FIELDS = ("role", "rules_cited", "if_clause")
 _OLD_RULE_SET_FIELDS = ("reasoning",)
 
 _CASE_FIELDS = ("id", "date", "project", "question", "context", "artifact_ref")

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -45,6 +45,13 @@ the same order to map a prediction back. The mapping is never written
 into the cases file — shipping it would hand the ordering signal
 straight back.
 
+Two channels survive masking and are REPORTED rather than repaired,
+because records are immutable: `cases` lists `leaks` — a key carried
+by every option but one, or a context that narrates the ruling — and
+`score` carries blind baselines (always slot 1, the odd option) next to
+the streams, so a hit rate is always read against what the case alone
+gives away.
+
 Stdlib only. Usage:
 
     python .github/store/replay.py cases --out /tmp/cases.json

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -64,6 +64,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -212,6 +213,20 @@ def mask_record(record: dict, include_reasoning: bool = False) -> dict:
 
 
 LEAK_ODD_OPTION = "odd-option"
+LEAK_CONTEXT = "context"
+
+# Ruling narration in the input-side context. A denylist, deliberately
+# small: it flags the phrasings measured on a real corpus (a verdict in
+# the past tense, a reference to what was ruled) and nothing subtler.
+# The context is written before the ruling by contract, so a match is a
+# recording-discipline finding as much as a masking one.
+_CONTEXT_NARRATION = re.compile(
+    r"\b(?:ruled|ruling)\b"
+    r"|\bthe principal (?:caught|chose|decided|reviewed|accepted|rejected"
+    r"|merged|reverted)\b"
+    r"|\bwas (?:chosen|decided|accepted|rejected|merged|reverted|rewritten)\b",
+    re.IGNORECASE,
+)
 
 
 def case_leaks(case: dict) -> list[dict]:
@@ -221,16 +236,28 @@ def case_leaks(case: dict) -> list[dict]:
     option out, exactly as the if-clause did before it was masked. The
     check runs on the masked case, so a field the recorder adds later
     is caught the day it ships, not the day someone notices 20/20.
+
+    Textual: a context that narrates the ruling. Reported once per
+    case, on the first match, so a long context does not flood the
+    report.
     """
     options = case.get("options") or []
     leaks: list[dict] = []
-    if len(options) < 2:
-        return leaks
-    keys = set().union(*(option.keys() for option in options))
-    for key in sorted(keys):
-        carriers = sum(1 for option in options if key in option)
-        if carriers == len(options) - 1:
-            leaks.append({"id": case.get("id"), "channel": LEAK_ODD_OPTION, "key": key})
+    if len(options) >= 2:
+        keys = set().union(*(option.keys() for option in options))
+        for key in sorted(keys):
+            carriers = sum(1 for option in options if key in option)
+            if carriers == len(options) - 1:
+                leaks.append(
+                    {"id": case.get("id"), "channel": LEAK_ODD_OPTION, "key": key}
+                )
+    context = case.get("context")
+    if isinstance(context, str):
+        match = _CONTEXT_NARRATION.search(context)
+        if match:
+            leaks.append(
+                {"id": case.get("id"), "channel": LEAK_CONTEXT, "match": match.group(0)}
+            )
     return leaks
 
 
@@ -539,7 +566,15 @@ def main(argv: list[str] | None = None) -> int:
     records = load_records(args.root)
 
     if args.command == "cases":
-        _emit(build_cases(records, window, args.include_reasoning), args.out)
+        payload = build_cases(records, window, args.include_reasoning)
+        _emit(payload, args.out)
+        for leak in payload["leaks"]:
+            detail = leak.get("key") or leak.get("match")
+            print(
+                f"LEAK {leak['channel']}: {leak['id']} — {detail!r} identifies the "
+                "recorded answer; read the gate's pass with that in mind",
+                file=sys.stderr,
+            )
         return 0
 
     predictions, errors = normalise_predictions(_read_json(args.predictions))

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -517,6 +517,7 @@ def gate(baseline: dict, candidate: dict, min_gated_cases: int = 0) -> dict:
             "baseline": baseline.get("streams", {}).get(COLD, {}),
             "candidate": candidate.get("streams", {}).get(COLD, {}),
         },
+        "blind_baselines": candidate.get("blind_baselines", {}),
         "stream_shifts": {
             "cold_to_preference_driven": sum(
                 1 for shift in shifts if shift["candidate"] == PREFERENCE_DRIVEN

--- a/decision-memory/.github/store/replay.py
+++ b/decision-memory/.github/store/replay.py
@@ -326,6 +326,41 @@ def _rate(hits: int, total: int) -> float | None:
     return round(hits / total, 4) if total else None
 
 
+def odd_option_slot(record: dict) -> int | None:
+    """The recorded slot a reader of the raw record would pick: the one
+    option without an if-clause, when exactly one lacks it."""
+    without = [
+        slot
+        for slot, option in zip(record_slots(record), _option_dicts(record))
+        if "if_clause" not in option
+    ]
+    return without[0] if len(without) == 1 else None
+
+
+def blind_baselines(records: list[dict]) -> dict:
+    """What scoring without any rule set would get on these records.
+
+    `always_slot_1` answers the prediction slot every time; `odd_option`
+    answers the one option without an if-clause and abstains where there
+    is none. Both are reported next to the streams so a hit rate is
+    read against what the case alone gives away.
+    """
+    slot_1 = {"n": 0, "hits": 0}
+    odd = {"n": 0, "hits": 0}
+    for record in records:
+        chosen = record.get("chosen_slot")
+        slot_1["n"] += 1
+        slot_1["hits"] += int(chosen == 1)
+        odd_slot = odd_option_slot(record)
+        if odd_slot is not None:
+            odd["n"] += 1
+            odd["hits"] += int(chosen == odd_slot)
+    return {
+        "always_slot_1": {**slot_1, "hit_rate": _rate(slot_1["hits"], slot_1["n"])},
+        "odd_option": {**odd, "hit_rate": _rate(odd["hits"], odd["n"])},
+    }
+
+
 def score(
     records: list[dict],
     predictions: dict[str, dict],
@@ -392,6 +427,7 @@ def score(
             }
             for stream in STREAMS
         },
+        "blind_baselines": blind_baselines(selected),
         "stream_shifts": shifts,
         "cases": cases,
     }

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -891,7 +891,10 @@ class BudgetGateTests(unittest.TestCase):
 
 
 class ReplayTests(unittest.TestCase):
+    @unittest.expectedFailure
     def test_mask_strips_leaky_fields(self):
+        """The if-clause singles out the prediction slot: alternatives
+        carry one by contract, the prediction does not (AET#228)."""
         case = replay.mask_record(make_record("20260715T143205Z-a", 1))
         self.assertNotIn("chosen_slot", case)
         self.assertNotIn("outcome", case)
@@ -899,7 +902,7 @@ class ReplayTests(unittest.TestCase):
             self.assertNotIn("role", option)
             self.assertNotIn("rules_cited", option)
             self.assertNotIn("reasoning", option)
-        self.assertEqual(case["options"][1]["if_clause"], "if x")
+            self.assertNotIn("if_clause", option)
 
     def test_mask_can_keep_reasoning(self):
         case = replay.mask_record(

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1040,7 +1040,6 @@ class LeakCheckTests(unittest.TestCase):
         payload = replay.build_cases([make_record("20260715T143205Z-a", 1)], 20)
         self.assertEqual(payload["leaks"], [])
 
-    @unittest.expectedFailure
     def test_a_context_that_narrates_the_ruling_is_a_context_leak(self):
         """The context is input side, written before the ruling; a
         past-tense verdict in it hands the reader the answer."""

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1089,7 +1089,6 @@ class BlindBaselineTests(unittest.TestCase):
         ]
         return make_record(record_id, chosen_slot, options=options)
 
-    @unittest.expectedFailure
     def test_score_reports_always_slot_1_and_odd_option_baselines(self):
         records = [
             self._odd("20260715T143205Z-a", 1),

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1040,6 +1040,34 @@ class LeakCheckTests(unittest.TestCase):
         payload = replay.build_cases([make_record("20260715T143205Z-a", 1)], 20)
         self.assertEqual(payload["leaks"], [])
 
+    @unittest.expectedFailure
+    def test_a_context_that_narrates_the_ruling_is_a_context_leak(self):
+        """The context is input side, written before the ruling; a
+        past-tense verdict in it hands the reader the answer."""
+        record = make_record("20260715T143205Z-a", 1)
+        record["context"] = "Two layouts were open. The principal reviewed: 'B.'"
+        payload = replay.build_cases([record], 20)
+        self.assertEqual(
+            payload["leaks"],
+            [
+                {
+                    "id": "20260715T143205Z-a",
+                    "channel": "context",
+                    "match": "The principal reviewed",
+                }
+            ],
+        )
+
+    def test_a_context_stating_the_situation_is_no_leak(self):
+        record = make_record("20260715T143205Z-a", 1)
+        record["context"] = "Two layouts are open; the reviewer prefers neither yet."
+        self.assertEqual(replay.build_cases([record], 20)["leaks"], [])
+
+    def test_a_missing_context_is_no_leak(self):
+        record = make_record("20260715T143205Z-a", 1)
+        record["context"] = None
+        self.assertEqual(replay.build_cases([record], 20)["leaks"], [])
+
 
 class CorpusReplayTests(unittest.TestCase):
     """The harness must cope with the real corpus, not just fixtures."""

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -990,6 +990,19 @@ class ReplayTests(unittest.TestCase):
         result = replay.gate(baseline, candidate)
         self.assertEqual(result["gate"], "fail")
 
+    @unittest.expectedFailure
+    def test_gate_carries_the_candidate_blind_baselines(self):
+        """The gate report is what lands in the PR body; the baselines
+        must travel with it or the reader never sees them."""
+        baseline = self._report(pd=(4, 5), cold=(1, 5), sha="base")
+        candidate = self._report(pd=(4, 5), cold=(1, 5), sha="cand")
+        candidate["blind_baselines"] = {
+            "always_slot_1": {"n": 5, "hits": 4, "hit_rate": 0.8},
+            "odd_option": {"n": 3, "hits": 3, "hit_rate": 1.0},
+        }
+        result = replay.gate(baseline, candidate)
+        self.assertEqual(result["blind_baselines"], candidate["blind_baselines"])
+
     def test_gate_fails_on_mismatched_windows(self):
         baseline = self._report(pd=(1, 1), cold=(0, 0), sha="base", ids=["a"])
         candidate = self._report(pd=(1, 1), cold=(0, 0), sha="cand", ids=["b"])

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1068,6 +1068,47 @@ class LeakCheckTests(unittest.TestCase):
         self.assertEqual(replay.build_cases([record], 20)["leaks"], [])
 
 
+class BlindBaselineTests(unittest.TestCase):
+    """Every score report carries what a reader of the case alone would
+    score, so a rule-set hit rate is read against it (AET#228)."""
+
+    @staticmethod
+    def _odd(record_id, chosen_slot):
+        options = [
+            {"slot": 1, "label": "a", "role": "prediction"},
+            {"slot": 2, "label": "b", "if_clause": "if x"},
+            {"slot": 3, "label": "c", "if_clause": "if y"},
+        ]
+        return make_record(record_id, chosen_slot, options=options)
+
+    @staticmethod
+    def _even(record_id, chosen_slot):
+        options = [
+            {"slot": 1, "label": "a", "role": "prediction", "if_clause": "if w"},
+            {"slot": 2, "label": "b", "if_clause": "if x"},
+        ]
+        return make_record(record_id, chosen_slot, options=options)
+
+    @unittest.expectedFailure
+    def test_score_reports_always_slot_1_and_odd_option_baselines(self):
+        records = [
+            self._odd("20260715T143205Z-a", 1),
+            self._odd("20260716T143205Z-b", 2),
+            self._even("20260717T143205Z-c", 2),
+        ]
+        predictions, _ = replay.normalise_predictions(
+            [make_prediction(record["id"], 1) for record in records]
+        )
+        report, _ = replay.score(records, predictions, 20, "prefs")
+        self.assertEqual(
+            report["blind_baselines"],
+            {
+                "always_slot_1": {"n": 3, "hits": 1, "hit_rate": 0.3333},
+                "odd_option": {"n": 2, "hits": 1, "hit_rate": 0.5},
+            },
+        )
+
+
 class CorpusReplayTests(unittest.TestCase):
     """The harness must cope with the real corpus, not just fixtures."""
 

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1016,6 +1016,33 @@ class ReplayTests(unittest.TestCase):
         }
 
 
+class LeakCheckTests(unittest.TestCase):
+    """`cases` reports what still identifies the recorded answer (AET#228).
+
+    Records are immutable, so a leak is reported, never repaired: the
+    reader of the report decides what a pass is worth.
+    """
+
+    @unittest.expectedFailure
+    def test_a_key_carried_by_all_but_one_option_is_an_odd_option_leak(self):
+        options = [
+            {"slot": 1, "label": "a", "role": "prediction"},
+            {"slot": 2, "label": "b", "if_clause": "if x", "note": "n"},
+            {"slot": 3, "label": "c", "if_clause": "if y", "note": "n"},
+        ]
+        record = make_record("20260715T143205Z-a", 1, options=options)
+        payload = replay.build_cases([record], 20)
+        self.assertEqual(
+            payload["leaks"],
+            [{"id": "20260715T143205Z-a", "channel": "odd-option", "key": "note"}],
+        )
+
+    @unittest.expectedFailure
+    def test_a_symmetric_key_set_is_no_leak(self):
+        payload = replay.build_cases([make_record("20260715T143205Z-a", 1)], 20)
+        self.assertEqual(payload["leaks"], [])
+
+
 class CorpusReplayTests(unittest.TestCase):
     """The harness must cope with the real corpus, not just fixtures."""
 

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -990,7 +990,6 @@ class ReplayTests(unittest.TestCase):
         result = replay.gate(baseline, candidate)
         self.assertEqual(result["gate"], "fail")
 
-    @unittest.expectedFailure
     def test_gate_carries_the_candidate_blind_baselines(self):
         """The gate report is what lands in the PR body; the baselines
         must travel with it or the reader never sees them."""

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -891,7 +891,6 @@ class BudgetGateTests(unittest.TestCase):
 
 
 class ReplayTests(unittest.TestCase):
-    @unittest.expectedFailure
     def test_mask_strips_leaky_fields(self):
         """The if-clause singles out the prediction slot: alternatives
         carry one by contract, the prediction does not (AET#228)."""

--- a/decision-memory/.github/store/tests/test_store.py
+++ b/decision-memory/.github/store/tests/test_store.py
@@ -1023,7 +1023,6 @@ class LeakCheckTests(unittest.TestCase):
     reader of the report decides what a pass is worth.
     """
 
-    @unittest.expectedFailure
     def test_a_key_carried_by_all_but_one_option_is_an_odd_option_leak(self):
         options = [
             {"slot": 1, "label": "a", "role": "prediction"},
@@ -1037,7 +1036,6 @@ class LeakCheckTests(unittest.TestCase):
             [{"id": "20260715T143205Z-a", "channel": "odd-option", "key": "note"}],
         )
 
-    @unittest.expectedFailure
     def test_a_symmetric_key_set_is_no_leak(self):
         payload = replay.build_cases([make_record("20260715T143205Z-a", 1)], 20)
         self.assertEqual(payload["leaks"], [])


### PR DESCRIPTION
CLOSES #228.

## What

The replay-regression harness (`decision-memory/.github/store/replay.py`) let a predictor score the case instead of the rule set through two channels. This PR closes one and makes both visible.

- **Mask the if-clause.** `if_clause` joins `role` and `rules_cited` in the stripped option fields. The prediction slot never carries one and every alternative must, so its absence identified the recorded answer in 14 of 20 cases of the 2026-09-03 run.
- **Leak check in `cases`.** The payload carries a `leaks` list, one entry per record: `odd-option` for a key carried by every option but one (checked on the masked case, so a field the recorder adds later is caught), and `context` for a context matching a small ruling-narration denylist. Every leak is also printed to stderr. Warn, not fail: records are immutable, so a fail would block every future compaction on a context nobody can rewrite.
- **Blind baselines in `score` and `gate`.** `blind_baselines` reports `always_slot_1` and `odd_option` hit rates next to the two streams, and the gate report carries the candidate's copy so the numbers land in the compaction PR body.
- Docs: module docstring, store README, compact-preferences skill (step 3 and step 6).

## Verification

On the decision-memory corpus at `main` (20 records): the cases file no longer contains `if_clause`, no odd-option leak is reported, seven contexts trip the narration denylist (the four from the issue plus three that cite a prior ruling by name).

Store self-test: 190 tests, 1 skipped. Root suite subset `tests/test_store_layer.py` and `tests/test_decision_memory_subtemplate.py`: 11 passed. `prek run --all-files` clean on every commit. Red commits are red on tests only, marked `unittest.expectedFailure`.

## Out of scope

A write-time validator warning on past-tense ruling verbs in `context` (the issue's last paragraph) is recording discipline in the validator, not the harness. Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1