### PR TITLE
fix(workflows): grant every checking-out workflow its read of the repository

### DIFF
--- a/.github/workflows/gate-rerun.yml
+++ b/.github/workflows/gate-rerun.yml
@@ -25,6 +25,10 @@ on:
     types: [created, edited, deleted]
 
 permissions:
+  # `permissions:` replaces the default set — a block naming only
+  # `actions` leaves the token unable to read the repository, and
+  # the checkout below dies on "Repository not found" (#253).
+  contents: read
   actions: write
 
 concurrency:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,6 +23,11 @@ jobs:
     # as SKIPPED, which is visibly different from a green run — an absent
     # sync must never be indistinguishable from a successful one.
     if: ${{ vars.LABELS_SYNC_ENABLED == 'true' }}
+    # The label sync itself runs on LABELS_TOKEN, but the checkout
+    # below still reads labels.toml out of this repository, which
+    # the workflow-level `permissions: {}` otherwise forbids (#253).
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/gate-rerun.yml
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/gate-rerun.yml
@@ -25,6 +25,10 @@ on:
     types: [created, edited, deleted]
 
 permissions:
+  # `permissions:` replaces the default set — a block naming only
+  # `actions` leaves the token unable to read the repository, and
+  # the checkout below dies on "Repository not found" (#253).
+  contents: read
   actions: write
 
 concurrency:

--- a/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml.jinja
+++ b/template/{% if agentic_forge == 'github' %}.github{% endif %}/workflows/labels.yml.jinja
@@ -23,6 +23,11 @@ jobs:
     # as SKIPPED, which is visibly different from a green run — an absent
     # sync must never be indistinguishable from a successful one.
     if: {% raw %}${{ vars.LABELS_SYNC_ENABLED == 'true' }}{% endraw %}
+    # The label sync itself runs on LABELS_TOKEN, but the checkout
+    # below still reads labels.toml out of this repository, which
+    # the workflow-level `permissions: {}` otherwise forbids (#253).
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/tests/test_generate_workflows.py
+++ b/tests/test_generate_workflows.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import yaml
 
+
+from tests.conftest import PROJECT_ROOT as ROOT
 from tests.render_support import check_file_contents, render_answers
 
 
@@ -383,3 +386,46 @@ def test_the_weekly_run_fails_loudly_when_the_repo_is_behind(
     assert "has not been merged" in workflow
     assert "did not reach this repo" in workflow
     assert "::error::" in workflow
+
+
+def _effective_contents_permission(workflow: dict, job: dict) -> str | None:
+    """What `contents` scope a job actually gets.
+
+    A job-level `permissions:` block replaces the workflow-level one
+    outright, and either block sets every permission it does not name
+    to `none` — so the answer is one lookup in whichever block is
+    nearest, and an absent block means the default (write on a push
+    into the repo, read on a fork), which always covers checkout.
+    """
+    block = job.get("permissions", workflow.get("permissions"))
+    if block is None:
+        return "default"
+    if isinstance(block, str):  # `permissions: read-all` / `write-all`
+        return block
+    return block.get("contents")
+
+
+def test_every_workflow_that_checks_out_may_read_the_repository():
+    """`permissions:` is a replacement, not an addition — naming one
+    scope silently revokes the rest. gate-rerun.yml named only
+    `actions: write`, so `actions/checkout` met a token with no
+    `contents` scope and every run died on "Repository not found"
+    before the janitor's first line ran (#253).
+
+    The check covers the class rather than that one file: any workflow
+    that checks the repository out needs the scope to read it.
+    """
+    stamped = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    assert stamped, "no stamped workflows found"
+
+    for path in stamped:
+        workflow = yaml.safe_load(path.read_text())
+        for name, job in workflow.get("jobs", {}).items():
+            steps = job.get("steps") or []
+            if not any("actions/checkout" in str(step.get("uses", "")) for step in steps):
+                continue
+            granted = _effective_contents_permission(workflow, job)
+            assert granted in ("read", "write", "read-all", "write-all", "default"), (
+                f"{path.name} job '{name}' checks out the repository but is "
+                f"granted contents: {granted!r}"
+            )

--- a/tests/test_generate_workflows.py
+++ b/tests/test_generate_workflows.py
@@ -422,7 +422,9 @@ def test_every_workflow_that_checks_out_may_read_the_repository():
         workflow = yaml.safe_load(path.read_text())
         for name, job in workflow.get("jobs", {}).items():
             steps = job.get("steps") or []
-            if not any("actions/checkout" in str(step.get("uses", "")) for step in steps):
+            if not any(
+                "actions/checkout" in str(step.get("uses", "")) for step in steps
+            ):
                 continue
             granted = _effective_contents_permission(workflow, job)
             assert granted in ("read", "write", "read-all", "write-all", "default"), (


### PR DESCRIPTION
CLOSES #253

`permissions:` is a **replacement**, not an addition — every scope a
block does not name is set to `none`. Two workflows named a scope and
so silently revoked `contents`, leaving `actions/checkout` unable to
read the repository it was running in:

| workflow | declared | what broke |
| --- | --- | --- |
| `gate-rerun.yml` | `actions: write` | the janitor never ran, anywhere |
| `labels.yml` | `permissions: {}` | the sync could not read `labels.toml` |

Measured on [meta!135](https://github.com/pandoscope/meta/pull/135):

```
remote: Repository not found.
Error: fatal: repository 'https://github.com/pandoscope/meta/' not found
```

Three retries, then the job fails — before `check_gate.py rerun` runs
its first line. So the stale-red janitor (#190) has never cleared a
stale gate run in any consumer since it shipped; the manual re-run is
still what unblocks a re-judged PR. It does not block merges: only
`ci-ok` is required, so meta!135 sits at `unstable`, not `blocked`.

## The test covers the class, not the two files

`test_every_workflow_that_checks_out_may_read_the_repository` walks
the stamped workflows and, for each job that uses `actions/checkout`,
resolves the `contents` scope the job actually gets — job-level block
if present, else workflow-level, else the default. Written red first,
where it named `gate-rerun.yml`; once that was fixed it named
`labels.yml`, which is how the second instance was found rather than
guessed at.

The permission resolution is its own helper because the rule is not
obvious: a job-level block *replaces* the workflow-level one outright
rather than merging with it.

## Verification

396 tests pass, `prek run --all-files` clean, and
`scripts/dev/self_application.py --range origin/main..HEAD` confirms
every commit kept sources and stamps apart.

Consumers pick this up with the next template update; nothing in a
consumer repo should be hand-edited for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUXJh1hKmW4ccUwRQ1Ep1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pandoscope/codesmith/agentic-engineering-template/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791134072&installation_model_id=432661&pr_number=254&repository=pandoscope%2Fagentic-engineering-template&return_to=https%3A%2F%2Fgithub.com%2Fpandoscope%2Fagentic-engineering-template%2Fpull%2F254&signature=99b86e15d6ed548aeda7c723b4f9b67f6b2e631184f5636001369a4fecc2628c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->