### PR TITLE
refactor: bring the three grandfathered functions under the complexity limits

### DIFF
--- a/decision-memory/.github/guards/decision_validator.py
+++ b/decision-memory/.github/guards/decision_validator.py
@@ -306,9 +306,8 @@ def _validate_streams(
         )
 
 
-def _validate_ruling(  # noqa: C901, PLR0915 — refactor: #243
-    record: dict, prediction_option: dict | None, errors: list[str]
-) -> None:
+def _validate_chosen(record: dict, errors: list[str]) -> int | None:
+    """The picked slot and its text. Returns the slot, or None when unusable."""
     chosen_slot = record.get("chosen_slot")
     if not isinstance(chosen_slot, int) or isinstance(chosen_slot, bool):
         errors.append("chosen_slot: must be an integer")
@@ -316,33 +315,41 @@ def _validate_ruling(  # noqa: C901, PLR0915 — refactor: #243
     chosen = record.get("chosen")
     if not isinstance(chosen, str) or not chosen:
         errors.append("chosen: must be a non-empty string")
+    return chosen_slot
 
+
+def _validate_outcome(
+    record: dict,
+    prediction_option: dict | None,
+    chosen_slot: int | None,
+    errors: list[str],
+) -> None:
+    """The scored outcome, against the slot the decider actually picked."""
     outcome = record.get("outcome")
     if outcome not in OUTCOMES:
         errors.append(f"outcome: {outcome!r} not in {sorted(OUTCOMES)}")
-    elif (
-        outcome != "near-tie"
-        and prediction_option is not None
-        and chosen_slot is not None
-    ):
-        # Scored outcomes must match the slots. Near-ties are exempt by
-        # design (never scored as misses); 'refined' requires a slot
-        # MISMATCH like miss — the chosen answer CONTAINS the
-        # prediction plus an extension, distinguished from miss only by
-        # that containment judgment (same slot would be a plain hit).
-        hit = chosen_slot == prediction_option.get("slot")
-        if outcome == "hit" and not hit:
-            errors.append(
-                "outcome: 'hit' but chosen_slot differs from the prediction slot"
-            )
-        if outcome in ("miss", "refined") and hit:
-            errors.append(
-                f"outcome: {outcome!r} but chosen_slot equals the "
-                "prediction slot (that is a hit)"
-            )
+        return
+    if outcome == "near-tie" or prediction_option is None or chosen_slot is None:
+        return
+    # Scored outcomes must match the slots. Near-ties are exempt by
+    # design (never scored as misses); 'refined' requires a slot
+    # MISMATCH like miss — the chosen answer CONTAINS the
+    # prediction plus an extension, distinguished from miss only by
+    # that containment judgment (same slot would be a plain hit).
+    hit = chosen_slot == prediction_option.get("slot")
+    if outcome == "hit" and not hit:
+        errors.append("outcome: 'hit' but chosen_slot differs from the prediction slot")
+    if outcome in ("miss", "refined") and hit:
+        errors.append(
+            f"outcome: {outcome!r} but chosen_slot equals the "
+            "prediction slot (that is a hit)"
+        )
 
-    # operative_reason is required when a listed non-prediction option
-    # won — unless the pick was declared silent.
+
+def _validate_operative_reason(
+    record: dict, chosen_slot: int | None, errors: list[str]
+) -> None:
+    """The reason a listed non-prediction option won, or a declared silence."""
     operative_source = record.get("operative_reason_source")
     if operative_source is not None:
         if operative_source not in OPERATIVE_REASON_SOURCES:
@@ -362,78 +369,96 @@ def _validate_ruling(  # noqa: C901, PLR0915 — refactor: #243
                 "operative_reason: must be a non-empty string when "
                 "operative_reason_source is 'stated'"
             )
-    options = record.get("options")
-    if isinstance(options, list) and chosen_slot is not None:
-        chosen_option = next(
-            (
-                o
-                for o in options
-                if isinstance(o, dict) and o.get("slot") == chosen_slot
-            ),
-            None,
-        )
-        if (
-            chosen_option is not None
-            and chosen_option.get("role") not in PREDICTION_ROLES
-            and not record.get("operative_reason")
-            and operative_source != "none"
-        ):
-            errors.append(
-                "operative_reason: required when a listed non-prediction "
-                "option is chosen (declare operative_reason_source 'none' "
-                "for a silent pick)"
-            )
 
+    options = record.get("options")
+    if not isinstance(options, list) or chosen_slot is None:
+        return
+    chosen_option = next(
+        (o for o in options if isinstance(o, dict) and o.get("slot") == chosen_slot),
+        None,
+    )
+    if (
+        chosen_option is not None
+        and chosen_option.get("role") not in PREDICTION_ROLES
+        and not record.get("operative_reason")
+        and operative_source != "none"
+    ):
+        errors.append(
+            "operative_reason: required when a listed non-prediction "
+            "option is chosen (declare operative_reason_source 'none' "
+            "for a silent pick)"
+        )
+
+
+def _validate_rejection_reason(
+    index: int, rejection: dict, status: str, errors: list[str]
+) -> None:
+    """The reason attached to one rejection, per its status."""
+    reason = rejection.get("reason")
+    source = rejection.get("reason_source")
+    if status == "operative":
+        # Operative reasons are decider-stated by definition.
+        if source not in (None, "stated"):
+            errors.append(
+                f"rejections[{index}].reason_source: {source!r} — "
+                "operative rejections are stated by definition"
+            )
+        if not isinstance(reason, str) or not reason:
+            errors.append(
+                f"rejections[{index}].reason: operative rejections "
+                "require the stated reason, verbatim"
+            )
+        return
+    # presumed-false
+    if source not in PRESUMED_REASON_SOURCES:
+        errors.append(
+            f"rejections[{index}].reason_source: {source!r} not in "
+            f"{sorted(PRESUMED_REASON_SOURCES)} (required for "
+            "presumed-false rejections)"
+        )
+    elif source == "none":
+        if reason is not None:
+            errors.append(
+                f"rejections[{index}].reason: must be null when reason_source is 'none'"
+            )
+    elif not isinstance(reason, str) or not reason:
+        errors.append(
+            f"rejections[{index}].reason: must be a non-empty "
+            f"string when reason_source is {source!r} (declare "
+            "reason_source 'none' if nothing is inferable)"
+        )
+
+
+def _validate_rejections(record: dict, errors: list[str]) -> None:
+    """Every option the decider turned down, and why."""
     rejections = record.get("rejections")
     if not isinstance(rejections, list):
         errors.append("rejections: must be a list")
-    else:
-        for i, rejection in enumerate(rejections):
-            if not isinstance(rejection, dict):
-                errors.append(f"rejections[{i}]: must be an object")
-                continue
-            if not isinstance(rejection.get("option"), str) or not rejection["option"]:
-                errors.append(f"rejections[{i}].option: must be a non-empty string")
-            status = rejection.get("status")
-            if status not in REJECTION_STATUSES:
-                errors.append(
-                    f"rejections[{i}].status: {status!r} not in "
-                    f"{sorted(REJECTION_STATUSES)}"
-                )
-                continue
-            reason = rejection.get("reason")
-            source = rejection.get("reason_source")
-            if status == "operative":
-                # Operative reasons are decider-stated by definition.
-                if source not in (None, "stated"):
-                    errors.append(
-                        f"rejections[{i}].reason_source: {source!r} — "
-                        "operative rejections are stated by definition"
-                    )
-                if not isinstance(reason, str) or not reason:
-                    errors.append(
-                        f"rejections[{i}].reason: operative rejections "
-                        "require the stated reason, verbatim"
-                    )
-            else:  # presumed-false
-                if source not in PRESUMED_REASON_SOURCES:
-                    errors.append(
-                        f"rejections[{i}].reason_source: {source!r} not in "
-                        f"{sorted(PRESUMED_REASON_SOURCES)} (required for "
-                        "presumed-false rejections)"
-                    )
-                elif source == "none":
-                    if reason is not None:
-                        errors.append(
-                            f"rejections[{i}].reason: must be null when "
-                            "reason_source is 'none'"
-                        )
-                elif not isinstance(reason, str) or not reason:
-                    errors.append(
-                        f"rejections[{i}].reason: must be a non-empty "
-                        f"string when reason_source is {source!r} (declare "
-                        "reason_source 'none' if nothing is inferable)"
-                    )
+        return
+    for i, rejection in enumerate(rejections):
+        if not isinstance(rejection, dict):
+            errors.append(f"rejections[{i}]: must be an object")
+            continue
+        if not isinstance(rejection.get("option"), str) or not rejection["option"]:
+            errors.append(f"rejections[{i}].option: must be a non-empty string")
+        status = rejection.get("status")
+        if status not in REJECTION_STATUSES:
+            errors.append(
+                f"rejections[{i}].status: {status!r} not in "
+                f"{sorted(REJECTION_STATUSES)}"
+            )
+            continue
+        _validate_rejection_reason(i, rejection, status, errors)
+
+
+def _validate_ruling(
+    record: dict, prediction_option: dict | None, errors: list[str]
+) -> None:
+    """What the decider chose, how it scored, and what it turned down."""
+    chosen_slot = _validate_chosen(record, errors)
+    _validate_outcome(record, prediction_option, chosen_slot, errors)
+    _validate_operative_reason(record, chosen_slot, errors)
+    _validate_rejections(record, errors)
 
 
 def _validate_optional_fields(record: dict, errors: list[str]) -> None:

--- a/decision-memory/tools/record.py
+++ b/decision-memory/tools/record.py
@@ -59,8 +59,6 @@ import datetime as dt
 import json
 import os
 import re
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 
@@ -69,10 +67,13 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import record_core  # noqa: E402  (path bootstrap above)
 
 from record_confirm import (  # noqa: E402
-    bump_preference_counter,
     build_pr_body,
-    confirmations_for,
     session_hit_rates,
+)
+from record_submit import (  # noqa: E402
+    confirm_preferences,
+    open_pr,
+    session_records,
 )
 from record_store import (  # noqa: E402
     STATE_FILE,
@@ -81,7 +82,6 @@ from record_store import (  # noqa: E402
     covered_closures,
     default_branch,
     fail,
-    github_slug,
     list_closed_unmerged_prs,
     load_corpus,
     load_state,
@@ -399,78 +399,16 @@ def cmd_check(args: argparse.Namespace) -> int:
     return 1 if errors else 0
 
 
-def cmd_submit(args: argparse.Namespace) -> int:  # noqa: PLR0915 — refactor: #243
+def cmd_submit(args: argparse.Namespace) -> int:
     repo_dir = store_root()
     state = load_state(repo_dir)
     validator = load_validator(repo_dir)
     branch = state["branch"]
     today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
 
-    added = run_git(
-        repo_dir,
-        "diff",
-        "--name-only",
-        "--diff-filter=A",
-        f"{state['base_commit']}..HEAD",
-        "--",
-        "decisions/",
-    ).split()
-    # Scoped to decisions/ deliberately: a prediction is an agent's own
-    # choice, and letting one reach the counters would be the rule
-    # confirming itself through a second door.
-    records = []
-    for name in added:
-        path = repo_dir / name
-        records.append(json.loads(path.read_text(encoding="utf-8")))
-    if not records:
-        raise fail("no records on this session branch — nothing to submit")
-
+    records = session_records(repo_dir, state["base_commit"])
     streams = session_hit_rates(records)
-
-    source_path = repo_dir / validator.PREFERENCES_SOURCE
-    rendered_path = repo_dir / validator.PREFERENCES_RENDERED
-    for record in records:
-        if record.get("prediction_stream") != "preference-driven":
-            continue
-        confirmations, skipped = confirmations_for(record)
-        for rule, reason in skipped:
-            print(f"pref-skip: {rule} ({reason}) — no counter bumped")
-        for rule, independent in confirmations:
-            if not source_path.exists():
-                print(f"WARN: no {validator.PREFERENCES_SOURCE} — cannot bump {rule!r}")
-                continue
-            data, source_errors = validator.parse_preferences(
-                source_path.read_text(encoding="utf-8")
-            )
-            if source_errors:
-                raise fail(
-                    f"{validator.PREFERENCES_SOURCE} is invalid — fix it before "
-                    "submitting:\n" + "\n".join(source_errors)
-                )
-            count = bump_preference_counter(
-                data, rule, today, validator, independent=independent
-            )
-            if count is None:
-                print(
-                    f"WARN: cited rule {rule!r} not found in "
-                    f"{validator.PREFERENCES_SOURCE} — no counter bumped "
-                    "(proposal?)"
-                )
-                continue
-            source_path.write_text(
-                validator.serialize_preferences(data), encoding="utf-8"
-            )
-            rendered_path.write_text(
-                validator.render_preferences(data), encoding="utf-8"
-            )
-            run_git(
-                repo_dir,
-                "add",
-                validator.PREFERENCES_SOURCE,
-                validator.PREFERENCES_RENDERED,
-            )
-            run_git(repo_dir, "commit", "-m", f"pref-confirm: {rule} (n={count})")
-            print(f"pref-confirm: {rule} (n={count})")
+    confirm_preferences(repo_dir, records, validator, today)
 
     # Records were pushed as they landed; this catches the counter
     # bumps above and is a no-op when there were none.
@@ -480,44 +418,7 @@ def cmd_submit(args: argparse.Namespace) -> int:  # noqa: PLR0915 — refactor: 
     title = f"decision session {branch.split('/', 1)[1]} — " + (
         f"{len(records)} record(s)"
     )
-    body = build_pr_body(records, streams)
-
-    url = os.environ.get("DECISION_MEMORY_URL", "")
-    slug = github_slug(url)
-    if slug and shutil.which("gh"):
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "create",
-                "--repo",
-                slug,
-                "--head",
-                branch,
-                "--title",
-                title,
-                "--body",
-                body,
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            print(result.stdout.strip())
-            return 0
-        print(
-            f"gh pr create failed ({result.stderr.strip()}) — falling back to handoff.",
-            file=sys.stderr,
-        )
-
-    print()
-    print("── PR handoff (managed environment / no usable gh) ──")
-    print("The branch is pushed; open the PR with the tooling your")
-    print("environment declares, using exactly this title and body:")
-    print()
-    print(f"Title: {title}")
-    print("Body:")
-    print(body)
+    open_pr(branch, title, build_pr_body(records, streams))
     return 0
 
 

--- a/decision-memory/tools/record_submit.py
+++ b/decision-memory/tools/record_submit.py
@@ -1,0 +1,144 @@
+"""What `record.py submit` does, once a session is finished.
+
+Copier-vendored from the agentic-engineering-template guard
+subtemplate — change it there, pull via `copier update`.
+
+Reads the records the session branch added, bumps the counter of every
+rule a preference-driven record cited, and opens the PR — or prints the
+handoff when nothing in the environment can open one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from record_confirm import bump_preference_counter, confirmations_for  # noqa: E402
+from record_store import fail, github_slug, run_git  # noqa: E402
+
+
+def session_records(repo_dir: Path, base_commit: str) -> list[dict]:
+    """Every record this session branch added, read from disk."""
+    added = run_git(
+        repo_dir,
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{base_commit}..HEAD",
+        "--",
+        "decisions/",
+    ).split()
+    # Scoped to decisions/ deliberately: a prediction is an agent's own
+    # choice, and letting one reach the counters would be the rule
+    # confirming itself through a second door.
+    records = []
+    for name in added:
+        path = repo_dir / name
+        records.append(json.loads(path.read_text(encoding="utf-8")))
+    if not records:
+        raise fail("no records on this session branch — nothing to submit")
+    return records
+
+
+def _bump_cited_rule(
+    repo_dir: Path,
+    validator,
+    rule: str,
+    today: str,
+    *,
+    independent: bool,
+) -> None:
+    """Bump one cited rule's counter and commit the render beside it."""
+    source_path = repo_dir / validator.PREFERENCES_SOURCE
+    rendered_path = repo_dir / validator.PREFERENCES_RENDERED
+    if not source_path.exists():
+        print(f"WARN: no {validator.PREFERENCES_SOURCE} — cannot bump {rule!r}")
+        return
+    data, source_errors = validator.parse_preferences(
+        source_path.read_text(encoding="utf-8")
+    )
+    if source_errors:
+        raise fail(
+            f"{validator.PREFERENCES_SOURCE} is invalid — fix it before "
+            "submitting:\n" + "\n".join(source_errors)
+        )
+    count = bump_preference_counter(
+        data, rule, today, validator, independent=independent
+    )
+    if count is None:
+        print(
+            f"WARN: cited rule {rule!r} not found in "
+            f"{validator.PREFERENCES_SOURCE} — no counter bumped "
+            "(proposal?)"
+        )
+        return
+    source_path.write_text(validator.serialize_preferences(data), encoding="utf-8")
+    rendered_path.write_text(validator.render_preferences(data), encoding="utf-8")
+    run_git(
+        repo_dir,
+        "add",
+        validator.PREFERENCES_SOURCE,
+        validator.PREFERENCES_RENDERED,
+    )
+    run_git(repo_dir, "commit", "-m", f"pref-confirm: {rule} (n={count})")
+    print(f"pref-confirm: {rule} (n={count})")
+
+
+def confirm_preferences(
+    repo_dir: Path, records: list[dict], validator, today: str
+) -> None:
+    """Bump the counter of every rule a preference-driven record cited."""
+    for record in records:
+        if record.get("prediction_stream") != "preference-driven":
+            continue
+        confirmations, skipped = confirmations_for(record)
+        for rule, reason in skipped:
+            print(f"pref-skip: {rule} ({reason}) — no counter bumped")
+        for rule, independent in confirmations:
+            _bump_cited_rule(repo_dir, validator, rule, today, independent=independent)
+
+
+def open_pr(branch: str, title: str, body: str) -> None:
+    """Open the session's PR, or print the handoff when nothing can."""
+    url = os.environ.get("DECISION_MEMORY_URL", "")
+    slug = github_slug(url)
+    if slug and shutil.which("gh"):
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                slug,
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print(result.stdout.strip())
+            return
+        print(
+            f"gh pr create failed ({result.stderr.strip()}) — falling back to handoff.",
+            file=sys.stderr,
+        )
+
+    print()
+    print("── PR handoff (managed environment / no usable gh) ──")
+    print("The branch is pushed; open the PR with the tooling your")
+    print("environment declares, using exactly this title and body:")
+    print()
+    print(f"Title: {title}")
+    print("Body:")
+    print(body)

--- a/tests/test_decision_memory_subtemplate.py
+++ b/tests/test_decision_memory_subtemplate.py
@@ -80,6 +80,7 @@ STORE_FILES = frozenset(
         "tools/record.py",
         "tools/record_confirm.py",
         "tools/record_store.py",
+        "tools/record_submit.py",
         "tools/record_core.py",
     }
 )

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import copier
+import pytest
 import yaml
 
 from tests.render_support import PROJECT_ROOT, check_file_contents, render_answers
@@ -56,20 +58,93 @@ def test_branch_name_hook_guards_the_pattern(
     assert run_on("claude/anything", keywords=False).returncode == 0
 
 
-def test_linear_history_hooks_refuse_a_merge_into_a_working_branch(  # noqa: PLR0915 — refactor: #243
-    tmp_path: Path,
-    base_answers: dict[str, str],
-) -> None:
-    """A claude/* branch is rebased onto main, never merged into
-    (skills#147): the only merge commits are the forge's own. Three
-    prek stages share one script — the merge is refused as `git merge`
-    would commit it, a conflicted merge finished with `git commit` is
-    refused at pre-commit, and the push is the backstop for a merge
-    that got past both. A merge commit main already holds passes."""
-    dst_path = render_answers(tmp_path, base_answers, "linear-history-hooks")
+@dataclass
+class LinearHistory:
+    """The rendered hook script, plus the git fixtures the stages need."""
 
+    tmp_path: Path
+    dst_path: Path
+    script: Path
+    env: dict[str, str]
+
+    def git(self, repo: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=self.env,
+        ).stdout.strip()
+
+    def land(self, repo: Path, branch: str, msg: str) -> None:
+        self.git(repo, "checkout", "-q", branch)
+        with (repo / f"{branch.replace('/', '-')}.txt").open("a") as fh:
+            fh.write(msg + "\n")
+        self.git(repo, "add", "-A")
+        self.git(repo, "commit", "-q", "-m", msg)
+        self.git(repo, "push", "-q", "origin", branch)
+
+    def diverged(self, name: str) -> Path:
+        """A working branch off main, with main advanced past it on origin."""
+        origin = self.tmp_path / f"{name}.git"
+        subprocess.run(
+            ["git", "init", "-q", "--bare", "-b", "main", origin], check=True
+        )
+        repo = self.tmp_path / name
+        subprocess.run(
+            ["git", "clone", "-q", str(origin), str(repo)],
+            check=True,
+            capture_output=True,
+        )
+        self.git(repo, "checkout", "-q", "-b", "main")
+        (repo / "README.md").write_text("seed\n")
+        self.git(repo, "add", "-A")
+        self.git(repo, "commit", "-q", "-m", "chore: seed")
+        self.git(repo, "push", "-q", "-u", "origin", "main")
+        self.git(repo, "remote", "set-head", "origin", "main")
+        self.git(repo, "checkout", "-q", "-b", "claude/147-work", "main")
+        self.land(repo, "claude/147-work", "feat: the work")
+        self.land(repo, "main", "feat: a merged PR")
+        self.git(repo, "checkout", "-q", "claude/147-work")
+        self.git(repo, "fetch", "-q", "origin")
+        return repo
+
+    def check(self, repo: Path, mode: str, **extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(self.script), mode],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={**self.env, **extra},
+        )
+
+
+@pytest.fixture
+def linear_history(tmp_path: Path, base_answers: dict[str, str]) -> LinearHistory:
+    dst_path = render_answers(tmp_path, base_answers, "linear-history-hooks")
+    script = dst_path / "scripts" / "check-linear-history.sh"
+    assert script.stat().st_mode & 0o111, "hook script must be executable"
+    return LinearHistory(
+        tmp_path=tmp_path,
+        dst_path=dst_path,
+        script=script,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.test",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.test",
+        },
+    )
+
+
+def test_linear_history_hooks_are_registered_at_every_stage(
+    linear_history: LinearHistory,
+) -> None:
+    """One script, three prek stages and the CI job — a stage nobody
+    registered is a refusal that never fires."""
     check_file_contents(
-        dst_path / ".pre-commit-config.yaml",
+        linear_history.dst_path / ".pre-commit-config.yaml",
         [
             "default_install_hook_types: [pre-commit, commit-msg, pre-merge-commit, pre-push]",
             "id: linear-history",
@@ -79,124 +154,93 @@ def test_linear_history_hooks_refuse_a_merge_into_a_working_branch(  # noqa: PLR
         ],
     )
     check_file_contents(
-        dst_path / ".github" / "workflows" / "lint.yml",
+        linear_history.dst_path / ".github" / "workflows" / "lint.yml",
         [
             "linear-history:",
             'name: "linear history (PR commits)"',
             "git rev-list --merges",
         ],
     )
-    script = dst_path / "scripts" / "check-linear-history.sh"
-    assert script.stat().st_mode & 0o111, "hook script must be executable"
 
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "t",
-        "GIT_AUTHOR_EMAIL": "t@example.test",
-        "GIT_COMMITTER_NAME": "t",
-        "GIT_COMMITTER_EMAIL": "t@example.test",
-    }
 
-    def git(repo: Path, *args: str) -> str:
-        return subprocess.run(
-            ["git", "-C", str(repo), *args],
-            check=True,
-            capture_output=True,
-            text=True,
-            env=env,
-        ).stdout.strip()
-
-    def land(repo: Path, branch: str, msg: str) -> None:
-        git(repo, "checkout", "-q", branch)
-        with (repo / f"{branch.replace('/', '-')}.txt").open("a") as fh:
-            fh.write(msg + "\n")
-        git(repo, "add", "-A")
-        git(repo, "commit", "-q", "-m", msg)
-        git(repo, "push", "-q", "origin", branch)
-
-    def diverged(name: str) -> Path:
-        """A working branch off main, with main advanced past it on origin."""
-        origin = tmp_path / f"{name}.git"
-        subprocess.run(
-            ["git", "init", "-q", "--bare", "-b", "main", origin], check=True
-        )
-        repo = tmp_path / name
-        subprocess.run(
-            ["git", "clone", "-q", str(origin), str(repo)],
-            check=True,
-            capture_output=True,
-        )
-        git(repo, "checkout", "-q", "-b", "main")
-        (repo / "README.md").write_text("seed\n")
-        git(repo, "add", "-A")
-        git(repo, "commit", "-q", "-m", "chore: seed")
-        git(repo, "push", "-q", "-u", "origin", "main")
-        git(repo, "remote", "set-head", "origin", "main")
-        git(repo, "checkout", "-q", "-b", "claude/147-work", "main")
-        land(repo, "claude/147-work", "feat: the work")
-        land(repo, "main", "feat: a merged PR")
-        git(repo, "checkout", "-q", "claude/147-work")
-        git(repo, "fetch", "-q", "origin")
-        return repo
-
-    def check(repo: Path, mode: str, **extra: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [str(script), mode],
-            cwd=repo,
-            capture_output=True,
-            text=True,
-            env={**env, **extra},
-        )
-
-    # --merge: the pre-merge-commit stage, on a working branch.
-    repo = diverged("merge")
-    refused = check(repo, "--merge")
+def test_a_merge_into_a_working_branch_is_refused_as_git_merge_would_commit_it(
+    linear_history: LinearHistory,
+) -> None:
+    """A claude/* branch is rebased onto main, never merged into
+    (skills#147). The pre-merge-commit stage refuses it where the
+    reader can still abort; main is not a working branch and passes."""
+    repo = linear_history.diverged("merge")
+    refused = linear_history.check(repo, "--merge")
     assert refused.returncode != 0
     assert "git merge --abort && git rebase origin/main" in refused.stderr
-    git(repo, "checkout", "-q", "main")
-    assert check(repo, "--merge").returncode == 0, "main is not a working branch"
-
-    # --commit: a conflicted merge being finished by hand.
-    repo = diverged("commit")
-    assert check(repo, "--commit").returncode == 0, "an ordinary commit passes"
-    (repo / ".git" / "MERGE_HEAD").write_text(
-        git(repo, "rev-parse", "origin/main") + "\n"
+    linear_history.git(repo, "checkout", "-q", "main")
+    assert linear_history.check(repo, "--merge").returncode == 0, (
+        "main is not a working branch"
     )
-    refused = check(repo, "--commit")
+
+
+def test_a_conflicted_merge_finished_by_hand_is_refused_at_commit_time(
+    linear_history: LinearHistory,
+) -> None:
+    """`git merge` that stops on a conflict is finished with `git
+    commit`, which never reaches the pre-merge-commit stage — so
+    pre-commit reads MERGE_HEAD and refuses there instead."""
+    repo = linear_history.diverged("commit")
+    assert linear_history.check(repo, "--commit").returncode == 0, (
+        "an ordinary commit passes"
+    )
+    (repo / ".git" / "MERGE_HEAD").write_text(
+        linear_history.git(repo, "rev-parse", "origin/main") + "\n"
+    )
+    refused = linear_history.check(repo, "--commit")
     assert refused.returncode != 0
     assert "git merge --abort && git rebase origin/main" in refused.stderr
 
-    # --push: the backstop, fed the refs prek hands a pre-push hook.
-    repo = diverged("push")
-    git(repo, "merge", "--no-ff", "origin/main", "-m", "chore: merge main")
+
+def test_the_push_is_the_backstop_for_a_merge_that_got_past_both(
+    linear_history: LinearHistory,
+) -> None:
+    """Fed the refs prek hands a pre-push hook. A rebased branch pushes."""
+    repo = linear_history.diverged("push")
+    linear_history.git(
+        repo, "merge", "--no-ff", "origin/main", "-m", "chore: merge main"
+    )
     refs = {
         "PRE_COMMIT_LOCAL_BRANCH": "refs/heads/claude/147-work",
-        "PRE_COMMIT_TO_REF": git(repo, "rev-parse", "HEAD"),
+        "PRE_COMMIT_TO_REF": linear_history.git(repo, "rev-parse", "HEAD"),
     }
-    refused = check(repo, "--push", **refs)
+    refused = linear_history.check(repo, "--push", **refs)
     assert refused.returncode != 0
     assert "chore: merge main" in refused.stderr
     assert "git rebase origin/main" in refused.stderr
-    git(repo, "reset", "-q", "--hard", "HEAD~1")
-    git(repo, "rebase", "-q", "origin/main")
-    refs["PRE_COMMIT_TO_REF"] = git(repo, "rev-parse", "HEAD")
-    assert check(repo, "--push", **refs).returncode == 0, "a linear branch pushes"
+    linear_history.git(repo, "reset", "-q", "--hard", "HEAD~1")
+    linear_history.git(repo, "rebase", "-q", "origin/main")
+    refs["PRE_COMMIT_TO_REF"] = linear_history.git(repo, "rev-parse", "HEAD")
+    assert linear_history.check(repo, "--push", **refs).returncode == 0, (
+        "a linear branch pushes"
+    )
 
-    # A forge merge on main is not the branch's: a working branch off
-    # a merged main is linear in its own range.
-    repo = diverged("forge")
-    git(repo, "checkout", "-q", "main")
-    git(repo, "merge", "--no-ff", "claude/147-work", "-m", "Merge pull request #1")
-    git(repo, "push", "-q", "origin", "main")
-    git(repo, "checkout", "-q", "-b", "claude/148-next", "main")
+
+def test_a_forge_merge_on_main_leaves_the_next_branch_linear(
+    linear_history: LinearHistory,
+) -> None:
+    """A forge merge on main is not the branch's: a working branch off
+    a merged main is linear in its own range."""
+    repo = linear_history.diverged("forge")
+    linear_history.git(repo, "checkout", "-q", "main")
+    linear_history.git(
+        repo, "merge", "--no-ff", "claude/147-work", "-m", "Merge pull request #1"
+    )
+    linear_history.git(repo, "push", "-q", "origin", "main")
+    linear_history.git(repo, "checkout", "-q", "-b", "claude/148-next", "main")
     (repo / "next.txt").write_text("next\n")
-    git(repo, "add", "-A")
-    git(repo, "commit", "-q", "-m", "feat: next")
+    linear_history.git(repo, "add", "-A")
+    linear_history.git(repo, "commit", "-q", "-m", "feat: next")
     refs = {
         "PRE_COMMIT_LOCAL_BRANCH": "refs/heads/claude/148-next",
-        "PRE_COMMIT_TO_REF": git(repo, "rev-parse", "HEAD"),
+        "PRE_COMMIT_TO_REF": linear_history.git(repo, "rev-parse", "HEAD"),
     }
-    assert check(repo, "--push", **refs).returncode == 0
+    assert linear_history.check(repo, "--push", **refs).returncode == 0
 
 
 def test_commitlint_config_rejects_fixup_and_squash_commits(

--- a/tests/test_record_core.py
+++ b/tests/test_record_core.py
@@ -26,6 +26,10 @@ record_tool = load_module(
 record_store = load_module(
     "record_store", PROJECT_ROOT / "decision-memory" / "tools" / "record_store.py"
 )
+# The preference-counter math is its own module too.
+record_confirm = load_module(
+    "record_confirm", PROJECT_ROOT / "decision-memory" / "tools" / "record_confirm.py"
+)
 dv = load_module(
     "decision_validator",
     PROJECT_ROOT / "decision-memory" / ".github" / "guards" / "decision_validator.py",
@@ -200,7 +204,7 @@ def test_session_hit_rates_bucket_refined_separately() -> None:
         {"prediction_stream": "cold", "outcome": "miss"},
         {"prediction_stream": "preference-driven", "outcome": "refined"},
     ]
-    streams = record_tool.session_hit_rates(records)
+    streams = record_confirm.session_hit_rates(records)
     assert streams["cold"] == {"hit": 1, "miss": 1, "near-tie": 0, "refined": 1}
     assert streams["preference-driven"]["refined"] == 1
 
@@ -273,7 +277,7 @@ def test_a_disconfirmed_rule_earns_no_confirmation() -> None:
     that listed it under rules_disconfirmed (decision-memory PR #25).
     """
     record = _record("hit", ["rule a.", "rule b."], disconfirmed=["rule b."])
-    confirmations, skipped = record_tool.confirmations_for(record)
+    confirmations, skipped = record_confirm.confirmations_for(record)
     assert confirmations == [("rule a.", False)]
     assert skipped == [("rule b.", "disconfirmed")]
 
@@ -281,13 +285,13 @@ def test_a_disconfirmed_rule_earns_no_confirmation() -> None:
 def test_a_correction_earns_no_automatic_confirmation() -> None:
     """A record whose reason was replaced confirms nothing by itself."""
     record = _record("hit", ["rule a."], correction=True)
-    confirmations, skipped = record_tool.confirmations_for(record)
+    confirmations, skipped = record_confirm.confirmations_for(record)
     assert confirmations == []
     assert skipped == [("rule a.", "correction")]
 
 
 def test_an_independent_confirmation_still_skips_a_disconfirmed_rule() -> None:
     record = _record("miss", ["rule a."], disconfirmed=["other rule."])
-    confirmations, skipped = record_tool.confirmations_for(record)
+    confirmations, skipped = record_confirm.confirmations_for(record)
     assert confirmations == []
     assert skipped == [("other rule.", "disconfirmed")]


### PR DESCRIPTION
CLOSES #243

#242 shipped ruff's `C901` (mccabe 20) and `PLR0915` (50 statements) and grandfathered the three functions already over them behind `# noqa` comments naming this ticket. Each is now split along the seam its own comments already described, and every noqa is gone.

| function | was | now |
| --- | --- | --- |
| `decision_validator._validate_ruling` | complexity 26, 58 statements | an orchestrator over four validators |
| `record.cmd_submit` | 52 statements | the session flow, three helpers in `record_submit.py` |
| the linear-history test | 66 statements | a fixture and five tests |

## What each split gained

- **`_validate_ruling`** hands off to `_validate_chosen`, `_validate_outcome`, `_validate_operative_reason` and `_validate_rejections`, with the per-rejection reason rules in `_validate_rejection_reason`. The early returns the split allows replace three levels of `elif` nesting.
- **`cmd_submit`** keeps the session flow and calls `session_records`, `confirm_preferences` and `open_pr`. Those live in a new `record_submit.py`: extracting them inside `record.py` pushed it to 509 code lines, over the same PR's own file cap, so the submit verb's machinery moves out beside the confirm and store modules it already leaned on.
- **The linear-history test** was four scenarios sharing one setup. The setup is a `LinearHistory` fixture now, and merge, commit, push and the forge-merge case are each their own test — a failure names the stage that broke instead of the line that did.

## Two things this surfaced

- `tests/test_record_core.py` reached `confirmations_for` and `session_hit_rates` through `record.py`'s namespace, where they were only re-exports. It loads `record_confirm` directly now.
- The decision-memory subtemplate's expected file list needed `tools/record_submit.py`.

## Verification

394 pytest tests pass, the decision-memory store suite passes at 190, `uvx prek run --all-files` is clean, `scripts/dev/self_application.py --range origin/main..HEAD` reports every commit kept sources and stamps apart, and `ruff check --select C901,PLR0915` finds nothing anywhere in the tree.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791123128&installation_model_id=432661&pr_number=250&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F250&signature=124f2b0f0f81f1bee8932ce3533c182bb3e9fb62d9b282a528f5c6844c5a3679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->