### PR TITLE
fix(template): repo-hooks skips a local config that defines no hooks

### DIFF
--- a/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if agentic_precommit == 'prek' %}.pre-commit-config.yaml{% endif %}.jinja
@@ -122,11 +122,13 @@ repos:
       # and never stamps again. Delegating keeps them on the same
       # commit as the shared hooks without giving the repo a reason to
       # edit this template-owned file — which the vendored drift check
-      # would then flag on every run. No staged files, or no local
-      # config, means nothing to run.
+      # would then flag on every run. No staged files, no local
+      # config, or a seeded config that still defines no hooks
+      # (repos: []) all mean nothing to run — prek exits nonzero on
+      # a hookless config, so that case is filtered here (#236).
       - id: repo-hooks
         name: repo-owned hooks
-        entry: bash -c '[ "$#" -gt 0 ] && [ -f .pre-commit-config.local.yaml ] || exit 0; exec {{ agentic_precommit }} run --config .pre-commit-config.local.yaml --files "$@"' --
+        entry: bash -c '[ "$#" -gt 0 ] && [ -f .pre-commit-config.local.yaml ] || exit 0; grep -qE "^\s*-\s*repo:" .pre-commit-config.local.yaml || exit 0; exec {{ agentic_precommit }} run --config .pre-commit-config.local.yaml --files "$@"' --
         language: system
       - id: disambiguate-lint
         name: disambiguate --lint

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import json
 import os
 import re
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -1277,6 +1278,35 @@ def test_architecture_and_project_term_are_seeded_once(
 
     assert architecture.read_text() == "# The real architecture\n"
     assert term.read_text() == "## Snake Farm\n\nThe real definition.\n"
+
+
+def test_repo_owned_hooks_pass_while_the_seeded_config_is_hookless(
+    tmp_path: Path,
+    base_answers: dict[str, str],
+) -> None:
+    """The delegating hook exits 0 on the seeded `repos: []` config (#236).
+
+    prek exits nonzero on a config that defines no hooks, so a freshly
+    stamped repo failed `prek run --all-files` out of the box. The entry
+    must treat a hookless local config like the no-config case.
+    """
+    dst_path = _render(tmp_path, base_answers, "repo-hooks-empty")
+
+    stamped = yaml.safe_load((dst_path / ".pre-commit-config.yaml").read_text())
+    entry = next(
+        hook["entry"]
+        for repo in stamped["repos"]
+        for hook in repo.get("hooks", [])
+        if hook.get("id") == "repo-hooks"
+    )
+    result = subprocess.run(
+        [*shlex.split(entry), "README.md"],
+        cwd=dst_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_repo_owned_hooks_get_a_seeded_config_of_their_own(


### PR DESCRIPTION
CLOSES #236.

The `repo-hooks` passthrough (v4.14.0) execs `prek run --config .pre-commit-config.local.yaml`, but prek 0.4.x exits 1 with "No hooks found after filtering with the given selectors" on the seeded `repos: []` config — so every freshly stamped repo fails `prek (all hooks, all files)` out of the box, reproduced on pandoscope/pandoscope#13. The entry now greps for a `- repo:` line and treats a hookless local config like the no-config case (exit 0); a populated config still delegates exactly as before.

Red-first: commit 1 is the failing behavioral test (renders the template, runs the stamped entry against the seeded config, asserts exit 0); commit 2 greens it.

This is the second template fix PANDO!13 needs — after merge and the patch release, the update PR restamps once more and prek should finally go green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC7ew3vo1QHCQgYJbAGkmw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791064281&installation_model_id=432661&pr_number=237&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F237&signature=88e8027c400b4bc0835298589a421e06545b099b17bef42451933462b63544cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->