### PR TITLE
fix(record): submit withholds bumps for disconfirmed rules and corrections

### DIFF
--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -718,8 +718,36 @@ def confirmations_for(
     Returns `(confirmations, skipped)`: `confirmations` is a list of
     `(rule, independent)` pairs to bump, `skipped` a list of
     `(rule, reason)` pairs that were cited but earn nothing.
+
+    Two ways a rule earns a confirmation, counted apart. A `hit`
+    credits the rules cited on the slot that won — the rule agreeing
+    with itself. Anything else can still confirm a rule, if the decider
+    chose an option that cited it without that rule having proposed it;
+    that one is independent.
+
+    Two ways a citation earns nothing (AET#227). A rule listed in
+    `rules_disconfirmed` was set aside by the decider: neither win nor
+    loss. A record with `correction: true` had its reason replaced, so
+    the rules it cites did not drive the ruling and none auto-bumps;
+    the decider promotes by hand if one did.
     """
-    raise NotImplementedError
+    if record.get("outcome") == "hit":
+        candidates = [(rule, False) for rule in prediction_rules(record)]
+    else:
+        candidates = [(rule, True) for rule in independent_rules(record)]
+    disconfirmed = {
+        rule for rule in record.get("rules_disconfirmed") or [] if isinstance(rule, str)
+    }
+    confirmations: list[tuple[str, bool]] = []
+    skipped: list[tuple[str, str]] = []
+    for rule, independent in candidates:
+        if rule in disconfirmed:
+            skipped.append((rule, "disconfirmed"))
+        elif record.get("correction") is True:
+            skipped.append((rule, "correction"))
+        else:
+            confirmations.append((rule, independent))
+    return confirmations, skipped
 
 
 def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> str:
@@ -800,15 +828,9 @@ def cmd_submit(args: argparse.Namespace) -> int:
     for record in records:
         if record.get("prediction_stream") != "preference-driven":
             continue
-        # Two ways a rule earns a confirmation, and they are counted
-        # apart. A `hit` credits the rules cited on the slot that won —
-        # the rule agreeing with itself. Anything else can still confirm
-        # a rule, if the decider chose an option that cited it without
-        # that rule having proposed it; that one is independent.
-        if record.get("outcome") == "hit":
-            confirmations = [(rule, False) for rule in prediction_rules(record)]
-        else:
-            confirmations = [(rule, True) for rule in independent_rules(record)]
+        confirmations, skipped = confirmations_for(record)
+        for rule, reason in skipped:
+            print(f"pref-skip: {rule} ({reason}) — no counter bumped")
         for rule, independent in confirmations:
             if not source_path.exists():
                 print(f"WARN: no {validator.PREFERENCES_SOURCE} — cannot bump {rule!r}")

--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -710,6 +710,18 @@ def independent_rules(record: dict) -> list[str]:
     return []
 
 
+def confirmations_for(
+    record: dict,
+) -> tuple[list[tuple[str, bool]], list[tuple[str, str]]]:
+    """The counter bumps a record earns, and the citations it withholds.
+
+    Returns `(confirmations, skipped)`: `confirmations` is a list of
+    `(rule, independent)` pairs to bump, `skipped` a list of
+    `(rule, reason)` pairs that were cited but earn nothing.
+    """
+    raise NotImplementedError
+
+
 def build_pr_body(records: list[dict], streams: dict[str, dict[str, int]]) -> str:
     def rate(stream: str) -> str:
         counts = streams[stream]

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -244,3 +244,50 @@ def test_recorder_operates_on_the_checkout_it_lives_in(tmp_path: Path) -> None:
     )
     relocated = load_module("relocated_record", store / "tools" / "record.py")
     assert relocated.store_root() == store
+
+
+def _record(outcome: str, cited: list[str], disconfirmed=None, correction=None) -> dict:
+    record = {
+        "options": [
+            {"slot": 1, "role": "prediction", "rules_cited": cited},
+            {"slot": 2, "rules_cited": ["other rule."]},
+        ],
+        "chosen_slot": 1 if outcome == "hit" else 2,
+        "outcome": outcome,
+        "prediction_stream": "preference-driven",
+    }
+    if disconfirmed is not None:
+        record["rules_disconfirmed"] = disconfirmed
+    if correction is not None:
+        record["correction"] = correction
+    return record
+
+
+@pytest.mark.xfail(strict=True)
+def test_a_disconfirmed_rule_earns_no_confirmation() -> None:
+    """AET#227: a rule the decider set aside is neither win nor loss.
+
+    submit bumped "Makes absence observable" from 1 to 2 on a record
+    that listed it under rules_disconfirmed (decision-memory PR #25).
+    """
+    record = _record("hit", ["rule a.", "rule b."], disconfirmed=["rule b."])
+    confirmations, skipped = record_tool.confirmations_for(record)
+    assert confirmations == [("rule a.", False)]
+    assert skipped == [("rule b.", "disconfirmed")]
+
+
+@pytest.mark.xfail(strict=True)
+def test_a_correction_earns_no_automatic_confirmation() -> None:
+    """A record whose reason was replaced confirms nothing by itself."""
+    record = _record("hit", ["rule a."], correction=True)
+    confirmations, skipped = record_tool.confirmations_for(record)
+    assert confirmations == []
+    assert skipped == [("rule a.", "correction")]
+
+
+@pytest.mark.xfail(strict=True)
+def test_an_independent_confirmation_still_skips_a_disconfirmed_rule() -> None:
+    record = _record("miss", ["rule a."], disconfirmed=["other rule."])
+    confirmations, skipped = record_tool.confirmations_for(record)
+    assert confirmations == []
+    assert skipped == [("other rule.", "disconfirmed")]

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -263,7 +263,6 @@ def _record(outcome: str, cited: list[str], disconfirmed=None, correction=None) 
     return record
 
 
-@pytest.mark.xfail(strict=True)
 def test_a_disconfirmed_rule_earns_no_confirmation() -> None:
     """AET#227: a rule the decider set aside is neither win nor loss.
 
@@ -276,7 +275,6 @@ def test_a_disconfirmed_rule_earns_no_confirmation() -> None:
     assert skipped == [("rule b.", "disconfirmed")]
 
 
-@pytest.mark.xfail(strict=True)
 def test_a_correction_earns_no_automatic_confirmation() -> None:
     """A record whose reason was replaced confirms nothing by itself."""
     record = _record("hit", ["rule a."], correction=True)
@@ -285,7 +283,6 @@ def test_a_correction_earns_no_automatic_confirmation() -> None:
     assert skipped == [("rule a.", "correction")]
 
 
-@pytest.mark.xfail(strict=True)
 def test_an_independent_confirmation_still_skips_a_disconfirmed_rule() -> None:
     record = _record("miss", ["rule a."], disconfirmed=["other rule."])
     confirmations, skipped = record_tool.confirmations_for(record)


### PR DESCRIPTION
CLOSES #227.

## What

`record.py submit` bumped a preference counter for every rule cited on the winning slot, including rules the decider listed under `rules_disconfirmed` and rules on a record marked `correction: true`. Both are documented as neither win nor loss, and the counters drift upward silently because extraction and compaction trust them.

- New `confirmations_for(record)` returns the bumps a record earns and the citations it withholds, each skip with its reason (`disconfirmed`, `correction`). The hit and independent streams are unchanged for everything else.
- `submit` uses it and prints each withheld bump as `pref-skip: <rule> (<reason>) — no counter bumped`, so the session log shows what did not move.

## Verification

Three red-first tests in `tests/test_record_core.py` (`unittest`-style xfail strict in the red commit, cleared in the fix): a disconfirmed rule on a hit earns nothing while its sibling still bumps, a correction record earns nothing, an independent confirmation skips a disconfirmed rule. Record test files: 37 passed. `prek run --all-files` clean on every commit, including the signature-only stub that precedes the red test.

The two bumps this bug produced in decision-memory were reverted by hand at the time (dm!25 and the 2026-09-03 session) and need no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058584&installation_model_id=432661&pr_number=230&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F230&signature=80c6d6623cf7f387833c4ee7728282422aabd18b5790e0f002e82062406685a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->