### PR TITLE
fix(ci): the leaks gate scans only the added side of a diff

### DIFF
--- a/decision-memory/scripts/ci/check_gate.py
+++ b/decision-memory/scripts/ci/check_gate.py
@@ -884,6 +884,21 @@ def referenced_tickets(body, repo):
     return sorted(refs)
 
 
+def added_lines(patch):
+    """The published side of a unified diff: `+` lines, marker stripped.
+
+    A removal cannot publish anything main does not already publish,
+    and the PR that scrubs a value from main is exactly the one whose
+    removal lines carry it — scanning them made a scrub unable to pass
+    (#238). The `+++` header names a file, not content, and is skipped.
+    """
+    return "\n".join(
+        line[1:]
+        for line in (patch or "").splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
 def pr_surfaces(
     pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
 ):
@@ -916,7 +931,9 @@ def pr_surfaces(
             surfaces.append((f"commit {sha} {role} name", who.get("name")))
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
-        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+        surfaces.append(
+            (f"diff of {changed['filename']}", added_lines(changed.get("patch")))
+        )
     for comment in comments:
         surfaces.append((f"comment {comment['id']}", comment.get("body")))
     for review in reviews:

--- a/evidence-memory/scripts/ci/check_gate.py
+++ b/evidence-memory/scripts/ci/check_gate.py
@@ -884,6 +884,21 @@ def referenced_tickets(body, repo):
     return sorted(refs)
 
 
+def added_lines(patch):
+    """The published side of a unified diff: `+` lines, marker stripped.
+
+    A removal cannot publish anything main does not already publish,
+    and the PR that scrubs a value from main is exactly the one whose
+    removal lines carry it — scanning them made a scrub unable to pass
+    (#238). The `+++` header names a file, not content, and is skipped.
+    """
+    return "\n".join(
+        line[1:]
+        for line in (patch or "").splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
 def pr_surfaces(
     pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
 ):
@@ -916,7 +931,9 @@ def pr_surfaces(
             surfaces.append((f"commit {sha} {role} name", who.get("name")))
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
-        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+        surfaces.append(
+            (f"diff of {changed['filename']}", added_lines(changed.get("patch")))
+        )
     for comment in comments:
         surfaces.append((f"comment {comment['id']}", comment.get("body")))
     for review in reviews:

--- a/scripts/ci/check_gate.py
+++ b/scripts/ci/check_gate.py
@@ -884,6 +884,21 @@ def referenced_tickets(body, repo):
     return sorted(refs)
 
 
+def added_lines(patch):
+    """The published side of a unified diff: `+` lines, marker stripped.
+
+    A removal cannot publish anything main does not already publish,
+    and the PR that scrubs a value from main is exactly the one whose
+    removal lines carry it — scanning them made a scrub unable to pass
+    (#238). The `+++` header names a file, not content, and is skipped.
+    """
+    return "\n".join(
+        line[1:]
+        for line in (patch or "").splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
 def pr_surfaces(
     pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
 ):
@@ -916,7 +931,9 @@ def pr_surfaces(
             surfaces.append((f"commit {sha} {role} name", who.get("name")))
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
-        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+        surfaces.append(
+            (f"diff of {changed['filename']}", added_lines(changed.get("patch")))
+        )
     for comment in comments:
         surfaces.append((f"comment {comment['id']}", comment.get("body")))
     for review in reviews:

--- a/template/scripts/ci/check_gate.py
+++ b/template/scripts/ci/check_gate.py
@@ -884,6 +884,21 @@ def referenced_tickets(body, repo):
     return sorted(refs)
 
 
+def added_lines(patch):
+    """The published side of a unified diff: `+` lines, marker stripped.
+
+    A removal cannot publish anything main does not already publish,
+    and the PR that scrubs a value from main is exactly the one whose
+    removal lines carry it — scanning them made a scrub unable to pass
+    (#238). The `+++` header names a file, not content, and is skipped.
+    """
+    return "\n".join(
+        line[1:]
+        for line in (patch or "").splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
 def pr_surfaces(
     pr, commits, files, comments=(), reviews=(), review_comments=(), tickets=()
 ):
@@ -916,7 +931,9 @@ def pr_surfaces(
             surfaces.append((f"commit {sha} {role} name", who.get("name")))
             surfaces.append((f"commit {sha} {role} email", who.get("email")))
     for changed in files:
-        surfaces.append((f"diff of {changed['filename']}", changed.get("patch")))
+        surfaces.append(
+            (f"diff of {changed['filename']}", added_lines(changed.get("patch")))
+        )
     for comment in comments:
         surfaces.append((f"comment {comment['id']}", comment.get("body")))
     for review in reviews:

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -655,9 +655,12 @@ def test_diff_surface_is_the_added_side_only():
     assert "nobody@example.org" in surface
     assert "alice" not in surface
     assert "+++" not in surface
-    assert gate.leak_violations(
-        [("diff of tests/test_x.py", surface)], gate.parse_blocklist("alice")
-    ) == []
+    assert (
+        gate.leak_violations(
+            [("diff of tests/test_x.py", surface)], gate.parse_blocklist("alice")
+        )
+        == []
+    )
 
 
 def test_diff_surface_survives_a_missing_patch():

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -637,6 +637,36 @@ def test_pr_surfaces_include_branch_name_and_referenced_tickets():
     assert surfaces["ticket o/r#5 comment 3"] == "a comment"
 
 
+def test_diff_surface_is_the_added_side_only():
+    """A removal cannot publish anything main does not already publish,
+    and the PR that scrubs a value from main is exactly the one whose
+    removal lines carry it — so scanning them made a scrub unable to
+    pass (#238). Only `+` lines are the diff's published surface; the
+    `+++` header is a filename, not content."""
+    patch = (
+        "@@ -1,3 +1,3 @@\n"
+        " context alice-free\n"
+        "-fixture = 'alice@example.org'\n"
+        "+fixture = 'nobody@example.org'\n"
+    )
+    files = [{"filename": "tests/test_x.py", "patch": patch}]
+    surfaces = dict(gate.pr_surfaces({"title": "t", "body": "b"}, [], files))
+    surface = surfaces["diff of tests/test_x.py"]
+    assert "nobody@example.org" in surface
+    assert "alice" not in surface
+    assert "+++" not in surface
+    assert gate.leak_violations(
+        [("diff of tests/test_x.py", surface)], gate.parse_blocklist("alice")
+    ) == []
+
+
+def test_diff_surface_survives_a_missing_patch():
+    """Binary and oversized files arrive without a patch; that is no
+    surface, not a crash."""
+    surfaces = dict(gate.pr_surfaces({}, [], [{"filename": "img.png"}]))
+    assert surfaces["diff of img.png"] == ""
+
+
 def test_leaks_job_rides_the_gate_everywhere():
     """Layer 2 of #189: the leaks job rides ci-ok in the template AND
     both store variants, so the one required context enforces it. The


### PR DESCRIPTION
CLOSES pandoscope/agentic-engineering-template#238.

## What changes

`pr_surfaces` feeds the leaks scan the added side of each file's unified diff (`+` lines, marker stripped, `+++` header skipped) instead of the whole patch. A removal cannot publish anything main does not already publish, and the PR that scrubs a PUSH_BLOCKLIST value from main is exactly the one whose removal lines carry it, so the old surface made a scrub unable to pass. Every other surface (title, body, branch, commits, comments, reviews, referenced tickets) is unchanged. A file without a patch (binary, oversized) scans as an empty surface.

All four gate copies (template, root, decision-memory, evidence-memory) move together; the byte-identical test holds.

## Tests

Test-first: red commit with two tests (added side only, missing patch), then the fix. `tests/test_ci_gate.py` and `tests/test_self_application.py` green, prek clean.

## Follow-up

With this merged, the fixture email on pandoscope/pandoscope main (the case measured on pandoscope/pandoscope#15) can be scrubbed in a PR that goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071987&installation_model_id=432661&pr_number=240&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F240&signature=4e22077702454d5e963fc3b8d0386fed444759f3304646381d245cfe5e317f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->