### PR TITLE
fix(template): pipe the merge list through xargs so actionlint passes

### DIFF
--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/lint.yml.jinja
@@ -135,7 +135,7 @@ jobs:
         run: |
           merges="$(git rev-list --merges {% raw %}${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}{% endraw %})"
           [ -z "$merges" ] && { echo "The PR's range is linear."; exit 0; }
-          git log --no-walk --format='%h %s' $merges
+          echo "$merges" | xargs git log --no-walk --format='%h %s'
           echo "::error::The PR carries merge commit(s). A working branch is rebased onto main, never merged into (skills#147): git rebase origin/main, then push with --force-with-lease."
           exit 1
 {%- if agentic_precommit == 'prek' %}


### PR DESCRIPTION
CLOSES #232.

The linear-history job's `git log --no-walk --format='%h %s' $merges` relied on intentional word splitting over multiple shas; actionlint's embedded shellcheck flags it as SC2086, so every stamped repo's `prek (all hooks, all files)` job goes red on its own vendored `lint.yml` — first seen on pandoscope/pandoscope#13 after the v4.15.1 update. Piping the list through `xargs` keeps the multi-sha behavior and satisfies the linter. One-line change to `lint.yml.jinja`; behavior on the empty case is unchanged (the guard above exits before the pipe).

On merge this releases as a patch; the open template-update PRs pick it up on their next `copier update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791060067&installation_model_id=432661&pr_number=234&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F234&signature=3921fa0c5f5d0b7c603011b8d907a7a982df25a5d1d04648f58e21f7063c2fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->